### PR TITLE
Fix Clickgui css var not working

### DIFF
--- a/src-theme/clickgui/src/ClickGui.svelte
+++ b/src-theme/clickgui/src/ClickGui.svelte
@@ -63,7 +63,7 @@
         --accent: {accentColor};
         --accent-dimmed: {accendDimmed};
         --text: {textColor};
-        --textdimmed: {textDimmedColor}>">
+        --textdimmed: {textDimmedColor};">
 
             <SearchBar root="{clickGuiModule}" modules={modules}/>
             {#each panels as panel}


### PR DESCRIPTION
This is a crucial fix, without it all dim text will be colored black