### PR TITLE
[LEGACY] Add Scaffold as a GameDetector module

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -65,7 +65,7 @@ import javax.vecmath.Color3f
 import kotlin.math.*
 
 
-object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I, gameDetecting = false) {
+object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I) {
 
     private val mode by ListValue("Mode", arrayOf("Normal", "Rewinside", "Expand", "Telly", "GodBridge"), "Normal")
 


### PR DESCRIPTION
Just in case that someone accidentally turns on Scaffold before a match begins