### PR TITLE
feat(module): add notifier module

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -25,10 +25,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleSkinDerp
 import net.ccbluex.liquidbounce.features.module.modules.combat.*
 import net.ccbluex.liquidbounce.features.module.modules.exploit.*
-import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleFriendClicker
-import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleNameProtect
-import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleSpammer
-import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleTeams
+import net.ccbluex.liquidbounce.features.module.modules.misc.*
 import net.ccbluex.liquidbounce.features.module.modules.movement.*
 import net.ccbluex.liquidbounce.features.module.modules.player.*
 import net.ccbluex.liquidbounce.features.module.modules.render.*
@@ -160,7 +157,8 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
             ModulePerfectHorseJump,
             ModuleAntiAFK,
             ModuleNoJumpDelay,
-            ModuleNoBob
+            ModuleNoBob,
+            ModuleNotifier
         )
 
         builtin.apply {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -27,7 +27,6 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.regular
-import net.minecraft.client.MinecraftClient
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket
 import java.util.*
 
@@ -37,6 +36,7 @@ import java.util.*
  * Notifies you about all kinds of events.
  */
 object ModuleNotifier : Module("Notifier", Category.MISC) {
+
     private val joinMessages by boolean("Join Messages", true)
     private val joinMessageFormat by text("Join Message Format", "%s joined")
 
@@ -48,7 +48,7 @@ object ModuleNotifier : Module("Notifier", Category.MISC) {
     private val uuidNameCache = hashMapOf<UUID, String>()
 
     override fun enable() {
-        for (entry in MinecraftClient.getInstance().networkHandler!!.playerList) {
+        for (entry in network.playerList) {
             uuidNameCache[entry.profile.id] = entry.profile.name
         }
     }
@@ -97,4 +97,5 @@ object ModuleNotifier : Module("Notifier", Category.MISC) {
             }
         }
     }
+
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -19,11 +19,13 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
+import net.ccbluex.liquidbounce.event.NotificationEvent
 import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.regular
 import net.minecraft.client.MinecraftClient
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket
@@ -40,6 +42,8 @@ object ModuleNotifier : Module("Notifier", Category.MISC) {
 
     private val leaveMessages by boolean("Leave Messages", true)
     private val leaveMessageFormat by text("Leave Message Format", "%s left")
+
+    private val useNotification by boolean("Use Notification", false)
 
     private val uuidNameCache = hashMapOf<UUID, String>()
 
@@ -63,14 +67,26 @@ object ModuleNotifier : Module("Notifier", Category.MISC) {
                         uuidNameCache[entry.profile.id] = entry.profile.name
 
                         if (joinMessages) {
-                            chat(regular(joinMessageFormat.format(entry.profile.name)))
+                            val message = joinMessageFormat.format(entry.profile.name)
+
+                            if (useNotification) {
+                                notification("Notifier", message, NotificationEvent.Severity.INFO)
+                            } else {
+                                chat(regular(message))
+                            }
                         }
                     }
                 }
                 PlayerListS2CPacket.Action.REMOVE_PLAYER -> {
                     for (entry in packet.entries) {
                         if (leaveMessages) {
-                            chat(regular(leaveMessageFormat.format(uuidNameCache[entry.profile.id])))
+                            val message = leaveMessageFormat.format(uuidNameCache[entry.profile.id])
+
+                            if (useNotification) {
+                                notification("Notifier", message, NotificationEvent.Severity.INFO)
+                            } else {
+                                chat(regular(message))
+                            }
                         }
 
                         uuidNameCache.remove(entry.profile.id)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -1,0 +1,84 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2016 - 2021 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.module.modules.misc
+
+import net.ccbluex.liquidbounce.event.PacketEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.regular
+import net.minecraft.client.MinecraftClient
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket
+import java.util.*
+
+/**
+ * Notifier module
+ *
+ * Notifies you about all kinds of events.
+ */
+object ModuleNotifier : Module("Notifier", Category.MISC) {
+    private val joinMessages by boolean("Join Messages", true)
+    private val joinMessageFormat by text("Join Message Format", "%s joined")
+
+    private val leaveMessages by boolean("Leave Messages", true)
+    private val leaveMessageFormat by text("Leave Message Format", "%s left")
+
+    private val uuidNameCache = hashMapOf<UUID, String>()
+
+    override fun enable() {
+        for (entry in MinecraftClient.getInstance().networkHandler!!.playerList) {
+            uuidNameCache[entry.profile.id] = entry.profile.name
+        }
+    }
+
+    override fun disable() {
+        uuidNameCache.clear()
+    }
+
+    val packetHandler = handler<PacketEvent> { event ->
+        val packet = event.packet
+
+        if (packet is PlayerListS2CPacket) {
+            when (packet.action) {
+                PlayerListS2CPacket.Action.ADD_PLAYER -> {
+                    for (entry in packet.entries) {
+                        uuidNameCache[entry.profile.id] = entry.profile.name
+
+                        if (joinMessages) {
+                            chat(regular(joinMessageFormat.format(entry.profile.name)))
+                        }
+                    }
+                }
+                PlayerListS2CPacket.Action.REMOVE_PLAYER -> {
+                    for (entry in packet.entries) {
+                        if (leaveMessages) {
+                            chat(regular(leaveMessageFormat.format(uuidNameCache[entry.profile.id])))
+                        }
+
+                        uuidNameCache.remove(entry.profile.id)
+                    }
+                }
+                else -> {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `Notifier` module notifies a user about all kinds of events. However currently joins and leaves are the only events tracked. The reason to display joins and leaves with such a module, is that servers sometimes disable join/leave messages but people might still be interested in who joins/leaves.  
In the future stuff like another player popping totems or other important stuff that a player might want to be notified about could be added to this as well.