### PR TITLE
Fixed AAC3Bhop/AAC5Bhop's Speed reset problems after being disabled.

### DIFF
--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AAC3BHop.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AAC3BHop.kt
@@ -16,7 +16,7 @@ class AAC3BHop : SpeedMode("AAC3BHop") {
         val thePlayer = mc.thePlayer ?: return
 
         mc.timer.timerSpeed = 1f
-
+        
         if (thePlayer.isInWater)
             return
 
@@ -28,10 +28,8 @@ class AAC3BHop : SpeedMode("AAC3BHop") {
                         legitJump = false
                         return
                     }
-
                     thePlayer.motionY = 0.3852
                     thePlayer.onGround = false
-
                     MovementUtils.strafe(0.374f)
                 }
                 thePlayer.motionY < 0.0 -> {
@@ -50,4 +48,8 @@ class AAC3BHop : SpeedMode("AAC3BHop") {
     override fun onMotion() {}
     override fun onUpdate() {}
     override fun onMove(event: MoveEvent) {}
+    override fun onDisable() {
+        mc.thePlayer!!.speedInAir = 0.02f
+        mc.timer.timerSpeed = 1f
+    }
 }

--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AAC5BHop.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AAC5BHop.kt
@@ -11,9 +11,6 @@ import net.ccbluex.liquidbounce.utils.MovementUtils
 
 class AAC5BHop : SpeedMode("AAC5BHop") {
     private var legitJump = false
-    override fun onMotion() {}
-    override fun onUpdate() {}
-    override fun onMove(event: MoveEvent) {}
     override fun onTick() {
         val thePlayer = mc.thePlayer ?: return
 
@@ -28,13 +25,10 @@ class AAC5BHop : SpeedMode("AAC5BHop") {
                     if (legitJump) {
                         thePlayer.jump()
                         legitJump = false
-
                         return
                     }
-
                     thePlayer.motionY = 0.41
                     thePlayer.onGround = false
-
                     MovementUtils.strafe(0.374f)
                 }
                 thePlayer.motionY < 0.0 -> {
@@ -48,5 +42,13 @@ class AAC5BHop : SpeedMode("AAC5BHop") {
             thePlayer.motionX = 0.0
             thePlayer.motionZ = 0.0
         }
+    }
+
+    override fun onMotion() {}
+    override fun onUpdate() {}
+    override fun onMove(event: MoveEvent) {}
+    override fun onDisable() {
+        mc.thePlayer!!.speedInAir = 0.02f
+        mc.timer.timerSpeed = 1f
     }
 }


### PR DESCRIPTION
* Fixes this [bug.](https://github.com/CCBlueX/LiquidBounce/issues/258)

I tested those 2 modes before fixing those, and I realized that when on AAC, it would flag for timer after running for a bit. After fixing these, I noticed that flags are gone.