### PR TITLE
Fix entity interpolation

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -201,6 +201,9 @@ fun Entity.interpolateCurrentPosition(tickDelta: Float): Vec3 {
 }
 
 fun Entity.interpolateCurrentRotation(tickDelta: Float): Rotation {
+    if(this.age == 0)
+        return this.rotation
+
     return Rotation(
         this.prevYaw + (this.yaw - this.prevYaw) * tickDelta,
         this.prevPitch + (this.pitch - this.prevPitch) * tickDelta,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -190,6 +190,9 @@ fun Box.squaredBoxedDistanceTo(otherPos: Vec3d): Double {
 }
 
 fun Entity.interpolateCurrentPosition(tickDelta: Float): Vec3 {
+    if(this.age == 0)
+        return Vec3(this.pos)
+
     return Vec3(
         this.lastRenderX + (this.x - this.lastRenderX) * tickDelta,
         this.lastRenderY + (this.y - this.lastRenderY) * tickDelta,


### PR DESCRIPTION
Don't want to interpolate if we don't know the previous position. Same applies to rotation.

If we do we get weird effects like it looking like they fly form 0 0 to the their real position in 1 tick