### PR TITLE
Added check for modules settings to JumpCrit

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
@@ -105,9 +105,7 @@ object ModuleCriticals : Module("Criticals", Category.COMBAT) {
         val checkTrigger by boolean("CheckTrigger", false)
 
         val tickHandler = handler<TickJumpEvent> {
-            if (!enabled) return@handler
-
-            if(!ModuleKillAura.enabled)
+            if (!isActive()) return@handler
 
             if (!canCrit(player, true)) {
                 return@handler
@@ -210,13 +208,25 @@ object ModuleCriticals : Module("Criticals", Category.COMBAT) {
         tree(VisualsConfigurable)
     }
 
+    fun isActive(): Boolean {
+        if (!enabled)
+            return false
+
+        // if both module checks are disabled, we can safely say that we are active
+        if(!JumpCrit.checkKillaura && !JumpCrit.checkTrigger)
+            return true
+
+        return (!ModuleKillAura.enabled || !JumpCrit.checkKillaura) && (!ModuleTrigger.enabled || !JumpCrit.checkTrigger)
+    }
+
+
     /**
      * Sometimes when the player is almost at the highest point of his jump, the KillAura
      * will try to attack the enemy anyways. To maximise damage, this function is used to determine
      * whether or not it is worth to wait for the fall
      */
     fun shouldWaitForCrit(): Boolean {
-        if (!enabled) return false
+        if (!isActive()) return false
 
         val player = player
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
@@ -101,8 +101,13 @@ object ModuleCriticals : Module("Criticals", Category.COMBAT) {
 
         val optimizeForCooldown by boolean("OptimizeForCooldown", true)
 
+        val checkKillaura by boolean("CheckKillaura", false)
+        val checkTrigger by boolean("CheckTrigger", false)
+
         val tickHandler = handler<TickJumpEvent> {
             if (!enabled) return@handler
+
+            if(!ModuleKillAura.enabled)
 
             if (!canCrit(player, true)) {
                 return@handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
@@ -216,7 +216,7 @@ object ModuleCriticals : Module("Criticals", Category.COMBAT) {
         if(!JumpCrit.checkKillaura && !JumpCrit.checkTrigger)
             return true
 
-        return (!ModuleKillAura.enabled || !JumpCrit.checkKillaura) && (!ModuleTrigger.enabled || !JumpCrit.checkTrigger)
+        return (ModuleKillAura.enabled && JumpCrit.checkKillaura) || (ModuleTrigger.enabled && JumpCrit.checkTrigger)
     }
 
 


### PR DESCRIPTION
Added 2 new settings to Criticals Jump mode: CheckKillaura and CheckTrigger

These settings will make sure that you won't jump if you dont have Killaura / Trigger enabled

To clarify when what happens, i will some examples:
If both are disabled it will always jump (ofc only if the range requirements are met).
If only CheckKillaura is enabled, it will only jump if Killaura is enabled and the same with trigger.
If both are enabled, it will jump if Killaura OR Trigger is enabled. This is helpful if you switch a lot between using Killaura and Trigger.

If i have missed any modules, feel free to write a comment, and i will try to add it as soon as possible

![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/0495bb98-21b0-4f6d-b411-92724b287067)
