### PR TITLE
Fixed AutoReconnect.isEnabled not defined correctly

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/special/AutoReconnect.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/features/special/AutoReconnect.kt
@@ -18,7 +18,7 @@ object AutoReconnect {
         private set
     var delay = 5000
         set(value) {
-            isEnabled = delay < MAX
+            isEnabled = value < MAX
 
             field = value
         }


### PR DESCRIPTION
When you turn auto-reconnect off and relaunch the client, the timer will be set to 60 seconds since `isEnabled` isn't defined correctly on start