### PR TITLE
Some scaffold/tower fixes regarding blacklisted items

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
@@ -273,7 +273,8 @@ public class Scaffold extends Module {
 
     private void update() {
         if (autoBlockValue.get() ? InventoryUtils.findAutoBlockBlock() == -1 : mc.thePlayer.getHeldItem() == null ||
-                !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock))
+                !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) ||
+                InventoryUtils.BLOCK_BLACKLIST.contains(((ItemBlock) mc.thePlayer.getHeldItem().getItem()).getBlock()))
             return;
 
         findBlock(modeValue.get().equalsIgnoreCase("expand"));
@@ -325,9 +326,8 @@ public class Scaffold extends Module {
 
         int blockSlot = -1;
         ItemStack itemStack = mc.thePlayer.getHeldItem();
-        Block block = ((ItemBlock) itemStack.getItem()).getBlock();
 
-        if (mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) || mc.thePlayer.getHeldItem().stackSize <= 0 || InventoryUtils.BLOCK_BLACKLIST.contains(block)) {
+        if (mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) || mc.thePlayer.getHeldItem().stackSize <= 0 || InventoryUtils.BLOCK_BLACKLIST.contains(((ItemBlock) itemStack.getItem()).getBlock())) {
             if (!autoBlockValue.get())
                 return;
 

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
@@ -325,8 +325,9 @@ public class Scaffold extends Module {
 
         int blockSlot = -1;
         ItemStack itemStack = mc.thePlayer.getHeldItem();
+        Block block = ((ItemBlock) itemStack.getItem()).getBlock();
 
-        if (mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) || mc.thePlayer.getHeldItem().stackSize <= 0) {
+        if (mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) || mc.thePlayer.getHeldItem().stackSize <= 0 || InventoryUtils.BLOCK_BLACKLIST.contains(block)) {
             if (!autoBlockValue.get())
                 return;
 

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.java
@@ -22,6 +22,7 @@ import net.ccbluex.liquidbounce.value.BoolValue;
 import net.ccbluex.liquidbounce.value.FloatValue;
 import net.ccbluex.liquidbounce.value.IntegerValue;
 import net.ccbluex.liquidbounce.value.ListValue;
+import net.minecraft.block.Block;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.settings.GameSettings;
@@ -533,8 +534,11 @@ public class Scaffold extends Module {
         for (int i = 36; i < 45; i++) {
             final ItemStack itemStack = mc.thePlayer.inventoryContainer.getSlot(i).getStack();
 
-            if (itemStack != null && itemStack.getItem() instanceof ItemBlock)
-                amount += itemStack.stackSize;
+            if (itemStack != null && itemStack.getItem() instanceof ItemBlock) {
+                final Block block = ((ItemBlock) itemStack.getItem()).getBlock();
+                if (!InventoryUtils.BLOCK_BLACKLIST.contains(block))
+                    amount += itemStack.stackSize;
+            }
         }
 
         return amount;

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.java
@@ -124,7 +124,8 @@ public class Tower extends Module {
             timer.update();
 
             if (autoBlockValue.get() ? InventoryUtils.findAutoBlockBlock() != -1 : mc.thePlayer.getHeldItem() != null
-                    && mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) {
+                    && mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock
+                    && !InventoryUtils.BLOCK_BLACKLIST.contains(((ItemBlock) mc.thePlayer.getHeldItem().getItem()).getBlock())) {
                 if (!stopWhenBlockAbove.get() || BlockUtils.getBlock(new BlockPos(mc.thePlayer.posX,
                         mc.thePlayer.posY + 2, mc.thePlayer.posZ)) instanceof BlockAir)
                     move();
@@ -149,7 +150,7 @@ public class Tower extends Module {
         mc.thePlayer.isAirBorne = true;
         mc.thePlayer.triggerAchievement(StatList.jumpStat);
     }
-    
+
     /**
      * Move player
      */
@@ -244,11 +245,11 @@ public class Tower extends Module {
         // AutoBlock
         int blockSlot = -1;
         ItemStack itemStack = mc.thePlayer.getHeldItem();
+        Block block = ((ItemBlock) itemStack.getItem()).getBlock();
 
-        if(mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock)) {
+        if(mc.thePlayer.getHeldItem() == null || !(mc.thePlayer.getHeldItem().getItem() instanceof ItemBlock) || InventoryUtils.BLOCK_BLACKLIST.contains(block)) {
             if (!autoBlockValue.get())
                 return;
-
 
             blockSlot = InventoryUtils.findAutoBlockBlock();
 

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.java
@@ -21,6 +21,7 @@ import net.ccbluex.liquidbounce.value.BoolValue;
 import net.ccbluex.liquidbounce.value.FloatValue;
 import net.ccbluex.liquidbounce.value.IntegerValue;
 import net.ccbluex.liquidbounce.value.ListValue;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
@@ -407,8 +408,11 @@ public class Tower extends Module {
         for(int i = 36; i < 45; i++) {
             final ItemStack itemStack = mc.thePlayer.inventoryContainer.getSlot(i).getStack();
 
-            if(itemStack != null && itemStack.getItem() instanceof ItemBlock)
-                amount += itemStack.stackSize;
+            if (itemStack != null && itemStack.getItem() instanceof ItemBlock) {
+                final Block block = ((ItemBlock) itemStack.getItem()).getBlock();
+                if (!InventoryUtils.BLOCK_BLACKLIST.contains(block))
+                    amount += itemStack.stackSize;
+            }
         }
 
         return amount;

--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/utils/InventoryUtils.java
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/utils/InventoryUtils.java
@@ -26,7 +26,8 @@ public final class InventoryUtils extends MinecraftInstance implements Listenabl
     public static final MSTimer CLICK_TIMER = new MSTimer();
     public static final List<Block> BLOCK_BLACKLIST = Arrays.asList(Blocks.enchanting_table, Blocks.chest, Blocks.ender_chest, Blocks.trapped_chest,
             Blocks.anvil, Blocks.sand, Blocks.web, Blocks.torch, Blocks.crafting_table, Blocks.furnace, Blocks.waterlily, Blocks.dispenser,
-            Blocks.stone_pressure_plate, Blocks.wooden_pressure_plate, Blocks.noteblock, Blocks.dropper, Blocks.tnt, Blocks.standing_banner, Blocks.wall_banner);
+            Blocks.stone_pressure_plate, Blocks.wooden_pressure_plate, Blocks.noteblock, Blocks.dropper, Blocks.tnt, Blocks.standing_banner, Blocks.wall_banner,
+            Blocks.redstone_torch);
 
     public static int findItem(final int startSlot, final int endSlot, final Item item) {
         for(int i = startSlot; i < endSlot; i++) {


### PR DESCRIPTION
* Fixes block amount displayed (previously blacklisted items would count to that amount confusing the user)
* Prevents scaffold and tower from placing blacklisted items (previously this could happen in certain edge cases) and moving the player if only blacklisted items are in the player's hotbar
* Adds redstone torch to blacklisted items