### PR TITLE
(legacy) Buzz longjump

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
@@ -20,6 +20,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.m
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.ncp.NCP
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.other.Hycraft
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.other.Redesky
+import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.other.Buzz
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
 import net.ccbluex.liquidbounce.value.BoolValue

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
@@ -39,7 +39,7 @@ object LongJump : Module("LongJump", ModuleCategory.MOVEMENT) {
         Mineplex, Mineplex2, Mineplex3,
 
         // Other
-        Redesky, Hycraft
+        Redesky, Hycraft, Buzz
     )
 
     private val modes = longJumpModes.map { it.modeName }.toTypedArray()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
@@ -39,7 +39,7 @@ object LongJump : Module("LongJump", ModuleCategory.MOVEMENT) {
         Mineplex, Mineplex2, Mineplex3,
 
         // Other
-        Redesky, Hycraft, Buzz
+        Redesky, Hycraft, Buzz,
     )
 
     private val modes = longJumpModes.map { it.modeName }.toTypedArray()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/longjumpmodes/other/Buzz.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/longjumpmodes/other/Buzz.kt
@@ -10,7 +10,6 @@ import net.ccbluex.liquidbounce.utils.MovementUtils
 
 object Buzz : LongJumpMode("Buzz") {
     override fun onUpdate() {
-      if (thePlayer.hurtTime > 8) {
         mc.thePlayer.motionY += 0.4679942989799998
         MovementUtils.speed *= 0.7578698f
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/longjumpmodes/other/Buzz.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/longjumpmodes/other/Buzz.kt
@@ -1,0 +1,17 @@
+/*
+ * LiquidBounce Hacked Client
+ * A free open source mixin-based injection hacked client for Minecraft using Minecraft Forge.
+ * https://github.com/CCBlueX/LiquidBounce/
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.other
+
+import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.LongJumpMode
+import net.ccbluex.liquidbounce.utils.MovementUtils
+
+object Buzz : LongJumpMode("Buzz") {
+    override fun onUpdate() {
+      if (thePlayer.hurtTime > 8) {
+        mc.thePlayer.motionY += 0.4679942989799998
+        MovementUtils.speed *= 0.7578698f
+    }
+}


### PR DESCRIPTION
work on damage
still bypass on 2023.