### PR TITLE
Rollback .reload fix

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
@@ -9,7 +9,6 @@ import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.ui.client.clickgui.ClickGui
 import net.ccbluex.liquidbounce.ui.font.Fonts
-import net.ccbluex.liquidbounce.features.command.CommandManager
 
 class ReloadCommand : Command("reload", arrayOf("configreload")) {
     /**
@@ -17,9 +16,6 @@ class ReloadCommand : Command("reload", arrayOf("configreload")) {
      */
     override fun execute(args: Array<String>) {
         chat("Reloading...")
-        chat("§c§lReloading commands...")
-        LiquidBounce.commandManager = CommandManager()
-        LiquidBounce.commandManager.registerCommands()
         chat("§c§lReloading scripts...")
         LiquidBounce.scriptManager.reloadScripts()
         chat("§c§lReloading fonts...")


### PR DESCRIPTION
Reloading commands removed all LB commands.

The reason to reload them was that duplicates are created every time you reload.
Need to find a better solution...