### PR TITLE
Smart AutoBlock, value management & ModuleCommand improvements...

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.java
@@ -40,19 +40,19 @@ public class AutoArmor extends Module {
     public static final ArmorComparator ARMOR_COMPARATOR = new ArmorComparator();
     private final IntegerValue maxDelayValue = new IntegerValue("MaxDelay", 200, 0, 400) {
         @Override
-        protected void onChanged(final Integer oldValue, final Integer newValue) {
+        protected Integer onChange(final Integer oldValue, final Integer newValue) {
             final int minDelay = minDelayValue.get();
 
-            if (minDelay > newValue) set(minDelay);
+            return newValue > minDelay ? newValue : minDelay;
         }
     };
     private final IntegerValue minDelayValue = new IntegerValue("MinDelay", 100, 0, 400) {
 
         @Override
-        protected void onChanged(final Integer oldValue, final Integer newValue) {
+        protected Integer onChange(final Integer oldValue, final Integer newValue) {
             final int maxDelay = maxDelayValue.get();
 
-            if (maxDelay < newValue) set(maxDelay);
+            return newValue < maxDelay ? newValue : maxDelay;
         }
 
         @Override

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoClicker.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoClicker.kt
@@ -25,21 +25,12 @@ import kotlin.random.Random.Default.nextBoolean
 object AutoClicker : Module("AutoClicker", category = ModuleCategory.COMBAT) {
     private val maxCPSValue: IntegerValue = object : IntegerValue("MaxCPS", 8, 1, 20) {
 
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val minCPS = minCPSValue.get()
-            if (minCPS > newValue)
-                set(minCPS)
-        }
-
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minCPSValue.get())
     }
 
     private val minCPSValue: IntegerValue = object : IntegerValue("MinCPS", 5, 1, 20) {
 
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val maxCPS = maxCPSValue.get()
-            if (maxCPS < newValue)
-                set(maxCPS)
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxCPSValue.get())
 
         override fun isSupported() = !maxCPSValue.isMinimal()
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Trigger.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Trigger.kt
@@ -17,17 +17,17 @@ import net.minecraft.client.settings.KeyBinding
 object Trigger : Module("Trigger", category = ModuleCategory.COMBAT) {
 
     private val maxCPS: IntegerValue = object : IntegerValue("MaxCPS", 8, 1, 20) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minCPS.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = minCPS.get()
-            if (i > newValue) set(i)
             delay = randomClickDelay(minCPS.get(), get())
         }
     }
 
     private val minCPS: IntegerValue = object : IntegerValue("MinCPS", 5, 1, 20) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxCPS.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = maxCPS.get()
-            if (i < newValue) set(i)
             delay = randomClickDelay(get(), maxCPS.get())
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
@@ -19,32 +19,18 @@ import net.minecraft.network.play.client.C16PacketClientStatus
 object PingSpoof : Module("PingSpoof", ModuleCategory.EXPLOIT) {
 
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 1000, 0, 5000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val minDelayValue = minDelayValue.get()
-
-            if (minDelayValue > newValue) {
-                set(minDelayValue)
-            }
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 500, 0, 5000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val maxDelayValue = maxDelayValue.get()
-
-            if (maxDelayValue < newValue) {
-                set(maxDelayValue)
-            }
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
 
         override fun isSupported() = !maxDelayValue.isMinimal()
     }
 
     private val packetQueue = hashMapOf<Packet<*>, Long>()
 
-    override fun onDisable() {
-        packetQueue.clear()
-    }
+    override fun onDisable() = packetQueue.clear()
 
     @EventTarget
     fun onPacket(event: PacketEvent) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/fun/Derp.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/fun/Derp.kt
@@ -7,7 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
-import net.ccbluex.liquidbounce.utils.RotationUtils.getFixedSensitivityAngle
+import net.ccbluex.liquidbounce.utils.Rotation
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextFloat
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
@@ -22,22 +22,21 @@ object Derp : Module("Derp", ModuleCategory.FUN) {
 
     private var currentSpin = 0F
 
-    val rotation: FloatArray
+    val rotation: Rotation
         get() {
-            val derpRotations = floatArrayOf(mc.thePlayer.rotationYaw + nextFloat(-180f, 180f), nextFloat(-90f, 90f))
+            val rot = Rotation(mc.thePlayer.rotationYaw + nextFloat(-180f, 180f), nextFloat(-90f, 90f))
 
             if (headlessValue.get())
-                derpRotations[1] = 180F
+                rot.pitch = 180F
 
             if (spinnyValue.get()) {
-                derpRotations[0] = currentSpin + incrementValue.get()
-                currentSpin = derpRotations[0]
+                currentSpin += incrementValue.get()
+                rot.yaw = currentSpin
             }
 
-            derpRotations[0] = getFixedSensitivityAngle(derpRotations[0], mc.thePlayer.rotationYaw)
-            derpRotations[1] = getFixedSensitivityAngle(derpRotations[1], mc.thePlayer.rotationPitch)
+            rot.fixedSensitivity()
 
-            return derpRotations
+            return rot
         }
 
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AtAllProvider.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AtAllProvider.kt
@@ -20,17 +20,11 @@ import java.util.concurrent.LinkedBlockingQueue
 object AtAllProvider : Module("AtAllProvider", ModuleCategory.MISC) {
 
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 1000, 0, 20000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = minDelayValue.get()
-            if (i > newValue) set(i)
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 500, 0, 20000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = maxDelayValue.get()
-            if (i < newValue) set(i)
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
 
         override fun isSupported() = !maxDelayValue.isMinimal()
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AutoAccount.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AutoAccount.kt
@@ -30,14 +30,21 @@ object AutoAccount : Module("AutoAccount", ModuleCategory.MISC) {
 
     // Gamster requires 8 chars+
     private val passwordValue = object : TextValue("Password", "axolotlaxolotl") {
-        override fun changeValue(newValue: String) {
-            when {
-                newValue.equals("reset", true) -> {
-                    super.changeValue("axolotlaxolotl")
-                    displayChatMessage("§7[§a§lAutoAccount§7] §3Password reset to its default value.")
+        override fun onChange(oldValue: String, newValue: String): String {
+            return when {
+                " " in newValue -> {
+                    displayChatMessage("§7[§a§lAutoAccount§7] §cPassword cannot contain a space!")
+                    oldValue
                 }
-                newValue.length < 4 -> displayChatMessage("§7[§a§lAutoAccount§7] §cPassword must be longer than 4 characters!")
-                else -> super.changeValue(newValue)
+                newValue.equals("reset", true) -> {
+                    displayChatMessage("§7[§a§lAutoAccount§7] §3Password reset to its default value.")
+                    "axolotlaxolotl"
+                }
+                newValue.length < 4 -> {
+                    displayChatMessage("§7[§a§lAutoAccount§7] §cPassword must be longer than 4 characters!")
+                    oldValue
+                }
+                else -> super.onChange(oldValue, newValue)
             }
         }
 
@@ -70,10 +77,13 @@ object AutoAccount : Module("AutoAccount", ModuleCategory.MISC) {
     private val accountModeValue = object : ListValue("AccountMode", arrayOf("RandomName", "RandomAlt"), "RandomName") {
         override fun isSupported() = reconnectDelayValue.isSupported() || startupValue.isActive()
 
-        override fun changeValue(newValue: String) {
-            if (newValue == "RandomAlt" && accountsConfig.accounts.filterIsInstance<CrackedAccount>().size <= 1)
+        override fun onChange(oldValue: String, newValue: String): String {
+            if (newValue == "RandomAlt" && accountsConfig.accounts.filterIsInstance<CrackedAccount>().size <= 1) {
                 displayChatMessage("§7[§a§lAutoAccount§7] §cAdd more cracked accounts in AltManager to use RandomAlt option!")
-            else super.changeValue(newValue)
+                return oldValue
+            }
+
+            return super.onChange(oldValue, newValue)
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/Spammer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/Spammer.kt
@@ -21,22 +21,18 @@ import net.ccbluex.liquidbounce.value.TextValue
 
 object Spammer : Module("Spammer", ModuleCategory.MISC) {
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 1000, 0, 5000) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val minDelay = minDelayValue.get()
-            if (minDelay > newValue) {
-                set(minDelay)
-                delay = randomDelay(minDelayValue.get(), get())
-            }
+            delay = randomDelay(minDelayValue.get(), get())
         }
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 500, 0, 5000) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val maxDelay = maxDelayValue.get()
-            if (maxDelay < newValue) {
-                set(maxDelay)
-                delay = randomDelay(get(), maxDelayValue.get())
-            }
+            delay = randomDelay(get(), maxDelayValue.get())
         }
 
         override fun isSupported() = !maxDelayValue.isMinimal()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Speed.kt
@@ -75,9 +75,11 @@ object Speed : Module("Speed", ModuleCategory.MOVEMENT) {
     )
 
     val modeValue: ListValue = object : ListValue("Mode", modes, "NCPBHop") {
-        override fun onChange(oldValue: String, newValue: String) {
+        override fun onChange(oldValue: String, newValue: String): String {
             if (state)
                 onDisable()
+
+            return super.onChange(oldValue, newValue)
         }
 
         override fun onChanged(oldValue: String, newValue: String) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
@@ -36,17 +36,11 @@ object AntiFireBall : Module("AntiFireBall", ModuleCategory.PLAYER) {
 
     private val maxTurnSpeedValue: FloatValue =
         object : FloatValue("MaxTurnSpeed", 120f, 0f, 180f) {
-            override fun onChanged(oldValue: Float, newValue: Float) {
-                val i = minTurnSpeedValue.get()
-                if (i > newValue) set(i)
-            }
+            override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtLeast(minTurnSpeedValue.get())
         }
     private val minTurnSpeedValue: FloatValue =
         object : FloatValue("MinTurnSpeed", 80f, 0f, 180f) {
-            override fun onChanged(oldValue: Float, newValue: Float) {
-                val i = maxTurnSpeedValue.get()
-                if (i < newValue) set(i)
-            }
+            override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtMost(maxTurnSpeedValue.get())
 
             override fun isSupported() = !maxTurnSpeedValue.isMinimal()
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
@@ -39,17 +39,11 @@ object InventoryCleaner : Module("InventoryCleaner", ModuleCategory.PLAYER) {
      */
 
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 600, 0, 1000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val minCPS = minDelayValue.get()
-            if (minCPS > newValue) set(minCPS)
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 400, 0, 1000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val maxDelay = maxDelayValue.get()
-            if (maxDelay < newValue) set(maxDelay)
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
 
         override fun isSupported() = !maxDelayValue.isMinimal()
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -32,23 +32,18 @@ object ChestStealer : Module("ChestStealer", ModuleCategory.WORLD) {
      */
 
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 200, 0, 400) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = minDelayValue.get()
-            if (i > newValue)
-                set(i)
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
 
-            nextDelay = randomDelay(minDelayValue.get(), get())
+        override fun onChanged(oldValue: Int, newValue: Int) {
+            nextDelay = randomDelay(minDelayValue.get(), newValue)
         }
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 150, 0, 400) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = maxDelayValue.get()
-
-            if (i < newValue)
-                set(i)
-
-            nextDelay = randomDelay(get(), maxDelayValue.get())
+            nextDelay = randomDelay(newValue, maxDelayValue.get())
         }
 
         override fun isSupported() = !maxDelayValue.isMinimal()
@@ -61,20 +56,20 @@ object ChestStealer : Module("ChestStealer", ModuleCategory.WORLD) {
     private val autoCloseValue = BoolValue("AutoClose", true)
 
     private val autoCloseMaxDelayValue: IntegerValue = object : IntegerValue("AutoCloseMaxDelay", 0, 0, 400) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(autoCloseMinDelayValue.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = autoCloseMinDelayValue.get()
-            if (i > newValue) set(i)
-            nextCloseDelay = randomDelay(autoCloseMinDelayValue.get(), get())
+            nextCloseDelay = randomDelay(autoCloseMinDelayValue.get(), newValue)
         }
 
         override fun isSupported() = autoCloseValue.get()
     }
 
     private val autoCloseMinDelayValue: IntegerValue = object : IntegerValue("AutoCloseMinDelay", 0, 0, 400) {
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(autoCloseMaxDelayValue.get())
+
         override fun onChanged(oldValue: Int, newValue: Int) {
-            val i = autoCloseMaxDelayValue.get()
-            if (i < newValue) set(i)
-            nextCloseDelay = randomDelay(get(), autoCloseMaxDelayValue.get())
+            nextCloseDelay = randomDelay(newValue, autoCloseMaxDelayValue.get())
         }
 
         override fun isSupported() = autoCloseValue.get() && !autoCloseMaxDelayValue.isMinimal()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -68,35 +68,27 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
     private val extraClicks = BoolValue("DoExtraClicks", false)
 
     private val extraClickMaxCPS: IntegerValue = object : IntegerValue("ExtraClickMaxCPS", 7, 0, 20) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            set(newValue.coerceAtLeast(extraClickMinCPS.get()))
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(extraClickMinCPS.get())
 
         override fun isSupported() = extraClicks.isActive()
 
     }
 
     private val extraClickMinCPS: IntegerValue = object : IntegerValue("ExtraClickMinCPS", 3, 0, 20) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            set(newValue.coerceAtMost(extraClickMaxCPS.get()))
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(extraClickMaxCPS.get())
 
         override fun isSupported() = extraClicks.isActive() && !extraClickMaxCPS.isMinimal()
     }
 
     // Delay
     private val maxDelayValue: IntegerValue = object : IntegerValue("MaxDelay", 0, 0, 1000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            set(newValue.coerceAtLeast(minDelayValue.get()))
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelayValue.get())
 
         override fun isSupported() = placeDelay.get()
     }
 
     private val minDelayValue: IntegerValue = object : IntegerValue("MinDelay", 0, 0, 1000) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            set(newValue.coerceAtMost(maxDelayValue.get()))
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelayValue.get())
 
         override fun isSupported() = placeDelay.get() && !maxDelayValue.isMinimal()
     }
@@ -130,9 +122,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
     private val silentRotationValue = BoolValue("SilentRotation", true)
     private val keepRotationValue = BoolValue("KeepRotation", true)
     private val keepTicksValue = object : IntegerValue("KeepTicks", 1, 1, 20) {
-        override fun onChanged(oldValue: Int, newValue: Int) {
-            set(newValue.coerceAtLeast(minimum))
-        }
+        override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minimum)
     }
 
     // Search options
@@ -141,14 +131,10 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
 
     // Turn Speed
     private val maxTurnSpeedValue: FloatValue = object : FloatValue("MaxTurnSpeed", 180f, 1f, 180f) {
-        override fun onChanged(oldValue: Float, newValue: Float) {
-            set(newValue.coerceAtLeast(minTurnSpeedValue.get()))
-        }
+        override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtLeast(minTurnSpeedValue.get())
     }
     private val minTurnSpeedValue: FloatValue = object : FloatValue("MinTurnSpeed", 180f, 1f, 180f) {
-        override fun onChanged(oldValue: Float, newValue: Float) {
-            set(newValue.coerceAtMost(maxTurnSpeedValue.get()))
-        }
+        override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtMost(maxTurnSpeedValue.get())
 
         override fun isSupported() = !maxTurnSpeedValue.isMinimal()
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/entity/MixinEntityPlayerSP.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/entity/MixinEntityPlayerSP.java
@@ -173,9 +173,9 @@ public abstract class MixinEntityPlayerSP extends MixinAbstractClientPlayer {
 
             final Derp derp = Derp.INSTANCE;
             if (derp.getState()) {
-                float[] rot = derp.getRotation();
-                yaw = rot[0];
-                pitch = rot[1];
+                Rotation rot = derp.getRotation();
+                yaw = rot.getYaw();
+                pitch = rot.getPitch();
             }
 
             if (targetRotation != null) {


### PR DESCRIPTION
Improved `KillAura`:
* Smart AutoBlock:
* `ForceBlockWhenStill`, `CheckEnemyWeapon`, `BlockRange`, `MaxOwnHurtTime`, `MaxOpponentDirectionDiff`, `MaxOpponentSwingProgress`
* improved dynamic values (simulate cooldown hides cps and hurttime)

Improved `Value`:
* `onChange` now requires value type returned
* returned value will specify, what to actually set the `Value` to
* if returned value is same as current value, `Value.set()` returns `false` and `onChanged()`, `onUpdate()`, `saveConfig` are skipped
* rewritten all `onChanged` to new `onChange`

Improved `ModuleCommand`:
* value types except `BoolValue` check what `Value.set()` returns
* if it returns `false`, chat output is different, instead of setting the value to the current value, it prints "`newValue` isn't a valid value for `value.name`" or "`newValue` is already the value of `value.name`"
* use case: if you try to set `MinCPS` above `MaxCPS`, `value.set()` will return `false`, values config won't get saved, chat response will be "isn't a valid value"
* fixed LB accepting syntax like ".killaura mincps 20 xd lmao rofl kys", ".killaura simulatecooldown ok cool what now"

Simplified `Derp`:
* simplified rotation getter

Simplified `RotationUtils`:
* added optional argument `fromEntity` to `toRotation()`, useful when calculating opponent's angle difference from you for example
* simplified `getCenter()`
* simplified `getRotationDifference()` by implementing optional argument
* simplified `getFixedAngleDelta()`, `getFixedSensitivityAngle()`