### PR TITLE
Some improvements and bugfixes

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/Ambience.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/Ambience.kt
@@ -21,9 +21,9 @@ object Ambience : Module("Ambience", ModuleCategory.RENDER) {
     private val timeMode by ListValue("Mode", arrayOf("None", "Normal", "Custom"), "Custom")
     private val weatherMode by ListValue("WeatherMode", arrayOf("None", "Sun", "Rain", "Thunder"), "None")
 
-    private val customWorldTime by IntegerValue("Time", 19000, 0..24000) { timeMode != "Custom" }
+    private val customWorldTime by IntegerValue("Time", 19000, 0..24000) { timeMode == "Custom" }
 
-    private val changeWorldTimeSpeed by IntegerValue("TimeSpeed", 150, 10..500) { timeMode != "None" }
+    private val changeWorldTimeSpeed by IntegerValue("TimeSpeed", 150, 10..500) { timeMode == "Normal" }
 
     private val weatherStrength by FloatValue("WeatherStrength", 1f, 0f..1f) { weatherMode != "None" }
 
@@ -37,11 +37,8 @@ object Ambience : Module("Ambience", ModuleCategory.RENDER) {
     fun onUpdate(event: UpdateEvent) {
         when (timeMode.lowercase()) {
             "normal" -> {
-                if (i < 24000) {
-                    i += changeWorldTimeSpeed
-                } else {
-                    i = 0
-                }
+                i += changeWorldTimeSpeed
+                i %= 24000
                 mc.theWorld.worldTime = i
             }
             "custom" -> {
@@ -49,18 +46,20 @@ object Ambience : Module("Ambience", ModuleCategory.RENDER) {
             }
         }
 
+		val strength = weatherStrength.coerceIn(0F, 1F)
+
         when (weatherMode.lowercase()) {
             "sun" -> {
                 mc.theWorld.setRainStrength(0f)
                 mc.theWorld.setThunderStrength(0f)
             }
             "rain" -> {
-                mc.theWorld.setRainStrength(weatherStrength)
+                mc.theWorld.setRainStrength(strength)
                 mc.theWorld.setThunderStrength(0f)
             }
             "thunder" -> {
-                mc.theWorld.setRainStrength(weatherStrength)
-                mc.theWorld.setThunderStrength(weatherStrength)
+                mc.theWorld.setRainStrength(strength)
+                mc.theWorld.setThunderStrength(strength)
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/FreeCam.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/FreeCam.kt
@@ -53,6 +53,7 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
         fakePlayer = EntityOtherPlayerMP(mc.theWorld, mc.thePlayer.gameProfile)
         fakePlayer.clonePlayer(mc.thePlayer, true)
         fakePlayer.rotationYawHead = mc.thePlayer.rotationYawHead
+        fakePlayer.absorptionAmount = mc.thePlayer.absorptionAmount
         fakePlayer.copyLocationAndAnglesFrom(mc.thePlayer)
         mc.theWorld.addEntityToWorld(-1000, fakePlayer)
         if (noClip) {

--- a/src/main/java/net/ccbluex/liquidbounce/utils/CooldownHelper.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/CooldownHelper.kt
@@ -48,11 +48,11 @@ object CooldownHelper {
         }
         
         if (mc.thePlayer.isPotionActive(Potion.digSlowdown)) {
-            genericAttackSpeed *= 1.0 - min(1.0, 0.1 * mc.thePlayer.getActivePotionEffect(Potion.digSlowdown).amplifier + 1)
+            genericAttackSpeed *= 1.0 - min(1.0, 0.1 * (mc.thePlayer.getActivePotionEffect(Potion.digSlowdown).amplifier + 1))
         }
         
         if (mc.thePlayer.isPotionActive(Potion.digSpeed)) {
-            genericAttackSpeed *= 1.0 + (0.1 * mc.thePlayer.getActivePotionEffect(Potion.digSpeed).amplifier + 1)
+            genericAttackSpeed *= 1.0 + 0.1 * (mc.thePlayer.getActivePotionEffect(Potion.digSpeed).amplifier + 1)
         } 
     }
 


### PR DESCRIPTION
Ambience:
 - Fixed inability to set custom world time when mode is "Custom"
 - Made time changing smoother in "Normal" mode
 - Limited weatherStrength to (min = 0; max = 1) in order to prevent players from crashing their games using ".ambience weatherStrength 1000" command

CooldownHelper:
 - Fixed incorrect attack speed calculations when player have Haste/Mining Fatigue effects

Freecam:
 - Fixed fake player didn't have absorption

TargetHud:
 - Added "Absorption" option. When it's enabled targetHud consider target absorption amount by adding it to target health amount

NameTags:
 - Added a decimal format to HP display (For example, it shows 7.49 HP instead of 7.488886 HP)
 - Added "Absorption" option. When a player has a couple of absorption hearts and max. health it displays 24 HP instead of 20 HP. When "Absorption" is enabled "Bar" considers absorption amount as well.
 - Added an options to enable/disable health prefixes and suffixes