### PR TITLE
NEXTGEN: fixed searchbar being delayed

### DIFF
--- a/src-theme/clickgui/src/SearchBar.svelte
+++ b/src-theme/clickgui/src/SearchBar.svelte
@@ -4,7 +4,7 @@
 
     // Initial state of search bar visibility.
     let visible = root.instance.getSearchAlwaysOnTop();
-
+    let autofocus = root.instance.getSearchAutoFocus();
     let value = "";
     let filteredModules = [];
     let selectedModule = null;
@@ -125,7 +125,7 @@
 {#if visible}
     <div class="search-bar">
         <div class="search-bar-input-container">
-            <input bind:value type="text" placeholder="Search" on:input={onInput} autofocus>
+            <input bind:value type="text" placeholder="Search" on:input={onInput} autofocus={autofocus}>
         </div>
         {#if 0 < filteredModules.length}
             <div class="search-bar-list">

--- a/src-theme/clickgui/src/SearchBar.svelte
+++ b/src-theme/clickgui/src/SearchBar.svelte
@@ -68,6 +68,17 @@
         }
     });
 
+    
+    function onInput() {
+        filterModules();
+
+        if (0 < filteredModules.length) {
+            selectedModule = filteredModules[0];
+        } else {
+            selectedModule = null;
+        }
+    }
+
     window.addEventListener("keydown", event => {
         const key = event.which;
 
@@ -99,13 +110,7 @@
                 handleToggleClick(selectedModule);
             }
         } else {
-            filterModules();
 
-            if (0 < filteredModules.length) {
-                selectedModule = filteredModules[0];
-            } else {
-                selectedModule = null;
-            }
         }
 
         // Scroll to selected module
@@ -120,7 +125,7 @@
 {#if visible}
     <div class="search-bar">
         <div class="search-bar-input-container">
-            <input bind:value type="text" placeholder="Search" autofocus>
+            <input bind:value type="text" placeholder="Search" on:input={onInput} autofocus>
         </div>
         {#if 0 < filteredModules.length}
             <div class="search-bar-list">

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -36,6 +36,7 @@ object ModuleClickGui : Module("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY
 
     // Specifies whether the search bar should always be visible or only after pressing Ctrl + F.
     val searchAlwaysOnTop by boolean("SearchAlwaysOnTop", true)
+    val searchAutoFocus by boolean("SearchAutoFocus", true)
 
     override fun enable() {
         val page = ThemeManager.page("clickgui") ?: error("unable to find clickgui page in current theme")


### PR DESCRIPTION
Previously the search bar would be 1 input delayed. Let's say you typed "bow", previously the top result would be AbortBreaking because it still thought that you only had typed "bo". 

Before:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/1be39e3e-1ff5-446f-83aa-5f311fcb64c0)
Fixed:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/94c8a48a-1757-4ce8-bfda-27db7e170585)

This also fixes the bug where the search bar would get rounded but the results would stay

Before:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/c6d3a77b-62e4-4db6-b309-90a0fbfbe0fe)
Fixed:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/b46303a1-565f-480b-9ae9-4c661f85d204)
