### PR TITLE
Further Matrix Speed improvements.

### DIFF
--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
@@ -89,8 +89,6 @@ class Speed : Module() {
     val aacGroundTimerValue = FloatValue("AACGround-Timer", 3f, 1.1f, 10f)
     val cubecraftPortLengthValue = FloatValue("CubeCraft-PortLength", 1f, 0.1f, 2f)
     val mineplexGroundSpeedValue = FloatValue("MineplexGround-Speed", 0.5f, 0.1f, 1f)
-    val matrixSpeedValue = FloatValue("Matrix-Speed", 0.02f, 0.02f, 1f)
-    val matrixTimerValue = FloatValue("Matrix-Timer", 1f, 0.1f, 2f)
 
     @EventTarget
     fun onUpdate(event: UpdateEvent?) {

--- a/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/Matrix.kt
@@ -18,12 +18,10 @@ class Matrix : SpeedMode("Matrix") {
         if (MovementUtils.isMoving) {
             if (mc.thePlayer!!.onGround) {
                 mc.thePlayer!!.jump()
-                mc.thePlayer!!.speedInAir = (LiquidBounce.moduleManager.getModule(Speed::class.java) as Speed?)!!.matrixSpeedValue.get()
-                mc.timer.timerSpeed = (LiquidBounce.moduleManager.getModule(Speed::class.java) as Speed?)!!.matrixTimerValue.get()
+                mc.thePlayer!!.speedInAir = 0.0209f
+                mc.timer.timerSpeed = 1.055f
             }    
         } else {
-            mc.thePlayer!!.motionX = 0.0
-            mc.thePlayer!!.motionZ = 0.0
             mc.timer.timerSpeed = 1f    
         }
     }


### PR DESCRIPTION
* Removed values and value sliders because they actually aren't that much useful. I mean like there's almost nothing to change that can make you go faster, so I went the way I originally wanted to and also improved the speed values.

* Also removed the movement reset when player would stop sprinting, bypasses a flag that way.

Hopefully these are my last speed changes because I feel like I'm spamming the [changelog](https://liquidbounce.net/download) with Matrix Speed changes.