### PR TITLE
Fix .scripts reload

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
@@ -16,6 +16,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.*
 import java.util.zip.ZipFile
+import net.ccbluex.liquidbounce.features.command.CommandManager
 
 class ScriptManagerCommand : Command("scriptmanager", arrayOf("scripts")) {
     /**
@@ -113,7 +114,13 @@ class ScriptManagerCommand : Command("scriptmanager", arrayOf("scripts")) {
 
                 args[1].equals("reload", true) -> {
                     try {
+                        LiquidBounce.commandManager = CommandManager()
+                        LiquidBounce.commandManager.registerCommands()
                         LiquidBounce.scriptManager.reloadScripts()
+                        LiquidBounce.clickGui = new ClickGui();
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.clickGuiConfig);
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.modulesConfig);
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.valuesConfig);
                         chat("Successfully reloaded all scripts.")
                     } catch (t: Throwable) {
                         ClientUtils.getLogger().error("Something went wrong while reloading all scripts.", t)

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
@@ -17,6 +17,7 @@ import java.io.FileOutputStream
 import java.util.*
 import java.util.zip.ZipFile
 import net.ccbluex.liquidbounce.features.command.CommandManager
+import net.ccbluex.liquidbounce.ui.client.clickgui.ClickGui
 
 class ScriptManagerCommand : Command("scriptmanager", arrayOf("scripts")) {
     /**
@@ -117,10 +118,10 @@ class ScriptManagerCommand : Command("scriptmanager", arrayOf("scripts")) {
                         LiquidBounce.commandManager = CommandManager()
                         LiquidBounce.commandManager.registerCommands()
                         LiquidBounce.scriptManager.reloadScripts()
-                        LiquidBounce.clickGui = new ClickGui();
-                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.clickGuiConfig);
-                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.modulesConfig);
-                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.valuesConfig);
+                        LiquidBounce.clickGui = ClickGui()
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.clickGuiConfig)
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.modulesConfig)
+                        LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.valuesConfig)
                         chat("Successfully reloaded all scripts.")
                     } catch (t: Throwable) {
                         ClientUtils.getLogger().error("Something went wrong while reloading all scripts.", t)


### PR DESCRIPTION
This fixes:

1. .scripts reload lagging for a short time after using the command for multiple times (same thing as with the .reload bug)
2. .scripts reload crashes
3. commands not working after executing
4. resetting values, states, binds of custom scripts
5. not updating clickgui