### PR TITLE
Bumped up max fall distance to 255

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BugUp.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BugUp.kt
@@ -35,7 +35,7 @@ import kotlin.math.max
 class BugUp : Module() {
 
     private val modeValue = ListValue("Mode", arrayOf("TeleportBack", "FlyFlag", "OnGroundSpoof"), "FlyFlag")
-    private val maxFallDistance = IntegerValue("MaxFallDistance", 10, 2, 50)
+    private val maxFallDistance = IntegerValue("MaxFallDistance", 10, 2, 255)
     private val maxDistanceWithoutGround = FloatValue("MaxDistanceToSetback", 2.5f, 1f, 30f)
     private val indicator = BoolValue("Indicator", true)
 


### PR DESCRIPTION
To make it possible to only setback when there is no block below. See CCBlueX/LiquidBounce1.8-Issues#3362