### PR TITLE
Config management fixes

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -114,10 +114,6 @@ object LiquidBounce {
             LOGGER.error("Failed to load scripts.", throwable)
         }
 
-        // Set defaults
-        HUD.setToDefault()
-        ClickGui.setToDefault()
-
         // Load configs
         loadAllConfigs()
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
@@ -127,9 +127,7 @@ class ScriptManagerCommand : Command("scriptmanager", "scripts") {
                         loadConfig(modulesConfig)
 
                         isStarting = false
-                        loadConfig(valuesConfig)
-
-                        loadConfig(clickGuiConfig)
+                        loadConfigs(valuesConfig, clickGuiConfig, hudConfig)
 
                         chat("Successfully reloaded all scripts.")
                     } catch (t: Throwable) {

--- a/src/main/java/net/ccbluex/liquidbounce/file/FileConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/FileConfig.kt
@@ -38,4 +38,9 @@ abstract class FileConfig(val file: File) {
      * @return config file exist
      */
     fun hasConfig() = file.exists() && file.length() > 0
+
+    /**
+     * Load defaults when config file doesn't exist.
+     */
+    open fun loadDefault() {}
 }

--- a/src/main/java/net/ccbluex/liquidbounce/file/FileManager.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/FileManager.kt
@@ -93,7 +93,8 @@ object FileManager : MinecraftInstance() {
     fun loadConfig(config: FileConfig) {
         if (!config.hasConfig()) {
             LOGGER.info("[FileManager] Skipped loading config: ${config.file.name}.")
-            saveConfig(config, true)
+            config.loadDefault()
+            saveConfig(config, false)
             return
         }
         try {

--- a/src/main/java/net/ccbluex/liquidbounce/file/configs/ClickGuiConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/configs/ClickGuiConfig.kt
@@ -17,6 +17,9 @@ import net.ccbluex.liquidbounce.utils.ClientUtils.LOGGER
 import java.io.*
 
 class ClickGuiConfig(file: File) : FileConfig(file) {
+
+    override fun loadDefault() = ClickGui.setDefault()
+
     /**
      * Load config from file
      *
@@ -24,6 +27,9 @@ class ClickGuiConfig(file: File) : FileConfig(file) {
      */
     @Throws(IOException::class)
     override fun loadConfig() {
+        // Regenerate panels and elements in case a script got loaded or removed.
+        loadDefault()
+
         val jsonElement = JsonParser().parse(file.bufferedReader())
         if (jsonElement is JsonNull) return
 

--- a/src/main/java/net/ccbluex/liquidbounce/file/configs/HudConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/configs/HudConfig.kt
@@ -19,6 +19,8 @@ import java.io.IOException
 
 class HudConfig(file: File) : FileConfig(file) {
 
+    override fun loadDefault() = HUD.setDefault()
+
     /**
      * Load config from file
      *
@@ -82,7 +84,7 @@ class HudConfig(file: File) : FileConfig(file) {
             }
         } catch (e: Exception) {
             ClientUtils.LOGGER.error("Error while loading custom hud config.", e)
-            HUD.setToDefault()
+            HUD.setDefault()
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
@@ -43,7 +43,7 @@ object ClickGui : GuiScreen() {
     var mouseX = 0
     var mouseY = 0
 
-    fun setToDefault() {
+    fun setDefault() {
         panels.clear()
 
         val width = 100

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/HUD.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/HUD.kt
@@ -38,7 +38,7 @@ object HUD : MinecraftInstance() {
           Cooldown::class.java)
 
   /** Create default HUD */
-  fun setToDefault() {
+  fun setDefault() {
     elements.clear()
 
     addElement(Text.defaultClient())

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/designer/EditorPanel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/designer/EditorPanel.kt
@@ -169,7 +169,7 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
 
         Fonts.font35.drawString("§lReset", x + 2f, y.toFloat() + height, Color.WHITE.rgb)
         if (Mouse.isButtonDown(0) && !mouseDown && mouseX in x..x + width && mouseY in y + height..y + height + 10)
-            HUD.setToDefault()
+            HUD.setDefault()
 
         height += 15
         realHeight += 15


### PR DESCRIPTION
**Fixed `hud.json` and `clickgui.json`** not getting saved during startup if they didn't exist.
* if their loading was skipped, default config was tried to be saved with parameter `ignoreStarting = true` (should have been `false`)

**Fixed `.scriptmanager reload`** not reloading `HudConfig` -> TabGui could have buttons for nonexistent script modules

**Added** `open fun FileConfig.loadDefault()`
* overwritten by `HudConfig` and `ClickGuiConfig`
* called when file doesn't exist to load defaults

**Fixed `ClickGUI`** being empty after its config got reloaded.
* [should be set to default when loaded or not existing](https://github.com/CCBlueX/LiquidBounce/commit/bceac6a38e839f2aa042c0f94334cd5d6b58017c#diff-7817183955636705e78d8e4af9ce8c0eca674b597001f3c4e0de3b6708d2476eL27)