### PR TITLE
module highlighting for search

### DIFF
--- a/src-theme/clickgui/src/SearchBar.svelte
+++ b/src-theme/clickgui/src/SearchBar.svelte
@@ -1,4 +1,5 @@
 <script>
+	import Module from './../../hud/src/arraylist/Module.svelte';
     export let root;
     export let modules;
 
@@ -18,10 +19,31 @@
 
         filteredModules = modules.filter(module => module.name.toLowerCase().includes(value.toLowerCase()));
     };
+    function isElementVisible(container, element) {
+        const containerTop = container.scrollTop;
+        const containerBottom = containerTop + container.clientHeight;
+        const elementTop = element.offsetTop;
+        const elementBottom = elementTop + element.clientHeight;
 
+        return elementTop >= containerTop && elementBottom <= containerBottom;
+    }
+    function scrollToElement(container, element) {
+        if (!isElementVisible(container, element)) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+    }
     const handleToggleClick = (module) => {
         module.instance.setEnabled(!module.enabled);
     };
+
+    const handleHiglight = (module) => {
+        const elem = document.getElementById(module.name + "-module");
+        scrollToElement(elem.parentElement, elem)
+        elem.classList.add("module-highlight");
+        setTimeout(() => {
+            elem.classList.remove("module-highlight");
+        }, 1000);
+    }
 
     try {
         events.on("toggleModule", event => {
@@ -101,7 +123,7 @@
         {#if 0 < filteredModules.length}
             <div class="search-bar-list">
                 {#each filteredModules as module}
-                    <div class="search-bar-list-item" on:mousedown={() => handleToggleClick(module)}
+                    <div class="search-bar-list-item" on:mousedown={(e) => (e.button === 0 ? handleToggleClick : handleHiglight)(module)}
                          class:selected={selectedModule === module}>
                         <span class:active={module.enabled}>
                             {module.name}

--- a/src-theme/clickgui/src/SearchBar.svelte
+++ b/src-theme/clickgui/src/SearchBar.svelte
@@ -1,5 +1,4 @@
 <script>
-	import Module from './../../hud/src/arraylist/Module.svelte';
     export let root;
     export let modules;
 

--- a/src-theme/clickgui/src/clickgui/Module.svelte
+++ b/src-theme/clickgui/src/clickgui/Module.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <div>
-    <div on:mousedown={handleToggleSettings} on:click={handleToggle} class:has-settings={settings.length > 0} class:enabled={enabled} class:expanded={expanded} class="module">{name}</div>
+    <div on:mousedown={handleToggleSettings} on:click={handleToggle} class:has-settings={settings.length > 0} class:enabled={enabled} class:expanded={expanded} class="module" id={name + "-module"}>{name}</div>
     {#if expanded}
         <div class="settings" transition:slide={{duration: 400, easing: sineInOut}}>
             {#each settings as s}
@@ -93,8 +93,12 @@
                 opacity: 1;   
             }
         }
-    }
 
+    }
+    
+    :global(.module-highlight) {
+        background-color: #4677ffa2;
+    }
 
     .settings {
         background-color: rgba(0, 0, 0, 0.36);


### PR DESCRIPTION
Makes it so that when you right-click a module in the search menu, it will highlight it below its category(make it blue for 1 second) and, if not already visible, will scroll to make it visible.


![explanation](https://github.com/CCBlueX/LiquidBounce/assets/85990359/3732a43c-3665-4347-a515-fcb31455e6a6)
This makes it very fast and easy to quickly change the settings of a module.