### PR TITLE
Fixed AutoArmor Delay Bug

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.java
@@ -125,6 +125,8 @@ public class AutoArmor extends Module {
             mc.getNetHandler().addToSendQueue(new C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem));
 
             delay = TimeUtils.randomDelay(minDelayValue.get(), maxDelayValue.get());
+
+            return true;
         } else if (!(noMoveValue.get() && MovementUtils.isMoving()) && (!invOpenValue.get() || mc.currentScreen instanceof GuiInventory) && item != -1) {
             final boolean openInventory = simulateInventory.get() && !(mc.currentScreen instanceof GuiInventory);
 
@@ -138,9 +140,10 @@ public class AutoArmor extends Module {
             if (openInventory)
                 mc.getNetHandler().addToSendQueue(new C0DPacketCloseWindow());
 
-            return false;
+            return true;
         }
-        return true;
+        
+        return false;
     }
 
 }


### PR DESCRIPTION
Before this fix AutoArmor would wait for the delay, but if there are more than one update to perform it just ignores it.

Fixes CCBlueX/LiquidBounce1.8-Issues#3466