### PR TITLE
Update GuiServerStatus to request individual endpoints 

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
@@ -9,7 +9,11 @@ import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.ui.client.altmanager.GuiAltManager
 import net.ccbluex.liquidbounce.ui.font.Fonts
 import net.ccbluex.liquidbounce.utils.render.RenderUtils
-import net.minecraft.client.gui.*
+import net.minecraft.client.gui.GuiButton
+import net.minecraft.client.gui.GuiMultiplayer
+import net.minecraft.client.gui.GuiOptions
+import net.minecraft.client.gui.GuiScreen
+import net.minecraft.client.gui.GuiSelectWorld
 import net.minecraft.client.resources.I18n
 
 class GuiMainMenu : GuiScreen() {
@@ -19,7 +23,7 @@ class GuiMainMenu : GuiScreen() {
 
         buttonList.add(GuiButton(100, width / 2 - 100, defaultHeight + 24, 98, 20, "AltManager"))
         buttonList.add(GuiButton(103, width / 2 + 2, defaultHeight + 24, 98, 20, "Mods"))
-        buttonList.add(GuiButton(108, width / 2 - 100, defaultHeight + 24 * 2, 98, 20, "Contributors"))
+        buttonList.add(GuiButton(101, width / 2 - 100, defaultHeight + 24 * 2, 98, 20, "Server Status"))
         buttonList.add(GuiButton(102, width / 2 + 2, defaultHeight + 24 * 2, 98, 20, "Configuration"))
 
         buttonList.add(GuiButton(1, width / 2 - 100, defaultHeight, 98, 20, I18n.format("menu.singleplayer")))
@@ -28,14 +32,15 @@ class GuiMainMenu : GuiScreen() {
         // Minecraft Realms
         //		this.buttonList.add(new GuiButton(14, this.width / 2 - 100, j + 24 * 2, I18n.format("menu.online", new Object[0])));
 
-        buttonList.add(GuiButton(0, width / 2 - 100, defaultHeight + 24 * 3, 98, 20, I18n.format("menu.options")))
-        buttonList.add(GuiButton(4, width / 2 + 2, defaultHeight + 24 * 3, 98, 20, I18n.format("menu.quit")))
+        buttonList.add(GuiButton(108, width / 2 - 100, defaultHeight + 24 * 3, "Contributors"))
+        buttonList.add(GuiButton(0, width / 2 - 100, defaultHeight + 24 * 4, 98, 20, I18n.format("menu.options")))
+        buttonList.add(GuiButton(4, width / 2 + 2, defaultHeight + 24 * 4, 98, 20, I18n.format("menu.quit")))
     }
 
     override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
         drawBackground(0)
 
-        RenderUtils.drawRect(width / 2.0f - 115, height / 4.0f + 35, width / 2.0f + 115, height / 4.0f + 155, Integer.MIN_VALUE)
+        RenderUtils.drawRect(width / 2.0f - 115, height / 4.0f + 35, width / 2.0f + 115, height / 4.0f + 175, Integer.MIN_VALUE)
 
         Fonts.fontBold180.drawCenteredString(LiquidBounce.CLIENT_NAME, width / 2F, height / 8F, 4673984, true)
         Fonts.font35.drawCenteredString(LiquidBounce.CLIENT_VERSION, width / 2F + 148, height / 8F + Fonts.font35.fontHeight, 0xffffff, true)
@@ -50,6 +55,7 @@ class GuiMainMenu : GuiScreen() {
             2 -> mc.displayGuiScreen(GuiMultiplayer(this))
             4 -> mc.shutdown()
             100 -> mc.displayGuiScreen(GuiAltManager(this))
+            101 -> mc.displayGuiScreen(GuiServerStatus(this))
             102 -> mc.displayGuiScreen(GuiClientConfiguration(this))
             103 -> mc.displayGuiScreen(GuiModsMenu(this))
             108 -> mc.displayGuiScreen(GuiContributors(this))

--- a/src/main/java/net/ccbluex/liquidbounce/utils/misc/HttpUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/misc/HttpUtils.kt
@@ -66,6 +66,14 @@ object HttpUtils {
 
     @Throws(IOException::class)
     @JvmStatic
+    fun responseCode(url: String, method: String,
+                     agent: String = DEFAULT_AGENT): Int {
+        val connection = make(url, method, agent)
+        return connection.responseCode
+    }
+
+    @Throws(IOException::class)
+    @JvmStatic
     fun download(url: String, file: File) = FileUtils.copyInputStreamToFile(make(url, "GET").inputStream, file)
 
 }


### PR DESCRIPTION
Since the https://status.mojang.com/check was taken down, we need to check each endpoint individually. It's worth considering adding more endpoints e.g. XBox and Microsoft.

I took https://minecraftstatus.net/ as a reference.

I am aware that this is not an accurate and perfect representation of the actual status of the API. However, you get a rough overview. I think that's worth it.

Demo of Implementation:

https://user-images.githubusercontent.com/39240736/222963295-66428f75-3848-4da9-9eb8-5948b85fd52c.mp4

