### PR TITLE
Fixed trajectories' entity hit rendering

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrajectories.kt
@@ -141,7 +141,7 @@ object ModuleTrajectories : Module("Trajectories", Category.RENDER) {
                 }
             } else if (landingPosition is EntityHitResult) {
                 renderEnvironmentForWorld(matrixStack) {
-                    val vec = landingPosition.entity
+                    landingPosition.entity
                         .interpolateCurrentPosition(event.partialTicks)
 
                     withColor(Color4b(255, 0, 0, 100)) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrajectories.kt
@@ -144,11 +144,10 @@ object ModuleTrajectories : Module("Trajectories", Category.RENDER) {
                     val vec = landingPosition.entity
                         .interpolateCurrentPosition(event.partialTicks)
 
-                    withPosition(vec) {
-                        withColor(Color4b(255, 0, 0, 100)) {
-                            drawSolidBox(landingPosition.entity.box)
-                        }
+                    withColor(Color4b(255, 0, 0, 100)) {
+                        drawSolidBox(landingPosition.entity.box)
                     }
+
                 }
             }
         }


### PR DESCRIPTION
Fixed trajectories module rendering the entity hit result box at the wrong position

![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/498edd6c-18a1-4e8f-bf1e-74df9cbd24fc)
