### PR TITLE
AltManager fix & NoMove options

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/InventoryMove.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/InventoryMove.kt
@@ -23,23 +23,26 @@ object InventoryMove : Module() {
 
     private val undetectable = BoolValue("Undetectable", false)
     val aacAdditionProValue = BoolValue("AACAdditionPro", false)
+
     private val noMoveClicksValue = BoolValue("NoMoveClicks", false)
+    private val noClicksAirValue = object : BoolValue("NoClicksInAir", false) {
+        override fun isSupported() = noMoveClicksValue.get()
+    }
+    private val noClicksGroundValue = object : BoolValue("NoClicksOnGround", true) {
+        override fun isSupported() = noMoveClicksValue.get()
+    }
 
     private val affectedBindings = arrayOf(
-            mc.gameSettings.keyBindForward,
-            mc.gameSettings.keyBindBack,
-            mc.gameSettings.keyBindRight,
-            mc.gameSettings.keyBindLeft,
-            mc.gameSettings.keyBindJump,
-            mc.gameSettings.keyBindSprint
+        mc.gameSettings.keyBindForward,
+        mc.gameSettings.keyBindBack,
+        mc.gameSettings.keyBindRight,
+        mc.gameSettings.keyBindLeft,
+        mc.gameSettings.keyBindJump,
+        mc.gameSettings.keyBindSprint
     )
 
     @EventTarget
     fun onUpdate(event: UpdateEvent) {
-        tick()
-    }
-
-    fun tick() {
         if (mc.currentScreen !is GuiChat && mc.currentScreen !is GuiIngameMenu && (!undetectable.get() || mc.currentScreen !is GuiContainer)) {
             for (affectedBinding in affectedBindings) {
                 affectedBinding.pressed = GameSettings.isKeyDown(affectedBinding)
@@ -49,8 +52,10 @@ object InventoryMove : Module() {
 
     @EventTarget
     fun onClick(event: ClickWindowEvent) {
-        if (noMoveClicksValue.get() && isMoving)
-            event.cancelEvent()
+        if (noMoveClicksValue.get() && isMoving &&
+            if (mc.thePlayer.onGround) noClicksGroundValue.get()
+            else noClicksAirValue.get()
+        ) event.cancelEvent()
     }
 
     override fun onDisable() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.ModuleInfo
 import net.ccbluex.liquidbounce.features.module.modules.combat.AutoArmor
+import net.ccbluex.liquidbounce.features.module.modules.combat.AutoArmor.ARMOR_COMPARATOR
 import net.ccbluex.liquidbounce.injection.implementations.IMixinItemStack
 import net.ccbluex.liquidbounce.utils.ClientUtils.LOGGER
 import net.ccbluex.liquidbounce.utils.InventoryUtils
@@ -29,6 +30,7 @@ import net.minecraft.init.Blocks
 import net.minecraft.item.*
 import net.minecraft.network.play.client.C0DPacketCloseWindow
 import net.minecraft.network.play.client.C16PacketClientStatus
+import net.minecraft.network.play.client.C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT
 
 
 @ModuleInfo(
@@ -63,7 +65,15 @@ object InventoryCleaner : Module() {
     private val simulateInventory = object : BoolValue("SimulateInventory", true) {
         override fun isSupported() = !invOpenValue.get()
     }
-    private val noMoveValue = BoolValue("NoMove", false)
+
+    private val noMoveValue = BoolValue("NoMoveClicks", false)
+    private val noMoveAirValue = object : BoolValue("NoClicksInAir", false) {
+        override fun isSupported() = noMoveValue.get()
+    }
+    private val noMoveGroundValue = object : BoolValue("NoClicksOnGround", true) {
+        override fun isSupported() = noMoveValue.get()
+    }
+
     private val ignoreVehiclesValue = BoolValue("IgnoreVehicles", false)
     private val hotbarValue = BoolValue("Hotbar", true)
     private val randomSlotValue = BoolValue("RandomSlot", false)
@@ -109,7 +119,12 @@ object InventoryCleaner : Module() {
     fun onUpdate(event: UpdateEvent) {
         val thePlayer = mc.thePlayer ?: return
 
-        if (!InventoryUtils.CLICK_TIMER.hasTimePassed(delay) || mc.currentScreen !is GuiInventory && invOpenValue.get() || noMoveValue.get() && isMoving || thePlayer.openContainer != null && thePlayer.openContainer.windowId != 0 || (moduleManager[AutoArmor::class.java] as AutoArmor).isLocked) {
+        if (!InventoryUtils.CLICK_TIMER.hasTimePassed(delay)
+            || mc.currentScreen !is GuiInventory && invOpenValue.get()
+            || noMoveValue.get() && isMoving &&
+                    if (mc.thePlayer.onGround) noMoveGroundValue.get() else noMoveAirValue.get()
+            || thePlayer.openContainer != null && thePlayer.openContainer.windowId != 0
+            || (moduleManager[AutoArmor::class.java] as AutoArmor).isLocked) {
             return
         }
 
@@ -132,7 +147,7 @@ object InventoryCleaner : Module() {
             val openInventory = mc.currentScreen !is GuiInventory && simulateInventory.get()
 
             if (openInventory) {
-                mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+                mc.netHandler.addToSendQueue(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
             }
 
             mc.playerController.windowClick(thePlayer.openContainer.windowId, garbageItem, 1, 4, thePlayer)
@@ -163,7 +178,7 @@ object InventoryCleaner : Module() {
 
                 for (i in 0..8) {
                     if ((type(i) == "Sword" && item is ItemSword || type(i) == "Pickaxe" && item is ItemPickaxe
-                        || type(i) == "Axe" && item is ItemAxe) && findBetterItem(i, thePlayer.inventory.getStackInSlot(i)) == null)
+                                || type(i) == "Axe" && item is ItemAxe) && findBetterItem(i, thePlayer.inventory.getStackInSlot(i)) == null)
                         return true
                 }
 
@@ -192,7 +207,7 @@ object InventoryCleaner : Module() {
                         val armor = ArmorPiece(stack, slot)
 
                         if (armor.armorType != currArmor.armorType) false
-                        else AutoArmor.ARMOR_COMPARATOR.compare(currArmor, armor) <= 0
+                        else ARMOR_COMPARATOR.compare(currArmor, armor) <= 0
                     } else false
                 }
             } else if (itemStack.unlocalizedName == "item.compass") {
@@ -221,7 +236,7 @@ object InventoryCleaner : Module() {
             if (bestItem != index) {
                 val openInventory = mc.currentScreen !is GuiInventory && simulateInventory.get()
 
-                if (openInventory) mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+                if (openInventory) mc.netHandler.addToSendQueue(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
                 mc.playerController.windowClick(
                     0, if (bestItem < 9) bestItem + 36 else bestItem, index, 2, thePlayer

--- a/src/main/java/net/ccbluex/liquidbounce/file/configs/AccountsConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/configs/AccountsConfig.kt
@@ -20,7 +20,7 @@ import java.io.*
 
 class AccountsConfig(file: File) : FileConfig(file) {
 
-    val accounts: MutableList<MinecraftAccount> = ArrayList()
+    val accounts = mutableListOf<MinecraftAccount>()
 
     /**
      * Load config from file
@@ -85,7 +85,7 @@ class AccountsConfig(file: File) : FileConfig(file) {
         for (minecraftAccount in accounts)
             jsonArray.add(toJson(minecraftAccount))
 
-        file.writeText(PRETTY_GSON.toJson(accounts))
+        file.writeText(PRETTY_GSON.toJson(jsonArray))
     }
 
     /**


### PR DESCRIPTION
Fixed AltManager saving alts incorrectly, making them unloadable.

Added NoClicksOnGround and NoClicksInAir subvalues to NoMoveClicks values in InventoryMove and InventoryCleaner.
* you can legitimately move items in inventory while moving, when in air (falling, jumping, ...)
* anticheats that have checks for inventory clicks while moving (such as Matrix), can be bypassed by clicking while not onGround
* when you are jumping or using speed, you spend most of the time in air, so this is pretty useful