### PR TITLE
Fix .reload

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.ui.client.clickgui.ClickGui
 import net.ccbluex.liquidbounce.ui.font.Fonts
+import net.ccbluex.liquidbounce.features.command.CommandManager
 
 class ReloadCommand : Command("reload", arrayOf("configreload")) {
     /**
@@ -16,6 +17,9 @@ class ReloadCommand : Command("reload", arrayOf("configreload")) {
      */
     override fun execute(args: Array<String>) {
         chat("Reloading...")
+        chat("§c§lReloading commands...")
+        LiquidBounce.commandManager = CommandManager()
+        LiquidBounce.commandManager.registerCommands()
         chat("§c§lReloading scripts...")
         LiquidBounce.scriptManager.reloadScripts()
         chat("§c§lReloading fonts...")


### PR DESCRIPTION
CommandManager adds new and new script commands after every use of .reload

This causes LB to randomly crash, script commands to not work after reloading.
This is a major problem in most of LB versions.