### PR TITLE
Matrix Speed Addition.

### DIFF
--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
@@ -63,6 +63,7 @@ class Speed : Module() {
             HiveHop(),
             HypixelHop(),
             MineplexGround(),  // Other
+            Matrix(),
             SlowHop(),
             CustomSpeed()
     )

--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
@@ -13,20 +13,26 @@ class Matrix : SpeedMode("Matrix") {
     override fun onEnable() {
         mc.timer.timerSpeed = 1.055f
     }
-    
+ 
     override fun onDisable() {
+        mc.thePlayer!!.speedInAir = 0.02f
         mc.timer.timerSpeed = 1f
     }
-    
+
     override fun onMotion() {}
     override fun onUpdate() {
         if (mc.thePlayer!!.isInWater) return
         if (MovementUtils.isMoving) {
             if (mc.thePlayer!!.onGround) {
                 mc.thePlayer!!.jump()
+                mc.thePlayer!!.speedInAir = 0.02055f
                 mc.timer.timerSpeed = 1.055f
             }    
+        } else {
+            mc.thePlayer!!.motionX = 0.0
+            mc.thePlayer!!.motionZ = 0.0
+            mc.timer.timerSpeed = 1f    
         }
-    }
+    }  
     override fun onMove(event: MoveEvent) {}
 }

--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
@@ -1,0 +1,32 @@
+/*
+ * LiquidBounce Hacked Client
+ * A free open source mixin-based injection hacked client for Minecraft using Minecraft Forge.
+ * https://github.com/CCBlueX/LiquidBounce/
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.speeds.other
+
+import net.ccbluex.liquidbounce.event.MoveEvent
+import net.ccbluex.liquidbounce.features.module.modules.movement.speeds.SpeedMode
+import net.ccbluex.liquidbounce.utils.MovementUtils
+
+class Matrix : SpeedMode("Matrix") {
+    override fun onEnable() {
+        mc.timer.timerSpeed = 1.055f
+    }
+    
+    override fun onDisable() {
+        mc.timer.timerSpeed = 1f
+    }
+    
+    override fun onMotion() {}
+    override fun onUpdate() {
+        if (mc.thePlayer!!.isInWater) return
+        if (MovementUtils.isMoving) {
+            if (mc.thePlayer!!.onGround) {
+                mc.thePlayer!!.jump()
+                mc.timer.timerSpeed = 1.055f
+            }    
+        }
+    }
+    override fun onMove(event: MoveEvent) {}
+}


### PR DESCRIPTION
* Could have been a lot better by adding strafes to it. I tried but it turned out wrong so I gave up and only did the speed part. As of the strafes module, it is easily detectable when on Matrix, but luckily there's a remade version of it by yorik100, which with that, you will probably have an even better advantage.

Speed tests, on 2 servers tested.

* Updated videos regarding the new updates.
* 11/25/2020:

* [Loyisa.](https://youtu.be/wKdbcmSRiQ8)

* [Tree server.](https://youtu.be/GUm6qMS023E)