### PR TITLE
Few bugfixes

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
@@ -73,7 +73,7 @@ class AutoPot : Module() {
 
                     val collisionBlock = fallingPlayer.findCollision(20)?.pos
 
-                    if (thePlayer.posY - (collisionBlock?.y ?: 0) >= groundDistanceValue.get())
+                    if (thePlayer.posY - (collisionBlock?.y ?: return) - 1 > groundDistanceValue.get())
                         return
 
                     potion = potionInHotbar
@@ -108,7 +108,7 @@ class AutoPot : Module() {
             }
             POST -> {
                 if (potion >= 0 && serverRotation.pitch >= 75F) {
-                    val itemStack = thePlayer.inventory.getStackInSlot(potion)
+                    val itemStack = thePlayer.inventoryContainer.getSlot(potion).stack
 
                     if (itemStack != null) {
                         mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(itemStack))

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/altmanager/GuiAltManager.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/altmanager/GuiAltManager.kt
@@ -295,9 +295,7 @@ class GuiAltManager(private val prevGui: GuiScreen) : GuiScreen() {
         super.mouseClicked(mouseX, mouseY, mouseButton)
     }
 
-    override fun updateScreen() {
-        searchField.updateCursorCounter()
-    }
+    override fun updateScreen() = searchField.updateCursorCounter()
 
     private inner class GuiList constructor(prevGui: GuiScreen) : GuiSlot(mc, prevGui.width, prevGui.height, 40, prevGui.height - 40, 30) {
 
@@ -314,7 +312,7 @@ class GuiAltManager(private val prevGui: GuiScreen) : GuiScreen() {
 
         var selectedSlot = 0
             set(value) {
-                field = value.coerceIn(0, accounts.lastIndex)
+                field = value.coerceIn(0, accounts.lastIndex.coerceAtLeast(0))
             }
             get() {
                 return if (field > accounts.size) {

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
@@ -16,6 +16,7 @@ import net.ccbluex.liquidbounce.file.FileManager.saveConfig
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.ButtonElement
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.ModuleElement
 import net.ccbluex.liquidbounce.ui.client.clickgui.style.Style
+import net.ccbluex.liquidbounce.ui.client.clickgui.style.styles.LiquidBounceStyle
 import net.ccbluex.liquidbounce.ui.client.clickgui.style.styles.SlowlyStyle
 import net.ccbluex.liquidbounce.ui.client.hud.designer.GuiHudDesigner
 import net.ccbluex.liquidbounce.ui.font.AWTFontRenderer.Companion.assumeNonVolatile
@@ -38,11 +39,11 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 class ClickGui : GuiScreen() {
-    val panels: MutableList<Panel> = ArrayList()
+    val panels = mutableListOf<Panel>()
     private val hudIcon = ResourceLocation("${CLIENT_NAME.lowercase()}/custom_hud_icon.png")
-    var style: Style = SlowlyStyle
-    private var mouseX = 0
-    private var mouseY = 0
+    var style: Style = LiquidBounceStyle
+    var mouseX = 0
+    var mouseY = 0
 
     init {
         val width = 100

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
@@ -29,19 +29,24 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
 
     var x = x
         get() {
-            if (!drag && !Mouse.isButtonDown(1)) return field
+            // Don't rearrange panels when not interacting with ClickGUI.
+            if (!drag && !Mouse.isButtonDown(0) && !Mouse.isButtonDown(1)) return field
 
             val settingsWidth =
                 if (open) elements.filterIsInstance<ModuleElement>().maxOfOrNull { if (it.showSettings) it.settingsWidth else 0 } ?: 0
                 else 0
 
-            field = field.coerceIn(0, max(0, (mc.displayWidth / 2 / scaleValue.get() - width - settingsWidth).roundToInt()))
-            return field
+            return field.coerceIn(0, (mc.displayWidth / 2f / scaleValue.get() - width - settingsWidth).roundToInt().coerceAtLeast(0)).also {
+                if (it != field) {
+                    Mouse.setCursorPosition(Mouse.getX() + ((it - field) / scaleValue.get()).roundToInt(), Mouse.getY())
+                    field = it
+                }
+            }
         }
 
     var y = y
         get() {
-            if (!drag && !Mouse.isButtonDown(1)) return field
+            if (!drag && !Mouse.isButtonDown(0) && !Mouse.isButtonDown(1)) return field
 
             var yPos = height + 4
             var panelHeight = height + fade
@@ -57,8 +62,12 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
                     }
                 }
 
-            field = field.coerceIn(0, max(0, (mc.displayHeight / 2 / scaleValue.get() - panelHeight).roundToInt()))
-            return field
+            return field.coerceIn(0, (mc.displayHeight / 2f / scaleValue.get() - panelHeight).roundToInt().coerceAtLeast(0)).also {
+                if (it != field) {
+                    Mouse.setCursorPosition(Mouse.getX(), Mouse.getY() + ((field - it) / scaleValue.get()).roundToInt())
+                    field = it
+                }
+            }
         }
 
     var drag = false
@@ -68,7 +77,7 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
     var isVisible = true
     var fade = 0
         set(value) {
-            field = value.coerceIn(0, max(elementsHeight, 0))
+            field = value.coerceIn(0, elementsHeight.coerceAtLeast(0))
         }
     private var elementsHeight = 0
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
@@ -86,7 +86,7 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
             // How many elements should be hidden
             val hiddenCount = elements.size - maxElementsValue.get()
             // Don't overscroll
-            field = if (hiddenCount > 0) min(hiddenCount, value) else 0
+            field = if (hiddenCount > 0) min(hiddenCount, value.coerceAtLeast(0)) else 0
         }
 
     fun drawScreenAndClick(mouseX: Int, mouseY: Int, mouseButton: Int? = null): Boolean {

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/SlowlyStyle.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/SlowlyStyle.kt
@@ -14,8 +14,8 @@ import net.ccbluex.liquidbounce.ui.font.Fonts.font35
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlockName
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawBorderedRect
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawFilledCircle
+import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawRect
 import net.ccbluex.liquidbounce.value.*
-import net.minecraft.client.gui.Gui.drawRect
 import net.minecraft.util.StringUtils
 import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly


### PR DESCRIPTION
Fixed AutoPot:
* fixed IndexOutOfBounds exception because AutoPot was trying to get ItemStack from mc.thePlayer.inventory instead of mc.thePlayer.inventoryContainer, they have different indices.
* fixed wrong ground distance check that made AutoPot not do anything if set to 0 even while player was on the ground

Improved ClickGUI panels ([showcase](https://youtu.be/5on70f1xw3c)):
* cursor gets moved relatively to the panel if panel gets moved, to fit the screen
* cursor is "glued" to it while moving it
* fixed Slowly style rendering targets panel incorrectly
* fixed last-minute overscroll simplification making overscrolling possible

Fixed AltManager crashing LB when no alts were added (caused by my previous commit)...