### PR TITLE
Fix rotation vector showing when it shoudn't

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -50,9 +50,11 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
     val renderHandler = handler<WorldRenderEvent> { event ->
         val matrixStack = event.matrixStack
 
-        if (!showRotationVector) {
+        if (!showRotationVector)
             return@handler
-        }
+        if(!shouldSendCustomRotation())
+            return@handler
+
 
         val serverRotation = RotationManager.serverRotation
         val camera = mc.gameRenderer.camera
@@ -74,7 +76,7 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
     fun shouldDisplayRotations() = shouldSendCustomRotation() || ModuleFreeCam.shouldDisableRotations()
 
     /**
-     * Should we even send a rotation if we use freeCam
+     * Should we even send a rotation if we use freeCam?
      */
     fun shouldSendCustomRotation(): Boolean {
         val special = arrayOf(ModuleDerp).any { it.enabled }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -52,11 +52,11 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
 
         if (!showRotationVector)
             return@handler
-        if(!shouldSendCustomRotation())
-            return@handler
 
 
-        val serverRotation = RotationManager.serverRotation
+
+
+        val rotation = RotationManager.currentRotation ?: return@handler
         val camera = mc.gameRenderer.camera
 
         val eyeVector = Vec3(0.0, 0.0, 1.0)
@@ -65,7 +65,7 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
 
         renderEnvironmentForWorld(matrixStack) {
             withColor(Color4b.WHITE) {
-                drawLineStrip(eyeVector, eyeVector + Vec3(serverRotation.rotationVec * 100.0))
+                drawLineStrip(eyeVector, eyeVector + Vec3(rotation.rotationVec * 100.0))
             }
         }
     }


### PR DESCRIPTION
Because it was using the server rotation, it would show a line even when you just rotated manually. This was a little annoying so I fixed it by using current rotation instead of server rotation. 