### PR TITLE
Fixed getPath() not considering Y offset

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/utils/PathUtils.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/utils/PathUtils.java
@@ -49,17 +49,15 @@ public final class PathUtils extends MinecraftInstance {
 
     public static List<Vector3d> findPath(final double tpX, final double tpY, final double tpZ, final double offset) {
         final List<Vector3d> positions = new ArrayList<>();
-        final float yaw = (float) ((Math.atan2(tpZ - mc.thePlayer.posZ, tpX - mc.thePlayer.posX) * 180.0 / Math.PI) - 90F);
-        final double steps = getDistance(mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, tpX, tpY, tpZ) / offset;
+        final double steps = Math.ceil(getDistance(mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, tpX, tpY, tpZ) / offset);
 
-        double curY = mc.thePlayer.posY;
+        final double dX = tpX - mc.thePlayer.posX;
+        final double dY = tpY - mc.thePlayer.posY;
+        final double dZ = tpZ - mc.thePlayer.posZ;
 
-        for(double d = offset; d < getDistance(mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, tpX, tpY, tpZ); d += offset) {
-            curY -= (mc.thePlayer.posY - tpY) / steps;
-            positions.add(new Vector3d(mc.thePlayer.posX - (Math.sin(Math.toRadians(yaw)) * d), curY, mc.thePlayer.posZ + Math.cos(Math.toRadians(yaw)) * d));
+        for(double d = 1D; d <= steps; ++d) {
+            positions.add(new Vector3d(mc.thePlayer.posX + (dX * d) / steps, mc.thePlayer.posY + (dY * d) / steps, mc.thePlayer.posZ + (dZ * d) / steps));
         }
-
-        positions.add(new Vector3d(tpX, tpY, tpZ));
 
         return positions;
     }


### PR DESCRIPTION
The offset value of the original getPath() function is accidentally only a horizontal offset value; thus, if the current pos isn't on the same height as the target pos, the actual offside is bigger. Can cause the teleport not to work on servers because the real offset can exceed the max (vanilla) speed limit on servers even if the given offset value is low enough.