### PR TITLE
Fixed a timer bug in Regen

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Regen.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Regen.kt
@@ -31,6 +31,7 @@ class Regen : Module() {
     fun onUpdate(event: UpdateEvent) {
         if (resetTimer)
             mc.timer.timerSpeed = 1F
+            resetTimer = false
 
         if ((!noAirValue.get() || mc.thePlayer.onGround) && !mc.thePlayer.capabilities.isCreativeMode &&
                 mc.thePlayer.foodStats.foodLevel > foodValue.get() && mc.thePlayer.isEntityAlive && mc.thePlayer.health < healthValue.get()) {


### PR DESCRIPTION
Regen timer overwrote other timer values even if timer is nolonger in "healing state".  (Was only an issue when Spartan mode was used once)