### PR TITLE
[LEGACY] Inventory rework fixes and improvements

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
@@ -73,7 +73,7 @@ object InventoryManager: MinecraftInstance() {
 			 */
 
 			// Compact multiple small stacks into one to free up inventory space
-			CoroutineCleaner.compactStacks()
+			CoroutineCleaner.mergeInventoryStacks()
 
 			// Sort hotbar (with useful items without even dropping bad items first)
 			CoroutineCleaner.sortHotbar()

--- a/src/main/java/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
@@ -94,6 +94,8 @@ object InventoryUtils : MinecraftInstance(), Listenable {
 
     fun hasSpaceInInventory() = mc.thePlayer?.inventory?.firstEmptyStack != -1
 
+    fun countSpaceInInventory() = mc.thePlayer.inventory.mainInventory.count { it.isEmpty() }
+
     fun findBlockInHotbar(): Int? {
         val player = mc.thePlayer ?: return null
         val inventory = player.openContainer
@@ -116,6 +118,13 @@ object InventoryUtils : MinecraftInstance(), Listenable {
 
             stack.item is ItemBlock && stack.stackSize > 0 && block.isFullCube && block !in BLOCK_BLACKLIST && block !is BlockBush
         }.maxByOrNull { inventory.getSlot(it).stack.stackSize }
+    }
+
+    // Converts container slot to hotbar slot id, else returns null
+    fun Int.toHotbarIndex(stacksSize: Int): Int? {
+        val parsed = this - stacksSize + 9
+
+        return if (parsed in 0..8) parsed else null
     }
 
     @EventTarget

--- a/src/main/java/net/ccbluex/liquidbounce/value/Value.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/value/Value.kt
@@ -185,8 +185,8 @@ open class FontValue(name: String, value: FontRenderer, isSupported: (() -> Bool
     }
 
     fun previous() {
-        val fonts = Fonts.fonts.reversed()
-        value = fonts[(fonts.indexOf(value) + 1) % fonts.size]
+        val fonts = Fonts.fonts
+        value = fonts[(fonts.indexOf(value) - 1) % fonts.size]
     }
 }
 


### PR DESCRIPTION
Fixed ArmorComparator incorrectly marking equipped armor as better in some cases. (reported by @guosic)

Fixed Armorer equipping armor from chests even when hotbar equipping was disabled, simplified code.

Cleaner:
* added MaxThrowableStacks
* now preferably sorts strictly the best items into hotbar
* now keeps max 1 bucket of each type

Stealer:
* max stacks limit now checks, if the item that should be stolen won't merge with stacks in inventory, if so, it ignores stack limits, previously it wouldn't take it (reported by @guosic)

Added InventoryUtils.countSpaceInInventory()