### PR TITLE
[LEGACY] Added new mode in Criticals & Fix FastClimb mode Delay

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -26,7 +26,7 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
 
     val mode by ListValue(
         "Mode",
-        arrayOf("Packet", "NCPPacket", "BlocksMC", "NoGround", "Hop", "TPHop", "Jump", "LowJump", "Visual"),
+        arrayOf("Packet", "NCPPacket", "VerusJump", "BlocksMC", "NoGround", "Hop", "TPHop", "Jump", "LowJump", "Visual"),
         "Packet"
     )
 
@@ -38,6 +38,14 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
     override fun onEnable() {
         if (mode == "NoGround")
             mc.thePlayer.jump()
+    }
+
+    private fun playerJump() {
+        mc.thePlayer.isInWeb = true
+        mc.thePlayer.jump()
+        mc.thePlayer.prevPosY = mc.thePlayer.posY
+
+        mc.thePlayer.isInWeb = false
     }
 
     @EventTarget
@@ -72,6 +80,13 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
                         C04PacketPlayerPosition(x, y + 0.0000013579, z, false)
                     )
                     mc.thePlayer.onCriticalHit(entity)
+                }
+
+                "verusjump" -> {
+                    thePlayer.motionY = 0.11
+                    thePlayer.onGround = false
+                    thePlayer.posY = thePlayer.prevPosY
+                    playerJump()
                 }
 
                 "blocksmc" -> {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastClimb.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastClimb.kt
@@ -28,7 +28,7 @@ object FastClimb : Module("FastClimb", ModuleCategory.MOVEMENT) {
     private val speed by FloatValue("Speed", 1F, 0.01F..5F) { mode == "Vanilla" }
 
     // Delay mode | Separated Vanilla & Delay speed value
-    private val climbspeed by FloatValue("Speed", 1F, 0.01F..10F) { mode == "Delay"}
+    private val climbspeed by FloatValue("ClimbSpeed", 1F, 0.01F..5F) { mode == "Delay"}
     private val tickDelay by IntegerValue("TickDelay", 10, 1..20) { mode == "Delay" }
 
 


### PR DESCRIPTION
* Added "VerusJump" mode to Criticals, should be able to bypass Verus, NCP, other AntiCheat & bypassed BlocksMC too
* Fixed FastClimb mode "Delay", not showing ClimbSpeed/Speed