### PR TITLE
[LEGACY] Updated client start args for workspace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ minecraft {
     runDir = "run"
     mappings = "stable_22"
     makeObfSourceJar = false
-    clientJvmArgs += ["-Dfml.coreMods.load=net.ccbluex.liquidbounce.injection.forge.TransformerLoader", "-Xmx1024m -Xms1024m", "-Ddev-mode"]
+    clientJvmArgs += ["-Dfml.coreMods.load=net.ccbluex.liquidbounce.injection.forge.MixinLoader", "-Xmx1024m -Xms1024m", "-Ddev-mode"]
 }
 
 configurations {
@@ -104,7 +104,7 @@ classes.dependsOn(moveResources)
 
 jar {
     manifest.attributes(
-            "FMLCorePlugin": "net.ccbluex.liquidbounce.injection.forge.TransformerLoader",
+            "FMLCorePlugin": "net.ccbluex.liquidbounce.injection.forge.MixinLoader",
             "FMLCorePluginContainsFMLMod": true,
             "ForceLoadAsMod": true,
             "MixinConfigs": "liquidbounce.forge.mixins.json",


### PR DESCRIPTION
I recently cloned the legacy version for development, There was a small issue so I couldn't start it directly. The injection of LB was not performed. After a little debugging, I found that the [MixinLoader ](https://github.com/CCBlueX/LiquidBounce/blob/legacy/src/main/java/net/ccbluex/liquidbounce/injection/forge/MixinLoader.java) class is needed instead of the transformer in the start args.

Please note: I'm not really familiar with mixin. This solution just worked for me.

Greetings

