### PR TITLE
Modules with spaces, HUD editor, ClickGUI improvements, ...

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/BindCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/BindCommand.kt
@@ -30,8 +30,8 @@ class BindCommand : Command("bind") {
             module.keyBind = key
 
             // Response to user
-            chat("Bound module §a§l${module.name}§3 to key §a§l${Keyboard.getKeyName(key)}§3.")
-            addNotification(Notification("Bound ${module.name} to ${Keyboard.getKeyName(key)}"))
+            chat("Bound module §a§l${module.getName()}§3 to key §a§l${Keyboard.getKeyName(key)}§3.")
+            addNotification(Notification("Bound ${module.getName()} to ${Keyboard.getKeyName(key)}"))
             playEdit()
             return
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/BindsCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/BindsCommand.kt
@@ -27,7 +27,7 @@ class BindsCommand : Command("binds") {
 
         chat("§c§lBinds")
         moduleManager.modules.filter { it.keyBind != Keyboard.KEY_NONE }.forEach {
-            displayChatMessage("§6> §c${it.name}: §a§l${Keyboard.getKeyName(it.keyBind)}")
+            displayChatMessage("§6> §c${it.getName()}: §a§l${Keyboard.getKeyName(it.keyBind)}")
         }
         chatSyntax("binds clear")
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HideCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HideCommand.kt
@@ -20,7 +20,7 @@ class HideCommand : Command("hide") {
                 args[1].equals("list", true) -> {
                     chat("§c§lHidden")
                     moduleManager.modules.filter { !it.inArray }.forEach {
-                        displayChatMessage("§6> §c${it.name}")
+                        displayChatMessage("§6> §c${it.getName()}")
                     }
                     return
                 }
@@ -54,7 +54,7 @@ class HideCommand : Command("hide") {
                     module.inArray = !module.inArray
 
                     // Response to user
-                    chat("Module §a§l${module.name}§3 is now §a§l${if (module.inArray) "visible" else "invisible"}§3 on the array list.")
+                    chat("Module §a§l${module.getName()}§3 is now §a§l${if (module.inArray) "visible" else "invisible"}§3 on the array list.")
                     playEdit()
                     return
                 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ToggleCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ToggleCommand.kt
@@ -34,7 +34,7 @@ class ToggleCommand : Command("toggle", "t") {
                 module.toggle()
             }
 
-            chat("${if (module.state) "Enabled" else "Disabled"} module §8${module.name}§3.")
+            chat("${if (module.state) "Enabled" else "Disabled"} module §8${module.getName()}§3.")
             return
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/Module.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/Module.kt
@@ -26,7 +26,7 @@ open class Module @JvmOverloads constructor(
 
     val name: String,
     val category: ModuleCategory,
-    val description: String = translation("module.${name.toLowerCamelCase()}.description"),
+    private val forcedDescription: String?,
     keyBind: Int = Keyboard.KEY_NONE,
     val defaultInArray: Boolean = true, // Used in HideCommand to reset modules visibility.
     private val canEnable: Boolean = true,
@@ -44,12 +44,16 @@ open class Module @JvmOverloads constructor(
 
             saveConfig(modulesConfig)
         }
+
     var inArray = defaultInArray
         set(value) {
             field = value
 
             saveConfig(modulesConfig)
         }
+
+    val description: String
+        get() = forcedDescription ?: translation("module.${name.toLowerCamelCase()}.description")
 
     var slideStep = 0F
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/Module.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/Module.kt
@@ -26,7 +26,7 @@ open class Module @JvmOverloads constructor(
 
     val name: String,
     val category: ModuleCategory,
-    private val forcedDescription: String?,
+    private val forcedDescription: String? = null,
     keyBind: Int = Keyboard.KEY_NONE,
     val defaultInArray: Boolean = true, // Used in HideCommand to reset modules visibility.
     private val canEnable: Boolean = true,

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/ModuleCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/ModuleCommand.kt
@@ -52,7 +52,7 @@ class ModuleCommand(val module: Module, val values: List<Value<*>> = module.valu
                 val newValue = !value.get()
                 value.set(newValue)
 
-                chat("§7${module.name} §8${args[1]}§7 was toggled ${if (newValue) "§8on§7" else "§8off§7" + "."}")
+                chat("§7${module.getName()} §8${args[1]}§7 was toggled ${if (newValue) "§8on§7" else "§8off§7" + "."}")
                 playEdit()
             }
 
@@ -93,7 +93,7 @@ class ModuleCommand(val module: Module, val values: List<Value<*>> = module.valu
                                 return
                             }
 
-                            chat("§7${module.name} §8${args[1].lowercase()}§7 was set to §8${getBlockName(id)}§7.")
+                            chat("§7${module.getName()} §8${args[1].lowercase()}§7 was set to §8${getBlockName(id)}§7.")
                             playEdit()
 
                             return
@@ -122,7 +122,7 @@ class ModuleCommand(val module: Module, val values: List<Value<*>> = module.valu
                         return
                     }
 
-                    chat("§7${module.name} §8${args[1]}§7 was set to §8${value.get()}§7.")
+                    chat("§7${module.getName()} §8${args[1]}§7 was set to §8${value.get()}§7.")
                     playEdit()
                 } catch (e: NumberFormatException) {
                     chatInvalid(args[2], value, "cannot be converted to a number for")

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TNTBlock.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TNTBlock.kt
@@ -16,7 +16,7 @@ import net.minecraft.client.settings.GameSettings
 import net.minecraft.entity.item.EntityTNTPrimed
 import net.minecraft.item.ItemSword
 
-object TNTBlock : Module("TNTBlock", category = ModuleCategory.COMBAT) {
+object TNTBlock : Module("TNTBlock", category = ModuleCategory.COMBAT, spacedName = "TNT Block") {
     private val fuseValue = IntegerValue("Fuse", 10, 0, 80)
     private val rangeValue = FloatValue("Range", 9F, 1F, 20F)
     private val autoSwordValue = BoolValue("AutoSword", true)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
@@ -26,7 +26,7 @@ import net.minecraft.entity.projectile.EntityFireball
 import net.minecraft.network.play.client.C02PacketUseEntity
 import net.minecraft.network.play.client.C0APacketAnimation
 
-object AntiFireBall : Module("AntiFireBall", ModuleCategory.PLAYER) {
+object AntiFireBall : Module("AntiFireBall", ModuleCategory.PLAYER, spacedName = "Anti FireBall") {
     private val timer = MSTimer()
 
     private val rangeValue = FloatValue("Range", 4.5f, 3f, 8f)
@@ -34,16 +34,14 @@ object AntiFireBall : Module("AntiFireBall", ModuleCategory.PLAYER) {
     private val swingValue = ListValue("Swing", arrayOf("Normal", "Packet", "None"), "Normal")
     private val rotationsValue = BoolValue("Rotations", true)
 
-    private val maxTurnSpeedValue: FloatValue =
-        object : FloatValue("MaxTurnSpeed", 120f, 0f, 180f) {
-            override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtLeast(minTurnSpeedValue.get())
-        }
-    private val minTurnSpeedValue: FloatValue =
-        object : FloatValue("MinTurnSpeed", 80f, 0f, 180f) {
-            override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtMost(maxTurnSpeedValue.get())
+    private val maxTurnSpeedValue: FloatValue = object : FloatValue("MaxTurnSpeed", 120f, 0f, 180f) {
+        override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtLeast(minTurnSpeedValue.get())
+    }
+    private val minTurnSpeedValue: FloatValue = object : FloatValue("MinTurnSpeed", 80f, 0f, 180f) {
+        override fun onChange(oldValue: Float, newValue: Float) = newValue.coerceAtMost(maxTurnSpeedValue.get())
 
-            override fun isSupported() = !maxTurnSpeedValue.isMinimal()
-        }
+        override fun isSupported() = !maxTurnSpeedValue.isMinimal()
+    }
 
     @EventTarget
     private fun onUpdate(event: UpdateEvent) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/ClickGUI.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/ClickGUI.kt
@@ -33,9 +33,12 @@ object ClickGUI : Module("ClickGUI", ModuleCategory.RENDER, keyBind = Keyboard.K
     val maxElementsValue = IntegerValue("MaxElements", 15, 1, 30)
     val fadeSpeedValue = FloatValue("FadeSpeed", 1f, 0.5f, 2f)
     val scrollsValue = BoolValue("Scrolls", false)
+    val spacedModulesValue = BoolValue("SpacedModules", true)
+    val panelsBorderValue = BoolValue("PanelsNotBeyondBorder", true)
+
 
     private val colorRainbow = object : BoolValue("Rainbow", false) {
-        override fun isSupported() = styleValue.get() != "Slowly"
+        override fun isSupported() = styleValue.get() !in arrayOf("Slowly", "Black")
     }
     private val colorRedValue = object : IntegerValue("R", 0, 0, 255) {
         override fun isSupported() = colorRainbow.isSupported() && !colorRainbow.get()
@@ -59,11 +62,12 @@ object ClickGUI : Module("ClickGUI", ModuleCategory.RENDER, keyBind = Keyboard.K
     }
 
     private fun updateStyle() {
-        when (styleValue.get()) {
-            "LiquidBounce" -> clickGui.style = LiquidBounceStyle
-            "Null" -> clickGui.style = NullStyle
-            "Slowly" -> clickGui.style = SlowlyStyle
-            "Black" -> clickGui.style = BlackStyle
+        clickGui.style = when (styleValue.get()) {
+            "LiquidBounce" -> LiquidBounceStyle
+            "Null" -> NullStyle
+            "Slowly" -> SlowlyStyle
+            "Black" -> BlackStyle
+            else -> return
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/file/configs/ClickGuiConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/configs/ClickGuiConfig.kt
@@ -51,7 +51,7 @@ class ClickGuiConfig(file: File) : FileConfig(file) {
                         element.showSettings = elementObject["Settings"].asBoolean
                     } catch (e: Exception) {
                         LOGGER.error(
-                            "Error while loading clickgui module element with the name '" + element.module.name + "' (Panel Name: " + panel.name + ").", e
+                            "Error while loading clickgui module element with the name '" + element.module.getName() + "' (Panel Name: " + panel.name + ").", e
                         )
                     }
                 }

--- a/src/main/java/net/ccbluex/liquidbounce/script/api/ScriptModule.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/script/api/ScriptModule.kt
@@ -120,7 +120,7 @@ class ScriptModule(name: String, description: String, category: ModuleCategory, 
         try {
             events[eventName]?.call(moduleObject, payload)
         } catch (throwable: Throwable) {
-            LOGGER.error("[ScriptAPI] Exception in module '$name'!", throwable)
+            LOGGER.error("[ScriptAPI] Exception in module '${getName()}'!", throwable)
         }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/ClickGui.kt
@@ -17,6 +17,7 @@ import net.ccbluex.liquidbounce.ui.client.GuiClientSettings
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.ButtonElement
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.ModuleElement
 import net.ccbluex.liquidbounce.ui.client.clickgui.style.Style
+import net.ccbluex.liquidbounce.ui.client.clickgui.style.styles.BlackStyle
 import net.ccbluex.liquidbounce.ui.client.clickgui.style.styles.LiquidBounceStyle
 import net.ccbluex.liquidbounce.ui.client.clickgui.style.styles.SlowlyStyle
 import net.ccbluex.liquidbounce.ui.client.hud.designer.GuiHudDesigner
@@ -231,7 +232,7 @@ object ClickGui : GuiScreen() {
     }
 
     override fun updateScreen() {
-        if (style is SlowlyStyle) {
+        if (style is SlowlyStyle || style is BlackStyle) {
             for (panel in panels) {
                 for (element in panel.elements) {
                     if (element is ButtonElement)

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/Panel.kt
@@ -8,13 +8,13 @@ package net.ccbluex.liquidbounce.ui.client.clickgui
 import net.ccbluex.liquidbounce.LiquidBounce.clickGui
 import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.fadeSpeedValue
 import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.maxElementsValue
+import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.panelsBorderValue
 import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.scaleValue
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.Element
 import net.ccbluex.liquidbounce.ui.client.clickgui.elements.ModuleElement
 import net.ccbluex.liquidbounce.utils.MinecraftInstance
 import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
-import org.lwjgl.input.Mouse
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -28,25 +28,26 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
     var y2 = 0
 
     var x = x
-        get() {
+        set(value) {
             // Don't rearrange panels when not interacting with ClickGUI.
-            if (!drag && !Mouse.isButtonDown(0) && !Mouse.isButtonDown(1)) return field
+            if (mc.currentScreen !is ClickGui || !panelsBorderValue.get()) {
+                field = value
+                return
+            }
 
             val settingsWidth =
                 if (open) elements.filterIsInstance<ModuleElement>().maxOfOrNull { if (it.showSettings) it.settingsWidth else 0 } ?: 0
                 else 0
 
-            return field.coerceIn(0, (mc.displayWidth / 2f / scaleValue.get() - width - settingsWidth).roundToInt().coerceAtLeast(0)).also {
-                if (it != field) {
-                    Mouse.setCursorPosition(Mouse.getX() + ((it - field) / scaleValue.get()).roundToInt(), Mouse.getY())
-                    field = it
-                }
-            }
+            field = value.coerceIn(0, (mc.displayWidth / 2f / scaleValue.get() - width - settingsWidth).roundToInt().coerceAtLeast(0))
         }
 
     var y = y
-        get() {
-            if (!drag && !Mouse.isButtonDown(0) && !Mouse.isButtonDown(1)) return field
+        set(value) {
+            if (mc.currentScreen !is ClickGui || !panelsBorderValue.get()) {
+                field = value
+                return
+            }
 
             var yPos = height + 4
             var panelHeight = height + fade
@@ -62,12 +63,7 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
                     }
                 }
 
-            return field.coerceIn(0, (mc.displayHeight / 2f / scaleValue.get() - panelHeight).roundToInt().coerceAtLeast(0)).also {
-                if (it != field) {
-                    Mouse.setCursorPosition(Mouse.getX(), Mouse.getY() + ((field - it) / scaleValue.get()).roundToInt())
-                    field = it
-                }
-            }
+            field = value.coerceIn(0, (mc.displayHeight / 2f / scaleValue.get() - panelHeight).roundToInt().coerceAtLeast(0))
         }
 
     var drag = false
@@ -79,6 +75,7 @@ abstract class Panel(val name: String, x: Int, y: Int, val width: Int, val heigh
         set(value) {
             field = value.coerceIn(0, elementsHeight.coerceAtLeast(0))
         }
+
     private var elementsHeight = 0
 
     private var scroll = 0

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ButtonElement.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ButtonElement.kt
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.relauncher.SideOnly
 import java.awt.Color
 
 @SideOnly(Side.CLIENT)
-abstract class ButtonElement(val displayName: String) : Element() {
+abstract class ButtonElement(open val displayName: String) : Element() {
     open val color: Int
         get() = Color.WHITE.rgb
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ModuleElement.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ModuleElement.kt
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
 
 @SideOnly(Side.CLIENT)
-class ModuleElement(val module: Module) : ButtonElement(module.getName(spacedModulesValue.get())) {
+class ModuleElement(val module: Module) : ButtonElement(module.name) {
     override val displayName: String
         get() = module.getName(spacedModulesValue.get())
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ModuleElement.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/elements/ModuleElement.kt
@@ -7,12 +7,15 @@ package net.ccbluex.liquidbounce.ui.client.clickgui.elements
 
 import net.ccbluex.liquidbounce.LiquidBounce.clickGui
 import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.spacedModulesValue
 import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
-import org.lwjgl.input.Mouse
 
 @SideOnly(Side.CLIENT)
-class ModuleElement(val module: Module) : ButtonElement(module.name) {
+class ModuleElement(val module: Module) : ButtonElement(module.getName(spacedModulesValue.get())) {
+    override val displayName: String
+        get() = module.getName(spacedModulesValue.get())
+
     var showSettings = false
     var settingsWidth = 0
         set(value) {
@@ -21,7 +24,6 @@ class ModuleElement(val module: Module) : ButtonElement(module.name) {
 
     var settingsHeight = 0
 
-    private var wasPressed = false
     var slowlyFade = 0
         set(value) {
             field = value.coerceIn(0, 255)
@@ -47,11 +49,5 @@ class ModuleElement(val module: Module) : ButtonElement(module.name) {
         }
 
         return true
-    }
-
-    fun notPressed() = !wasPressed
-
-    fun updatePressed() {
-        wasPressed = Mouse.isButtonDown(0)
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/BlackStyle.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/BlackStyle.kt
@@ -231,6 +231,7 @@ object BlackStyle : Style() {
                                 // Cycle to next font when left-clicked, previous when right-clicked.
                                 if (mouseButton == 0) value.next()
                                 else value.previous()
+                                clickSound()
                                 return true
                             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/LiquidBounceStyle.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/LiquidBounceStyle.kt
@@ -221,6 +221,7 @@ object LiquidBounceStyle : Style() {
                                 // Cycle to next font when left-clicked, previous when right-clicked.
                                 if (mouseButton == 0) value.next()
                                 else value.previous()
+                                clickSound()
                                 return true
                             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/NullStyle.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/NullStyle.kt
@@ -211,6 +211,7 @@ object NullStyle : Style() {
                                 // Cycle to next font when left-clicked, previous when right-clicked.
                                 if (mouseButton == 0) value.next()
                                 else value.previous()
+                                clickSound()
                                 return true
                             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/SlowlyStyle.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/clickgui/style/styles/SlowlyStyle.kt
@@ -231,6 +231,7 @@ object SlowlyStyle : Style() {
                                 // Cycle to next font when left-clicked, previous when right-clicked.
                                 if (mouseButton == 0) value.next()
                                 else value.previous()
+                                clickSound()
                                 return true
                             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/designer/EditorPanel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/designer/EditorPanel.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.ui.client.hud.designer
 
 import net.ccbluex.liquidbounce.features.module.modules.render.ClickGUI.guiColor
+import net.ccbluex.liquidbounce.ui.client.clickgui.ClickGui
 import net.ccbluex.liquidbounce.ui.client.hud.HUD
 import net.ccbluex.liquidbounce.ui.client.hud.HUD.ELEMENTS
 import net.ccbluex.liquidbounce.ui.client.hud.element.Element
@@ -271,6 +272,8 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
 
         // Values
         for (value in element.values) {
+            if (!value.isSupported()) continue
+
             when (value) {
                 is BoolValue -> {
                     // Title
@@ -281,9 +284,11 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
                         width = stringWidth + 8
 
                     // Toggle value
-                    if (Mouse.isButtonDown(0) && !mouseDown && mouseX in x..x + width &&
-                            mouseY in y + height..y + height + 10)
+                    if (Mouse.isButtonDown(0) && !mouseDown && mouseX in x..x + width && mouseY in y + height..y + height + 10) {
                         value.toggle()
+                        element.updateElement()
+                        ClickGui.style.clickSound()
+                    }
 
                     // Change pos
                     height += 10
@@ -317,6 +322,7 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
                         val curr = MathHelper.clamp_float((mouseX - x - 8F) / (prevWidth - 18F), 0F, 1F)
 
                         value.set(min + (max - min) * curr)
+                        element.updateElement()
                     }
 
                     // Change pos
@@ -351,6 +357,7 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
                         val curr = MathHelper.clamp_float((mouseX - x - 8F) / (prevWidth - 18F), 0F, 1F)
 
                         value.set((min + (max - min) * curr).toInt())
+                        element.updateElement()
                     }
 
                     // Change pos
@@ -376,8 +383,11 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
                             width = stringWidth + 8
 
                         // Select value
-                        if (Mouse.isButtonDown(0) && !mouseDown && mouseX in x..x + width&& mouseY in y + height..y + height + 10)
+                        if (Mouse.isButtonDown(0) && !mouseDown && mouseX in x..x + width&& mouseY in y + height..y + height + 10) {
                             value.set(s)
+                            element.updateElement()
+                            ClickGui.style.clickSound()
+                        }
 
                         // Change pos
                         height += 10
@@ -400,6 +410,8 @@ class EditorPanel(private val hudDesigner: GuiHudDesigner, var x: Int, var y: In
                     ) {
                         if (Mouse.isButtonDown(0)) value.next()
                         else value.previous()
+                        element.updateElement()
+                        ClickGui.style.clickSound()
                     }
 
                     height += 10

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/TabGUI.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/TabGUI.kt
@@ -30,38 +30,80 @@ import java.awt.Color
 @ElementInfo(name = "TabGUI")
 class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
 
-    private val rainbowX = FloatValue("Rainbow-X", -1000F, -2000F, 2000F)
-    private val rainbowY = FloatValue("Rainbow-Y", -1000F, -2000F, 2000F)
-    private val redValue = IntegerValue("Rectangle Red", 0, 0, 255)
-    private val greenValue = IntegerValue("Rectangle Green", 148, 0, 255)
-    private val blueValue = IntegerValue("Rectangle Blue", 255, 0, 255)
-    private val alphaValue = IntegerValue("Rectangle Alpha", 140, 0, 255)
-    private val rectangleRainbow = BoolValue("Rectangle Rainbow", false)
-    private val backgroundRedValue = IntegerValue("Background Red", 0, 0, 255)
-    private val backgroundGreenValue = IntegerValue("Background Green", 0, 0, 255)
-    private val backgroundBlueValue = IntegerValue("Background Blue", 0, 0, 255)
-    private val backgroundAlphaValue = IntegerValue("Background Alpha", 150, 0, 255)
-    private val borderValue = BoolValue("Border", true)
-    private val borderStrength = FloatValue("Border Strength", 2F, 1F, 5F)
-    private val borderRedValue = IntegerValue("Border Red", 0, 0, 255)
-    private val borderGreenValue = IntegerValue("Border Green", 0, 0, 255)
-    private val borderBlueValue = IntegerValue("Border Blue", 0, 0, 255)
-    private val borderAlphaValue = IntegerValue("Border Alpha", 150, 0, 255)
-    private val borderRainbow = BoolValue("Border Rainbow", false)
-    private val arrowsValue = BoolValue("Arrows", true)
-    private val fontValue = FontValue("Font", Fonts.font35)
-    private val textShadow = BoolValue("TextShadow", false)
-    private val textFade = BoolValue("TextFade", true)
-    private val textPositionY = FloatValue("TextPosition-Y", 2F, 0F, 5F)
-    private val width = FloatValue("Width", 60F, 55F, 100F)
-    private val tabHeight = FloatValue("TabHeight", 12F, 10F, 15F)
-    private val upperCaseValue = BoolValue("UpperCase", false)
+    private val rectRainbow by BoolValue("Rectangle Rainbow", false)
+    private val rectRed by object : IntegerValue("Rectangle Red", 0, 0, 255) {
+        override fun isSupported() = !rectRainbow
+    }
+    private val rectGreen by object : IntegerValue("Rectangle Green", 148, 0, 255) {
+        override fun isSupported() = !rectRainbow
+    }
+    private val rectBlue by object : IntegerValue("Rectangle Blue", 255, 0, 255) {
+        override fun isSupported() = !rectRainbow
+    }
+    private val rectAlpha by object : IntegerValue("Rectangle Alpha", 140, 0, 255) {
+        override fun isSupported() = !rectRainbow
+    }
+
+    private val backgroundRed by IntegerValue("Background Red", 0, 0, 255)
+    private val backgroundGreen by IntegerValue("Background Green", 0, 0, 255)
+    private val backgroundBlue by IntegerValue("Background Blue", 0, 0, 255)
+    private val backgroundAlpha by IntegerValue("Background Alpha", 150, 0, 255)
+
+    private val borderValue by BoolValue("Border", true)
+    private val borderStrength by object : FloatValue("Border Strength", 2F, 1F, 5F) {
+        override fun isSupported() = borderValue
+    }
+    private val borderRainbow by object : BoolValue("Border Rainbow", false) {
+        override fun isSupported() = borderValue
+    }
+    private val borderRed by object : IntegerValue("Border Red", 0, 0, 255) {
+        override fun isSupported() = borderValue && !borderRainbow
+    }
+    private val borderGreen by object : IntegerValue("Border Green", 0, 0, 255) {
+        override fun isSupported() = borderValue && !borderRainbow
+    }
+    private val borderBlue by object : IntegerValue("Border Blue", 0, 0, 255) {
+        override fun isSupported() = borderValue && !borderRainbow
+    }
+    private val borderAlpha by object : IntegerValue("Border Alpha", 150, 0, 255) {
+        override fun isSupported() = borderValue && !borderRainbow
+    }
+
+    private val rainbowX by object : FloatValue("Rainbow-X", -1000F, -2000F, 2000F) {
+        override fun isSupported() = rectRainbow || (borderValue && borderRainbow)
+    }
+    private val rainbowY by object : FloatValue("Rainbow-Y", -1000F, -2000F, 2000F) {
+        override fun isSupported() = rectRainbow || (borderValue && borderRainbow)
+    }
+
+    private val arrows by BoolValue("Arrows", true)
+    private val font by FontValue("Font", Fonts.font35)
+    private val textShadow by BoolValue("TextShadow", false)
+    private val textFade by BoolValue("TextFade", true)
+    private val textPositionY by FloatValue("TextPosition-Y", 2F, 0F, 5F)
+    private val width by FloatValue("Width", 60F, 55F, 100F)
+    private val tabHeight by FloatValue("TabHeight", 12F, 10F, 15F)
+    private val upperCase by BoolValue("UpperCase", false)
 
     private val tabs = mutableListOf<Tab>()
 
     private var categoryMenu = true
     private var selectedCategory = 0
+        set(value) {
+            field = when {
+                value < 0 -> tabs.lastIndex
+                value > tabs.lastIndex -> 0
+                else -> value
+            }
+        }
     private var selectedModule = 0
+        set(value) {
+            field = when {
+                value < 0 -> tabs[selectedCategory].modules.lastIndex
+                value > tabs[selectedCategory].modules.lastIndex -> 0
+                else -> value
+            }
+        }
 
     private var tabY = 0F
     private var itemY = 0F
@@ -83,93 +125,70 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
 
         AWTFontRenderer.assumeNonVolatile = true
 
-        val fontRenderer = fontValue.get()
+        val backgroundColor = Color(backgroundRed, backgroundGreen, backgroundBlue, backgroundAlpha)
 
-        val rectangleRainbowEnabled = rectangleRainbow.get()
-
-        val backgroundColor = Color(backgroundRedValue.get(), backgroundGreenValue.get(), backgroundBlueValue.get(),
-                backgroundAlphaValue.get())
-
-        val borderColor = if (!borderRainbow.get())
-            Color(borderRedValue.get(), borderGreenValue.get(), borderBlueValue.get(), borderAlphaValue.get())
-        else
-            Color.black
+        val borderColor = if (borderRainbow) Color.black else Color(borderRed, borderGreen, borderBlue, borderAlpha)
 
         // Draw
-        val guiHeight = tabs.size * tabHeight.get()
+        val guiHeight = tabs.size * tabHeight
 
-        drawRect(1F, 0F, width.get(), guiHeight, backgroundColor.rgb)
+        drawRect(1F, 0F, width, guiHeight, backgroundColor.rgb)
 
-        if (borderValue.get()) {
-            RainbowShader.begin(borderRainbow.get(), if (rainbowX.get() == 0f) 0f else 1f / rainbowX.get(), if (rainbowY.get() == 0f) 0f else 1f / rainbowY.get(), System.currentTimeMillis() % 10000 / 10000F).use {
-                drawBorder(1F, 0F, width.get(), guiHeight, borderStrength.get(), borderColor.rgb)
+        if (borderValue) {
+            RainbowShader.begin(borderRainbow, if (rainbowX == 0f) 0f else 1f / rainbowX, if (rainbowY == 0f) 0f else 1f / rainbowY, System.currentTimeMillis() % 10000 / 10000F).use {
+                drawBorder(1F, 0F, width, guiHeight, borderStrength, borderColor.rgb)
             }
         }
 
         // Color
-        val rectColor = if (!rectangleRainbowEnabled)
-            Color(redValue.get(), greenValue.get(), blueValue.get(), alphaValue.get())
-        else {
-            Color.black
-        }
+        val rectColor = if (rectRainbow) Color.black else Color(rectRed, rectGreen, rectBlue, rectAlpha)
 
-        RainbowShader.begin(rectangleRainbowEnabled, if (rainbowX.get() == 0f) 0f else 1f / rainbowX.get(), if (rainbowY.get() == 0f) 0f else 1f / rainbowY.get(), System.currentTimeMillis() % 10000 / 10000F).use {
-            drawRect(1F, 1 + tabY - 1, width.get(), tabY + tabHeight.get(), rectColor)
+        RainbowShader.begin(rectRainbow, if (rainbowX == 0f) 0f else 1f / rainbowX, if (rainbowY == 0f) 0f else 1f / rainbowY, System.currentTimeMillis() % 10000 / 10000F).use {
+            drawRect(1F, 1 + tabY - 1, width, tabY + tabHeight, rectColor)
         }
 
         glColor4f(1f, 1f, 1f, 1f)
 
         var y = 1F
         tabs.forEachIndexed { index, tab ->
-            val tabName = if (upperCaseValue.get())
+            val tabName = if (upperCase)
                 tab.tabName.uppercase()
             else
                 tab.tabName
 
             val textX = if (side.horizontal == Side.Horizontal.RIGHT)
-                width.get() - fontRenderer.getStringWidth(tabName) - tab.textFade - 3
+                width - font.getStringWidth(tabName) - tab.textFade - 3
             else
                 tab.textFade + 5
-            val textY = y + textPositionY.get()
+            val textY = y + textPositionY
 
             val textColor = if (selectedCategory == index) 0xffffff else Color(210, 210, 210).rgb
 
-            fontRenderer.drawString(tabName, textX, textY, textColor, textShadow.get())
+            font.drawString(tabName, textX, textY, textColor, textShadow)
 
-            if (arrowsValue.get()) {
+            if (arrows) {
                 if (side.horizontal == Side.Horizontal.RIGHT)
-                    fontRenderer.drawString(if (!categoryMenu && selectedCategory == index) ">" else "<", 3F, y + 2F,
-                            0xffffff, textShadow.get())
+                    font.drawString(if (!categoryMenu && selectedCategory == index) ">" else "<", 3F, y + 2F,
+                            0xffffff, textShadow)
                 else
-                    fontRenderer.drawString(if (!categoryMenu && selectedCategory == index) "<" else ">",
-                            width.get() - 8F, y + 2F, 0xffffff, textShadow.get())
+                    font.drawString(if (!categoryMenu && selectedCategory == index) "<" else ">",
+                            width - 8F, y + 2F, 0xffffff, textShadow)
             }
 
             if (index == selectedCategory && !categoryMenu) {
                 val tabX = if (side.horizontal == Side.Horizontal.RIGHT)
                     1F - tab.menuWidth
                 else
-                    width.get() + 5
+                    width + 5
 
-                tab.drawTab(
-                        tabX,
-                        y,
-                        rectColor.rgb,
-                        backgroundColor.rgb,
-                        borderColor.rgb,
-                        borderStrength.get(),
-                        upperCaseValue.get(),
-                        fontRenderer,
-                        borderRainbow.get(),
-                        rectangleRainbowEnabled
-                )
+                tab.drawTab(tabX, y, rectColor.rgb, backgroundColor.rgb, borderColor.rgb, borderStrength, font, borderRainbow, rectRainbow)
             }
-            y += tabHeight.get()
+            y += tabHeight
         }
 
         AWTFontRenderer.assumeNonVolatile = false
 
-        return Border(1F, 0F, width.get(), guiHeight)
+        return Border(1F, 0F, width, guiHeight)
     }
 
     override fun handleKey(c: Char, keyCode: Int) {
@@ -183,53 +202,35 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
     }
 
     private fun updateAnimation() {
-        val delta = deltaTime
-
-        val xPos = tabHeight.get() * selectedCategory
+        val xPos = tabHeight * selectedCategory
         if (tabY.toInt() != xPos.toInt()) {
             if (xPos > tabY)
-                tabY += 0.1F * delta
+                tabY += 0.1F * deltaTime
             else
-                tabY -= 0.1F * delta
+                tabY -= 0.1F * deltaTime
         } else
             tabY = xPos
-        val xPos2 = tabHeight.get() * selectedModule
+        val xPos2 = tabHeight * selectedModule
 
         if (itemY.toInt() != xPos2.toInt()) {
             if (xPos2 > itemY)
-                itemY += 0.1F * delta
+                itemY += 0.1F * deltaTime
             else
-                itemY -= 0.1F * delta
+                itemY -= 0.1F * deltaTime
         } else
             itemY = xPos2
 
         if (categoryMenu)
             itemY = 0F
 
-        if (textFade.get()) {
+        if (textFade) {
             tabs.forEachIndexed { index, tab ->
-                if (index == selectedCategory) {
-                    if (tab.textFade < 4)
-                        tab.textFade += 0.05F * delta
-
-                    if (tab.textFade > 4)
-                        tab.textFade = 4F
-                } else {
-                    if (tab.textFade > 0)
-                        tab.textFade -= 0.05F * delta
-
-                    if (tab.textFade < 0)
-                        tab.textFade = 0F
-                }
+                if (index == selectedCategory) tab.textFade += 0.05F * deltaTime
+                else tab.textFade -= 0.05F * deltaTime
             }
         } else {
-            for (tab in tabs) {
-                if (tab.textFade > 0)
-                    tab.textFade -= 0.05F * delta
-
-                if (tab.textFade < 0)
-                    tab.textFade = 0F
-            }
+            for (tab in tabs)
+                tab.textFade -= 0.05F * deltaTime
         }
     }
 
@@ -237,38 +238,27 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
         var toggle = false
 
         when (action) {
-            Action.UP -> if (categoryMenu) {
-                --selectedCategory
-                if (selectedCategory < 0) {
-                    selectedCategory = tabs.size - 1
-                    tabY = tabHeight.get() * selectedCategory.toFloat()
+            Action.UP ->
+                if (categoryMenu) {
+                    --selectedCategory
+                    tabY = tabHeight * selectedCategory
+                } else {
+                    --selectedModule
+                    itemY = tabHeight * selectedModule
                 }
-            } else {
-                --selectedModule
-                if (selectedModule < 0) {
-                    selectedModule = tabs[selectedCategory].modules.size - 1
-                    itemY = tabHeight.get() * selectedModule.toFloat()
-                }
-            }
 
-            Action.DOWN -> if (categoryMenu) {
-                ++selectedCategory
-                if (selectedCategory > tabs.size - 1) {
-                    selectedCategory = 0
-                    tabY = tabHeight.get() * selectedCategory.toFloat()
+            Action.DOWN ->
+                if (categoryMenu) {
+                    ++selectedCategory
+                    tabY = tabHeight * selectedCategory
+                } else {
+                    ++selectedModule
+                    itemY = tabHeight * selectedModule
                 }
-            } else {
-                ++selectedModule
-                if (selectedModule > tabs[selectedCategory].modules.size - 1) {
-                    selectedModule = 0
-                    itemY = tabHeight.get() * selectedModule.toFloat()
-                }
-            }
 
-            Action.LEFT -> {
+            Action.LEFT ->
                 if (!categoryMenu)
                     categoryMenu = true
-            }
 
             Action.RIGHT ->
                 if (!categoryMenu) {
@@ -288,6 +278,8 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
         }
     }
 
+    fun getDisplayName(module: Module) = if (upperCase) module.getName().uppercase() else module.getName()
+
     /**
      * TabGUI Tab
      */
@@ -296,29 +288,36 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
         val modules = mutableListOf<Module>()
         var menuWidth = 0
         var textFade = 0F
+            set(value) {
+                field = value.coerceIn(0f, 4f)
+            }
 
-        fun drawTab(x: Float, y: Float, color: Int, backgroundColor: Int, borderColor: Int, borderStrength: Float,
-                    upperCase: Boolean, fontRenderer: FontRenderer, borderRainbow: Boolean, rectRainbow: Boolean) {
+        fun drawTab(
+            x: Float, y: Float, color: Int, backgroundColor: Int, borderColor: Int, borderStrength: Float,
+            fontRenderer: FontRenderer, borderRainbow: Boolean, rectRainbow: Boolean
+        ) {
             var maxWidth = 0
 
-            for (module in modules)
-                if (fontRenderer.getStringWidth(if (upperCase) module.name.uppercase() else module.name) + 4 > maxWidth)
-                    maxWidth = (fontRenderer.getStringWidth(if (upperCase) module.name.uppercase() else module.name) + 7F).toInt()
+            for (module in modules) {
+                val width = fontRenderer.getStringWidth(getDisplayName(module))
+                if (width + 4 > maxWidth)
+                    maxWidth = width + 7
+            }
 
             menuWidth = maxWidth
 
-            val menuHeight = modules.size * tabHeight.get()
+            val menuHeight = modules.size * tabHeight
 
-            if (borderValue.get()) {
-                RainbowShader.begin(borderRainbow, if (rainbowX.get() == 0f) 0f else 1f / rainbowX.get(), if (rainbowY.get() == 0f) 0f else 1f / rainbowY.get(), System.currentTimeMillis() % 10000 / 10000F).use {
+            if (borderValue) {
+                RainbowShader.begin(borderRainbow, if (rainbowX == 0f) 0f else 1f / rainbowX, if (rainbowY == 0f) 0f else 1f / rainbowY, System.currentTimeMillis() % 10000 / 10000F).use {
                     drawBorder(x - 1F, y - 1F, x + menuWidth - 2F, y + menuHeight - 1F, borderStrength, borderColor)
                 }
             }
             drawRect(x - 1F, y - 1F, x + menuWidth - 2F, y + menuHeight - 1F, backgroundColor)
 
 
-            RainbowShader.begin(rectRainbow, if (rainbowX.get() == 0f) 0f else 1f / rainbowX.get(), if (rainbowY.get() == 0f) 0f else 1f / rainbowY.get(), System.currentTimeMillis() % 10000 / 10000F).use {
-                drawRect(x - 1f, y + itemY - 1, x + menuWidth - 2F, y + itemY + tabHeight.get() - 1, color)
+            RainbowShader.begin(rectRainbow, if (rainbowX == 0f) 0f else 1f / rainbowX, if (rainbowY == 0f) 0f else 1f / rainbowY, System.currentTimeMillis() % 10000 / 10000F).use {
+                drawRect(x - 1f, y + itemY - 1, x + menuWidth - 2F, y + itemY + tabHeight - 1, color)
             }
 
             glColor4f(1f, 1f, 1f, 1f)
@@ -326,8 +325,8 @@ class TabGUI(x: Double = 5.0, y: Double = 25.0) : Element(x = x, y = y) {
             modules.forEachIndexed { index, module ->
                 val moduleColor = if (module.state) 0xffffff else Color(205, 205, 205).rgb
 
-                fontRenderer.drawString(if (upperCase) module.name.uppercase() else module.name, x + 2F,
-                        y + tabHeight.get() * index + textPositionY.get(), moduleColor, textShadow.get())
+                fontRenderer.drawString(getDisplayName(module), x + 2F,
+                        y + tabHeight * index + textPositionY, moduleColor, textShadow)
             }
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/Text.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/Text.kt
@@ -177,12 +177,7 @@ class Text(x: Double = 10.0, y: Double = 10.0, scale: Float = 1F,
             updateElement()
         }
 
-        return Border(
-                -2F,
-                -2F,
-                fontRenderer.getStringWidth(displayText) + 2F,
-                fontRenderer.FONT_HEIGHT.toFloat()
-        )
+        return Border(-2F, -2F, fontRenderer.getStringWidth(displayText) + 2F, fontRenderer.FONT_HEIGHT.toFloat())
     }
 
     override fun updateElement() {

--- a/src/main/java/net/ccbluex/liquidbounce/utils/SettingsUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/SettingsUtils.kt
@@ -110,19 +110,19 @@ object SettingsUtils {
 
                     if (valueName.equals("toggle", ignoreCase = true)) {
                         module.state = value.equals("true", ignoreCase = true)
-                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.name} §7was toggled §c§l${if (module.state) "on" else "off"}§7.")
+                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.getName()} §7was toggled §c§l${if (module.state) "on" else "off"}§7.")
                         return@forEachIndexed
                     }
 
                     if (valueName.equals("bind", ignoreCase = true)) {
                         module.keyBind = Keyboard.getKeyIndex(value)
-                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.name} §7was bound to §c§l${Keyboard.getKeyName(module.keyBind)}§7.")
+                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.getName()} §7was bound to §c§l${Keyboard.getKeyName(module.keyBind)}§7.")
                         return@forEachIndexed
                     }
 
                     val moduleValue = module[valueName]
                     if (moduleValue == null) {
-                        displayChatMessage("§7[§3§lAutoSettings§7] §cValue §a§l$valueName§c don't found in module §a§l$moduleName§c.")
+                        displayChatMessage("§7[§3§lAutoSettings§7] §cValue §a§l$valueName§c wasn't found in module §a§l${module.getName()}§c.")
                         return@forEachIndexed
                     }
 
@@ -139,9 +139,9 @@ object SettingsUtils {
                             is ListValue -> moduleValue.changeValue(value)
                         }
 
-                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.name}§7 value §8§l${moduleValue.name}§7 set to §c§l$value§7.")
+                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${module.getName()}§7 value §8§l${moduleValue.name}§7 set to §c§l$value§7.")
                     } catch (e: Exception) {
-                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${e.javaClass.name}§7(${e.message}) §cAn Exception occurred while setting §a§l$value§c to §a§l${moduleValue.name}§c in §a§l${module.name}§c.")
+                        displayChatMessage("§7[§3§lAutoSettings§7] §a§l${e.javaClass.name}§7(${e.message}) §cAn Exception occurred while setting §a§l$value§c to §a§l${moduleValue.name}§c in §a§l${module.getName()}§c.")
                     }
                 }
             }

--- a/src/main/java/net/ccbluex/liquidbounce/value/Value.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/value/Value.kt
@@ -14,6 +14,7 @@ import net.ccbluex.liquidbounce.ui.font.Fonts
 import net.ccbluex.liquidbounce.ui.font.GameFontRenderer
 import net.ccbluex.liquidbounce.utils.ClientUtils.LOGGER
 import net.minecraft.client.gui.FontRenderer
+import kotlin.reflect.KProperty
 
 abstract class Value<T>(val name: String, protected open var value: T) {
 
@@ -64,6 +65,10 @@ abstract class Value<T>(val name: String, protected open var value: T) {
     protected open fun onChanged(oldValue: T, newValue: T) {}
     open fun isSupported() = true
 
+    operator fun getValue(u: Any?, property: KProperty<*>) = value
+
+    operator fun setValue(u: Any?, property: KProperty<*>, t: T) = set(t)
+
 }
 
 /**
@@ -79,7 +84,7 @@ open class BoolValue(name: String, value: Boolean) : Value<Boolean>(name, value)
         return null
     }
 
-    fun toggle() = changeValue(!value)
+    fun toggle() = set(!value)
 
     fun isActive() = value && isSupported()
 


### PR DESCRIPTION
SHOWCASE: https://youtu.be/_gpESqsqD2s
(older version without click sounds added)

Value:
* added support for delegator like in nextgen

HUD editor:
* made values dynamic, reordered them (in ArrayList, TabGUI)
* added SpacedModules value to ArrayList, which toggles spaces in module names for ArrayList, Notifications, chat messages, TabGUI, ... except for ClickGUI
* reworked tags, added tags mode: [], (), |, ...
* made values that !isSupported() not show, like in ClickGUI
* added click sounds from ClickGui.style.clickSound() to BoolValue, ListValue, FontValue
* ArrayList now gets reordered when you change values like Tags in HUD editor, previously it didn't get reordered until you closed HUD editor
* turned values of ArrayList, TabGUI into delegators, simplified code

Spaced module names:
* implemented into commands output, notifications, clickgui, arraylist, ...
* module.getName(spaced = arraylist.spacedModules) returns normal name or name with space

ClickGUI:
* added click sound for FontValue
* added value SpacedModules: toggles module names with spaces within ClickGUI
* added value PanelsNotBeyondBorder: toggles panels movability beyond window borders (closes https://github.com/CCBlueX/LiquidBounce/issues/999)
* also reworked system of ^, it doesn't readjust all panels now, just the one you are dragging, ...
* panel scrolling now doesn't scroll them off the screen unless the panels movability beyond window borders is disabled, ...
* removed mouse being glued to the dragged panel, because of scaling inaccuracy
* BlackStyle:
* fixed modules not showing whether they are enabled or not