### PR TITLE
Added branch dropdown to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,14 +13,16 @@ body:
         - Keep your issue focused on one single problem. If you have multiple bug reports, please create separate issues for each of them.
         - Provide as much context as possible in the details section. Include screenshots, screen recordings, links, references, or anything else you may consider relevant.
 
-  - type: input
+  - type: dropdown
     attributes:
       label: LiquidBounce Branch
       description: Which edition of LiquidBounce does this bug affect?
-      placeholder: legacy or nextgen
+      options:
+        - Nextgen
+        - Legacy
+        - Both
     validations:
       required: true
-
   - type: input
     attributes:
       label: LiquidBounce Build/Version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,8 +21,8 @@ body:
       options:
         - Nextgen
         - Legacy
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,15 +14,13 @@ body:
         - Provide as much context as possible in the details section. Include screenshots, screen recordings, links, references, or anything else you may consider relevant.
         - If you want to ask a question instead of requesting a feature, please use the [forum](https://forums.ccbluex.net/) instead.
 
-  - type: choice
+  - type: dropdown
     attributes:
       label: LiquidBounce Branch
       description: Which edition of LiquidBounce does this bug affect?
       options:
         - nextgen
         - legacy
-      validations:
-        required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,6 +21,8 @@ body:
       options:
         - Nextgen
         - Legacy
+      validations:
+        required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,6 +21,7 @@ body:
       options:
         - Nextgen
         - Legacy
+        - Both
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,6 +14,16 @@ body:
         - Provide as much context as possible in the details section. Include screenshots, screen recordings, links, references, or anything else you may consider relevant.
         - If you want to ask a question instead of requesting a feature, please use the [forum](https://forums.ccbluex.net/) instead.
 
+  - type: select
+    attributes:
+      label: LiquidBounce Branch
+      description: Which edition of LiquidBounce does this bug affect?
+      options:
+        - nextgen
+        - legacy
+      validations:
+        required: true
+
   - type: textarea
     attributes:
       label: Describe your feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
         - Provide as much context as possible in the details section. Include screenshots, screen recordings, links, references, or anything else you may consider relevant.
         - If you want to ask a question instead of requesting a feature, please use the [forum](https://forums.ccbluex.net/) instead.
 
-  - type: select
+  - type: choice
     attributes:
       label: LiquidBounce Branch
       description: Which edition of LiquidBounce does this bug affect?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,8 +19,8 @@ body:
       label: LiquidBounce Branch
       description: Which edition of LiquidBounce does this bug affect?
       options:
-        - nextgen
-        - legacy
+        - Nextgen
+        - Legacy
 
   - type: textarea
     attributes:


### PR DESCRIPTION
I added a dropdown to the feature template to let the creator of the issue choose which branch of Liquidbounce he would like it to be added to. It has 3 options: Nextgen, Legacy, and Both. I added the both option in case someone has an idea for a feature that's not version-specific, but if it is unwanted I could remove it. I also changed the input field in the bug report to this dropdown. 