### PR TITLE
Fix java.io.FileNotFoundException

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/utils/misc/HttpUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/misc/HttpUtils.kt
@@ -6,9 +6,8 @@
 
 package net.ccbluex.liquidbounce.utils.misc
 
-import com.google.common.io.ByteStreams
+import org.apache.commons.io.FileUtils
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -67,6 +66,6 @@ object HttpUtils {
 
     @Throws(IOException::class)
     @JvmStatic
-    fun download(url: String, file: File) = FileOutputStream(file).use { ByteStreams.copy(make(url, "GET").inputStream, it) }
+    fun download(url: String, file: File) = FileUtils.copyInputStreamToFile(make(url, "GET").inputStream, file)
 
 }


### PR DESCRIPTION
Non cross-version HttpUtils used FileUtils that made all coresponding folders of the target directory.
I would otherwise have to check every file and mkdir() its path in all scripts that use HttpUtils.

https://github.com/CCBlueX/LiquidBounce/blob/7672ffacabf9baa70968e99209f841a335ea8ec9/1.8.9-Forge/src/main/java/net/ccbluex/liquidbounce/utils/misc/HttpUtils.kt