### PR TITLE
Fix build.gradle for Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
     id 'fabric-loom'
     id 'org.jetbrains.kotlin.jvm'
@@ -150,8 +152,12 @@ processResources {
 // The following code will include the theme into the build
 
 tasks.register('npmInstallTheme', Exec) {
+    String npm = 'npm';
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        npm = 'npm.cmd'
+    }
     workingDir file('src-theme')
-    commandLine 'npm', 'i'
+    commandLine npm, 'i'
     doLast {
         println 'Successfully installed dependencies for theme'
     }


### PR DESCRIPTION
Without this windows users would get the following error when trying to build the client: 
```
Execution failed for task ':npmInstallTheme'.
> A problem occurred starting process 'command 'npm''
````
This should still work for linux because we check what system is in use, but i haven't been able to test it on Linux

Edit: I think this will be automatically be tested on Linux by github anyway, so it should not be a problem.