### PR TITLE
fixed isSPacketExplosion and possible problem in 1.12

### DIFF
--- a/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/injection/backend/ClassProviderImpl.kt
+++ b/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/injection/backend/ClassProviderImpl.kt
@@ -266,7 +266,7 @@ object ClassProviderImpl : IClassProvider {
 
     override fun isSPacketEntityVelocity(obj: Any?): Boolean = obj is PacketImpl<*> && obj.wrapped is S12PacketEntityVelocity
 
-    override fun isSPacketExplosion(obj: Any?): Boolean = obj is PacketImpl<*> && obj.wrapped is S12PacketEntityVelocity
+    override fun isSPacketExplosion(obj: Any?): Boolean = obj is PacketImpl<*> && obj.wrapped is S27PacketExplosion
 
     override fun isSPacketCloseWindow(obj: Any?): Boolean = obj is PacketImpl<*> && obj.wrapped is S2EPacketCloseWindow
 

--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
@@ -195,9 +195,7 @@ class Velocity : Module() {
                     event.cancelEvent()
                 }
             }
-        }
-
-        if (classProvider.isSPacketExplosion(packet)) {
+        } else if (classProvider.isSPacketExplosion(packet)) {
             // TODO: Support velocity for explosions
             event.cancelEvent()
         }


### PR DESCRIPTION
#https://github.com/CCBlueX/LiquidBounce1.8-Issues/issues/3903
It seemed that `isSPacketExplosion` should see if it is a `S27PacketExplosion` in 1.8.9.
Since all the `S12PacketEntityVelocity` was treated as explosion packets, it get canceled. 
```
        if (classProvider.isSPacketExplosion(packet)) {
            // TODO: Support velocity for explosions
            event.cancelEvent()
        }
```
Also 1.12 use
`override fun isSPacketExplosion(obj: Any?): Boolean = obj is PacketImpl<*> && obj.wrapped is SPacketEntityVelocity`
will cause the same problem.

It fixed the bug in 1.8.9, and it **_should_** fix the problem in 1.12.2