### PR TITLE
fixed teleport position not being displayed

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
@@ -154,7 +154,7 @@ public class Teleport extends Module {
                 return;
             }
 
-            ClientUtils.displayChatMessage("§7[§8§lTeleport§7] §3Position was set to §8" + endPos.getX() + "§3, §8" + (BlockUtils.getBlock(endPos).getCollisionBoundingBox(mc.theWorld, endPos, BlockUtils.getBlock(endPos).getDefaultState()).maxY + fixedY) + "§3, §8" + endPos.getZ());
+            ClientUtils.displayChatMessage("§7[§8§lTeleport§7] §3Position was set to §8" + endPos.getX() + "§3, §8" + ((BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()) == null ? endPos.getY() + BlockUtils.getBlock(endPos).getBlockBoundsMaxY() : BlockUtils.getBlock(objectPosition.getBlockPos()).getCollisionBoundingBox(mc.theWorld, objectPosition.getBlockPos(), BlockUtils.getBlock(objectPosition.getBlockPos()).getDefaultState()).maxY) + fixedY) + "§3, §8" + endPos.getZ());
             delay = 6;
         }
 


### PR DESCRIPTION
fixed teleport position not being displayed while setting when IgnoreNoCollision is disabled and you teleport onto a block without collision box.
(considered it when getting the actual teleport pos but not when sending the chat message (200 IQ))