### PR TITLE
Fixed typo

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Ignite.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Ignite.java
@@ -28,7 +28,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 
-@ModuleInfo(name = "Ignite", description = "Automatically sets targets aroung you on fire.",
+@ModuleInfo(name = "Ignite", description = "Automatically sets targets around you on fire.",
             category = ModuleCategory.COMBAT)
 public class Ignite extends Module {
    private final BoolValue lighterValue = new BoolValue("Lighter", true);


### PR DESCRIPTION
"around" was misspelled as "aroung" in UI and code.