### PR TITLE
Fix .reload

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
@@ -23,11 +23,13 @@ class ReloadCommand : Command("reload", arrayOf("configreload")) {
         for(module in LiquidBounce.moduleManager.modules)
             LiquidBounce.moduleManager.generateCommand(module)
         chat("§c§lReloading scripts...")
+        LiquidBounce.isStarting = true
         LiquidBounce.scriptManager.reloadScripts()
         chat("§c§lReloading fonts...")
         Fonts.loadFonts()
         chat("§c§lReloading modules...")
         LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.modulesConfig)
+        LiquidBounce.isStarting = false
         chat("§c§lReloading values...")
         LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.valuesConfig)
         chat("§c§lReloading accounts...")


### PR DESCRIPTION
Doing LiquidBounce.fileManager.loadConfig(LiquidBounce.fileManager.modulesConfig) causes modulesConfig to be saved like 300 times if isStarting is false. (because every value change triggers config saving)

In addition to that, isStarting fixes custom modules values, states, binds getting reset because they don't overwrite the config by saving it 300 times.