### PR TITLE
 Make ForceUnicodeChat work with commands

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
@@ -35,7 +35,7 @@ object ModuleForceUnicodeChat : Module("ForceUnicodeChat", Category.EXPLOIT) {
     val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
 
-        if (packet is ChatMessageC2SPacket) {
+        if (packet is ChatMessageC2SPacket && packet.chatMessage[0] != '/') {
             packet.chatMessage = buildString {
                 for (c in packet.chatMessage) {
                     if (c.code in 33..128) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
@@ -36,17 +36,15 @@ object ModuleForceUnicodeChat : Module("ForceUnicodeChat", Category.EXPLOIT) {
         val packet = event.packet
 
         if (packet is ChatMessageC2SPacket) {
-	    if(packet.chatMessage[0] != '/') {
-		packet.chatMessage = buildString {
-                    for (c in packet.chatMessage) {
-			if (c.code in 33..128) {
-                            append(Character.toChars(c.code + 65248))
-			} else {
-                            append(c)
-			}
+            packet.chatMessage = buildString {
+                for (c in packet.chatMessage) {
+                    if (c.code in 33..128) {
+                        append(Character.toChars(c.code + 65248))
+                    } else {
+                        append(c)
                     }
-		}
-	    }
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleForceUnicodeChat.kt
@@ -36,15 +36,17 @@ object ModuleForceUnicodeChat : Module("ForceUnicodeChat", Category.EXPLOIT) {
         val packet = event.packet
 
         if (packet is ChatMessageC2SPacket) {
-            packet.chatMessage = buildString {
-                for (c in packet.chatMessage) {
-                    if (c.code in 33..128) {
-                        append(Character.toChars(c.code + 65248))
-                    } else {
-                        append(c)
+	    if(packet.chatMessage[0] != '/') {
+		packet.chatMessage = buildString {
+                    for (c in packet.chatMessage) {
+			if (c.code in 33..128) {
+                            append(Character.toChars(c.code + 65248))
+			} else {
+                            append(c)
+			}
                     }
-                }
-            }
+		}
+	    }
         }
     }
 }


### PR DESCRIPTION
This pull request will make ForceUnicodeChat do nothing if the chat message
starts with a slash, thus allowing for normal command functionality
while maintaining wide chat.