### PR TITLE
Fixed custom rotations not being allowed when using freeCam

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleSprint;
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleStep;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleFreeCam;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleNoSwing;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleRotations;
 import net.ccbluex.liquidbounce.utils.aiming.Rotation;
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager;
 import net.minecraft.client.gui.screen.Screen;
@@ -64,6 +65,8 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @Shadow
     protected abstract boolean isWalking();
+
+    @Shadow public boolean inSneakingPose;
 
     /**
      * Hook entity tick event
@@ -210,7 +213,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @ModifyVariable(method = "sendMovementPackets", at = @At("STORE"), ordinal = 2)
     private boolean hookFreeCamPreventRotations(boolean bl4) {
-        return !ModuleFreeCam.INSTANCE.shouldDisableRotations() && bl4;
+        return (!ModuleFreeCam.INSTANCE.shouldDisableRotations() ||  ModuleRotations.INSTANCE.shouldSendCustomRotation())  && bl4;
     }
 
     @ModifyConstant(method = "canSprint", constant = @Constant(floatValue = 6.0F), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/HungerManager;getFoodLevel()I", ordinal = 0)))

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
@@ -66,8 +66,6 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
     @Shadow
     protected abstract boolean isWalking();
 
-    @Shadow public boolean inSneakingPose;
-
     /**
      * Hook entity tick event
      */

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -63,7 +63,7 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
 
         renderEnvironmentForWorld(matrixStack) {
             withColor(Color4b.WHITE) {
-                drawLineStrip(eyeVector, eyeVector + Vec3(serverRotation.rotationVec * 2.0))
+                drawLineStrip(eyeVector, eyeVector + Vec3(serverRotation.rotationVec * 100.0))
             }
         }
     }
@@ -71,12 +71,15 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
     /**
      * Should server-side rotations be shown?
      */
-    fun shouldDisplayRotations(): Boolean {
-        val priority = ModuleFreeCam.shouldDisableRotations()
+    fun shouldDisplayRotations() = shouldSendCustomRotation() || ModuleFreeCam.shouldDisableRotations()
 
+    /**
+     * Should we even send a rotation if we use freeCam
+     */
+    fun shouldSendCustomRotation(): Boolean {
         val special = arrayOf(ModuleDerp).any { it.enabled }
 
-        return priority || enabled && (RotationManager.currentRotation != null || special)
+        return RotationManager.currentRotation != null || special
     }
 
     /**


### PR DESCRIPTION
Previously, when RotationManeger made a rotation whilst using freeCam it would only happen on the client, but not send it to the server. This way it would interact with blocks and entities that it didn't look at server side.