### PR TITLE
improve Breadcrumbs

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
@@ -41,6 +41,7 @@ object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER) {
 
     private val color by color("Color", Color4b(255, 179, 72, 255))
     private val colorRainbow by boolean("Rainbow", false)
+    private val maxLength by int("MaxLength", 500, 10..1000)
 
     private val positions = mutableListOf<Double>()
     private var lastPosX = 0.0
@@ -76,7 +77,7 @@ object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER) {
     @JvmStatic
     internal fun makeLines(color: Color4b, positions: List<Double>, tickDelta: Float): Array<Vec3> {
         val mutableList = mutableListOf<Vec3>()
-        for (i in 0 until positions.size / 3) {
+        for (i in 0 until positions.size / 3 - 1) {
             mutableList += Vec3(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2])
         }
         mutableList += player.interpolateCurrentPosition(tickDelta)
@@ -93,6 +94,9 @@ object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER) {
         lastPosZ = player.z
 
         synchronized(positions) {
+            if(positions.size > maxLength * 3){
+                positions.subList(0, positions.size - maxLength * 3).clear()
+            }
             positions.addAll(listOf(player.x, player.y, player.z))
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
@@ -41,7 +41,7 @@ object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER) {
 
     private val color by color("Color", Color4b(255, 179, 72, 255))
     private val colorRainbow by boolean("Rainbow", false)
-    private val maxLength by int("MaxLength", 500, 10..1000)
+    private val maxLength by int("MaxLength", 500, 10..5000)
 
     private val positions = mutableListOf<Double>()
     private var lastPosX = 0.0


### PR DESCRIPTION
- added MaxLength setting (Default: 500, Min: 10, Max: 1000)
https://www.veed.io/view/8296330e-9b75-45ae-a1a0-1e468ba5c83f?panel=share
- made the end of the trail smoothly follow the player
https://www.veed.io/view/324d16df-1ce7-4d80-bd1c-24f5e6d63571?panel=share

I am not completely sure if the setting's range and default value are correct so I'm happy to hear feedback on them

This should close https://github.com/CCBlueX/LiquidBounce/issues/693