### PR TITLE
Final .reload fix

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ReloadCommand.kt
@@ -20,11 +20,14 @@ class ReloadCommand : Command("reload", arrayOf("configreload")) {
         chat("§c§lReloading commands...")
         LiquidBounce.commandManager = CommandManager()
         LiquidBounce.commandManager.registerCommands()
+        LiquidBounce.isStarting = true
+        LiquidBounce.scriptManager.disableScripts()
+        LiquidBounce.scriptManager.unloadScripts()
         for(module in LiquidBounce.moduleManager.modules)
             LiquidBounce.moduleManager.generateCommand(module)
         chat("§c§lReloading scripts...")
-        LiquidBounce.isStarting = true
-        LiquidBounce.scriptManager.reloadScripts()
+        LiquidBounce.scriptManager.loadScripts()
+        LiquidBounce.scriptManager.enableScripts()
         chat("§c§lReloading fonts...")
         Fonts.loadFonts()
         chat("§c§lReloading modules...")


### PR DESCRIPTION
Generating commands before unregistering scripts caused their commands to not work after reloading.