### PR TITLE
Fixed typo in theme Readme

### DIFF
--- a/src-theme/README.md
+++ b/src-theme/README.md
@@ -48,7 +48,7 @@ CSS, contact us on our support@liquidbounce.net email or on GitHub (the faster w
 ## Building
 
 To build the themes, you need to have Node.js installed.
-Then run `node bundle.py` to build the theme.
+Then run `node bundle.js` to build the theme.
 
 ### Testing
 


### PR DESCRIPTION
It should be bundle.js instead of bundle.py. This is too supported by the build.gradle:
```
tasks.register('bundleTheme', Exec) {
    dependsOn 'npmInstallTheme'
    workingDir file('src-theme')
    commandLine 'node', 'bundle.js' // <-- here
        println 'Successfully attached theme to build'
    }
}
```
