### PR TITLE
A more correct rotation fix, which can bypass some advanced anti-cheats

### DIFF
--- a/shared/main/java/net/ccbluex/liquidbounce/utils/Rotation.kt
+++ b/shared/main/java/net/ccbluex/liquidbounce/utils/Rotation.kt
@@ -41,8 +41,18 @@ data class Rotation(var yaw: Float, var pitch: Float) : MinecraftInstance() {
         val f = sensitivity * 0.6F + 0.2F
         val gcd = f * f * f * 1.2F
 
-        yaw -= yaw % gcd
-        pitch -= pitch % gcd
+        // get previous rotation
+        val rotation = RotationUtils.serverRotation
+
+        // fix yaw
+        var deltaYaw = yaw - rotation.yaw
+        deltaYaw -= deltaYaw % gcd
+        yaw = rotation.yaw + deltaYaw
+
+        // fix pitch
+        var deltaPitch = pitch - rotation.pitch
+        deltaPitch -= deltaPitch % gcd
+        pitch = rotation.pitch + deltaPitch
     }
 
     /**


### PR DESCRIPTION
**Description**
LiquidBounce's mouse sensitivity repair is incorrect, yaw/pitch is not a multiple of gcd, but the **delta value of yaw/pitch** is a multiple of gcd. Fixing this bug can bypass AAC and some private anticheat, including my anticheat Matrix. Enjoy it~

**Why make this public?**
A hacked client in my country have already patched it and bypassed Matrix, so I don’t need to hide it anymore

The principle is explained below