### PR TITLE
Update Teleport.java

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
@@ -15,8 +15,11 @@ import net.ccbluex.liquidbounce.utils.PathUtils;
 import net.ccbluex.liquidbounce.utils.block.BlockUtils;
 import net.ccbluex.liquidbounce.utils.render.RenderUtils;
 import net.ccbluex.liquidbounce.utils.timer.TickTimer;
+import net.ccbluex.liquidbounce.value.BoolValue;
 import net.ccbluex.liquidbounce.value.ListValue;
 import net.minecraft.block.BlockAir;
+import net.minecraft.block.BlockFence;
+import net.minecraft.block.BlockSnow;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -27,6 +30,7 @@ import net.minecraft.network.play.client.C0BPacketEntityAction.Action;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 import org.lwjgl.input.Mouse;
 
 import java.awt.*;
@@ -38,11 +42,12 @@ import static org.lwjgl.opengl.GL11.*;
 
 @ModuleInfo(name = "Teleport", description = "Allows you to teleport around.", category = ModuleCategory.EXPLOIT)
 public class Teleport extends Module {
+    private final BoolValue ignoreNoCollision = new BoolValue("IgnoreNoCollision", true);
     private final ListValue modeValue = new ListValue("Mode", new String[] {"Blink", "Flag", "Rewinside", "OldRewinside", "Spoof", "Minesucht", "AAC3.5.0"}, "Blink");
     private final ListValue buttonValue = new ListValue("Button", new String[] {"Left", "Right", "Middle"}, "Middle");
-
     private final TickTimer flyTimer = new TickTimer();
     private boolean hadGround;
+    private double fixedY;
     private final List<Packet<?>> packets = new ArrayList<>();
     private boolean disableLogger = false;
     private boolean zitter = false;
@@ -65,7 +70,9 @@ public class Teleport extends Module {
 
     @Override
     public void onDisable() {
+        fixedY = 0D;
         delay = 0;
+        mc.timer.timerSpeed = 1F;
         endPos = null;
         hadGround = false;
         freeze = false;
@@ -141,22 +148,31 @@ public class Teleport extends Module {
         if(mc.currentScreen == null && Mouse.isButtonDown(buttonIndex) && delay <= 0) {
             endPos = objectPosition.getBlockPos();
 
+
             if(BlockUtils.getBlock(endPos).getMaterial() == Material.air) {
                 endPos = null;
                 return;
             }
 
-            ClientUtils.displayChatMessage("§7[§8§lTeleport§7] §3Position was set to §8" + endPos.getX() + "§3, §8" + (endPos.getY() + 1) + "§3, §8" + endPos.getZ());
+            ClientUtils.displayChatMessage("§7[§8§lTeleport§7] §3Position was set to §8" + endPos.getX() + "§3, §8" + (BlockUtils.getBlock(endPos).getCollisionBoundingBox(mc.theWorld, endPos, BlockUtils.getBlock(endPos).getDefaultState()).maxY + fixedY) + "§3, §8" + endPos.getZ());
             delay = 6;
         }
 
         if(delay > 0)
             --delay;
 
+
+
+
+
+
         if(endPos != null) {
+
             final double endX = (double) endPos.getX() + 0.5D;
-            final double endY = (double) endPos.getY() + 1D;
+            final double endY = (double) (BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()) == null ? endPos.getY() + BlockUtils.getBlock(endPos).getBlockBoundsMaxY() : BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()).maxY) + fixedY;
             final double endZ = (double) endPos.getZ() + 0.5D;
+
+
 
             switch(modeValue.get().toLowerCase()) {
                 case "blink":
@@ -242,13 +258,20 @@ public class Teleport extends Module {
         if(modeValue.get().equals("AAC3.5.0"))
             return;
 
-        objectPosition = mc.thePlayer.rayTrace(1000, event.getPartialTicks());
+        final Vec3 lookVec = new Vec3(mc.thePlayer.getLookVec().xCoord * 300, mc.thePlayer.getLookVec().yCoord * 300, mc.thePlayer.getLookVec().zCoord * 300);
+        final Vec3 posVec = new Vec3(mc.thePlayer.posX, mc.thePlayer.posY + 1.62, mc.thePlayer.posZ);
+
+        objectPosition = mc.thePlayer.worldObj.rayTraceBlocks(posVec, posVec.add(lookVec), false, ignoreNoCollision.get(), false);
 
         if(objectPosition.getBlockPos() == null)
             return;
 
+        final BlockPos belowBlockPos = new BlockPos(objectPosition.getBlockPos().getX(), objectPosition.getBlockPos().getY() - 1, objectPosition.getBlockPos().getZ());
+        
+        fixedY = BlockUtils.getBlock(objectPosition.getBlockPos()) instanceof BlockFence ? (mc.theWorld.getCollidingBoundingBoxes(mc.thePlayer, mc.thePlayer.getEntityBoundingBox().offset(objectPosition.getBlockPos().getX() + 0.5D - mc.thePlayer.posX, objectPosition.getBlockPos().getY() + 1.5D - mc.thePlayer.posY, objectPosition.getBlockPos().getZ() + 0.5D - mc.thePlayer.posZ)).isEmpty() ? 0.5D : 0D) : BlockUtils.getBlock(belowBlockPos) instanceof BlockFence ? (!mc.theWorld.getCollidingBoundingBoxes(mc.thePlayer, mc.thePlayer.getEntityBoundingBox().offset(objectPosition.getBlockPos().getX() + 0.5D - mc.thePlayer.posX, objectPosition.getBlockPos().getY() + 0.5D - mc.thePlayer.posY, objectPosition.getBlockPos().getZ() + 0.5D - mc.thePlayer.posZ)).isEmpty() || BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()) == null ? 0D : 0.5D - BlockUtils.getBlock(objectPosition.getBlockPos()).getBlockBoundsMaxY()) : BlockUtils.getBlock(objectPosition.getBlockPos()) instanceof BlockSnow ? BlockUtils.getBlock(objectPosition.getBlockPos()).getBlockBoundsMaxY() - 0.125D : 0D;
+        
         final int x = objectPosition.getBlockPos().getX();
-        final int y = objectPosition.getBlockPos().getY();
+        final double y = (BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()) == null ? objectPosition.getBlockPos().getY() + BlockUtils.getBlock(objectPosition.getBlockPos()).getBlockBoundsMaxY() : BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()).maxY) - 1D + fixedY;
         final int z = objectPosition.getBlockPos().getZ();
 
         if(!(BlockUtils.getBlock(objectPosition.getBlockPos()) instanceof BlockAir)) {
@@ -260,14 +283,14 @@ public class Teleport extends Module {
             glDisable(GL_TEXTURE_2D);
             glDisable(GL_DEPTH_TEST);
             glDepthMask(false);
-            RenderUtils.glColor(modeValue.get().equalsIgnoreCase("minesucht") && mc.thePlayer.getPosition().getY() != y + 1 ? new Color(255, 0, 0, 90) : BlockUtils.getBlock(objectPosition.getBlockPos().up()).getMaterial() != Material.air ? new Color(255, 0, 0, 90) : new Color(0, 255, 0, 90));
+            RenderUtils.glColor(modeValue.get().equalsIgnoreCase("minesucht") && mc.thePlayer.getPosition().getY() != y + 1 ? new Color(255, 0, 0, 90) : !mc.theWorld.getCollidingBoundingBoxes(mc.thePlayer, mc.thePlayer.getEntityBoundingBox().offset(x + 0.5D - mc.thePlayer.posX, y + 1D - mc.thePlayer.posY, z + 0.5D - mc.thePlayer.posZ)).isEmpty() ? new Color(255, 0, 0, 90) : new Color(0, 255, 0, 90));
             RenderUtils.drawFilledBox(new AxisAlignedBB(x - renderManager.renderPosX, (y + 1) - renderManager.renderPosY, z - renderManager.renderPosZ, x - renderManager.renderPosX + 1.0D, y + 1.2D - renderManager.renderPosY, z - renderManager.renderPosZ + 1.0D));
             glEnable(GL_TEXTURE_2D);
             glEnable(GL_DEPTH_TEST);
             glDepthMask(true);
             glDisable(GL_BLEND);
 
-            RenderUtils.renderNameTag(Math.round(mc.thePlayer.getDistance(x, y, z)) + "m", x + 0.5, y + 1.7, z + 0.5);
+            RenderUtils.renderNameTag(Math.round(mc.thePlayer.getDistance(x + 0.5D, y + 1D, z + 0.5D)) + "m", x + 0.5, y + 1.7, z + 0.5);
             GlStateManager.resetColor();
         }
     }


### PR DESCRIPTION
- fixed retrieving the target position for non-full blocks, especially for snow layers and fences (the target position's yPos is the actual maxY pos of the target block)
- Added boolValue "IgnoreNoCollision" to either ignore or consider blocks without collision boxes
- uses AABB instead of BlockPos to check whether a teleport position is valid (onRender/red color)
=> should fix it for non-full blocks constellations