### PR TITLE
Fix SilentHotbar not changing mining speed

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinPlayerInventory.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinPlayerInventory.java
@@ -39,20 +39,21 @@ public class MixinPlayerInventory {
     /**
      * Modify slot, to drop item from according to server side information.
      *
-     * @param playerInventory inventory
-     */
-    @Redirect(method = "dropSelectedItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getMainHandStack()Lnet/minecraft/item/ItemStack;"))
-    private ItemStack hookItemDrop(PlayerInventory playerInventory) {
-        return player.getInventory().main.get(SilentHotbar.INSTANCE.getServersideSlot());
-    }
-
-    /**
-     * Modify slot, to drop item from according to server side information.
-     *
      * @param instance inventory
      */
     @Redirect(method = "dropSelectedItem", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I"))
+    private int hookCustomSelectedSlotForDropping(PlayerInventory instance) {
+        return SilentHotbar.INSTANCE.getServersideSlot();
+    }
+
+    @Redirect(method = "getBlockBreakingSpeed", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I"))
     private int hookCustomSelectedSlot(PlayerInventory instance) {
         return SilentHotbar.INSTANCE.getServersideSlot();
     }
+    @Redirect(method = "getMainHandStack", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I"))
+    private int hookCustomSelectedSlotGetFunc(PlayerInventory instance) {
+        return SilentHotbar.INSTANCE.canGetSlot() ? SilentHotbar.INSTANCE.getServersideSlot() : instance.selectedSlot;
+    }
+
+
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
@@ -65,22 +65,6 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity {
     }
 
     /**
-     * Hook silent inventory feature
-     */
-//    @Redirect(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getMainHandStack()Lnet/minecraft/item/ItemStack;"))
-//    private ItemStack hookMainHandStack(PlayerInventory playerInventory) {
-//        ClientPlayerEntity player = MinecraftClient.getInstance().player;
-//
-//        if ((Object) this != player) {
-//            return this.inventory.getMainHandStack();
-//        }
-//
-//        int slot = SilentHotbar.INSTANCE.getServersideSlot();
-//
-//        return PlayerInventory.isValidHotbarIndex(slot) ? player.getInventory().main.get(slot) : ItemStack.EMPTY;
-//    }
-
-    /**
      * Hook safe walk event
      */
     @Inject(method = "clipAtLedge", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
@@ -67,18 +67,18 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity {
     /**
      * Hook silent inventory feature
      */
-    @Redirect(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getMainHandStack()Lnet/minecraft/item/ItemStack;"))
-    private ItemStack hookMainHandStack(PlayerInventory playerInventory) {
-        ClientPlayerEntity player = MinecraftClient.getInstance().player;
-
-        if ((Object) this != player) {
-            return this.inventory.getMainHandStack();
-        }
-
-        int slot = SilentHotbar.INSTANCE.getServersideSlot();
-
-        return PlayerInventory.isValidHotbarIndex(slot) ? player.getInventory().main.get(slot) : ItemStack.EMPTY;
-    }
+//    @Redirect(method = "getEquippedStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getMainHandStack()Lnet/minecraft/item/ItemStack;"))
+//    private ItemStack hookMainHandStack(PlayerInventory playerInventory) {
+//        ClientPlayerEntity player = MinecraftClient.getInstance().player;
+//
+//        if ((Object) this != player) {
+//            return this.inventory.getMainHandStack();
+//        }
+//
+//        int slot = SilentHotbar.INSTANCE.getServersideSlot();
+//
+//        return PlayerInventory.isValidHotbarIndex(slot) ? player.getInventory().main.get(slot) : ItemStack.EMPTY;
+//    }
 
     /**
      * Hook safe walk event

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
@@ -55,6 +55,9 @@ object SilentHotbar : Listenable {
         this.ticksSinceLastUpdate = 0
     }
 
+    fun canGetSlot() = mc.player != null
+
+
     fun resetSlot(requester: Any?) {
         if (this.hotbarState?.requester == requester) {
             this.hotbarState = null


### PR DESCRIPTION
Currently works, but not the cleanest solution because I had to add the `canGetSlot` function to SilentHotbar. For some weird reason, `getMainHandStack` gets called before `mc.player` gets initialized. If someone has a fix for this I would be happy to change it. If not I think it should be fine like this. It at least works now.

closes #1533 