### PR TITLE
Big performance improvements in BlockEsp and StorageEsp

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -82,12 +82,15 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                 VertexInputType.Pos,
                 RenderBufferBuilder.TESSELATOR_A
             )
-            val outlinesRenderer: RenderBufferBuilder<VertexInputType.Pos> =
-                RenderBufferBuilder(
-                    VertexFormat.DrawMode.DEBUG_LINES,
-                    VertexInputType.Pos,
-                    RenderBufferBuilder.TESSELATOR_B
-                )
+            val outlinesRenderer =
+                if(outline)
+                    RenderBufferBuilder(
+                        VertexFormat.DrawMode.DEBUG_LINES,
+                        VertexInputType.Pos,
+                        RenderBufferBuilder.TESSELATOR_B
+                    )
+                else
+                    null
 
 
 
@@ -101,7 +104,7 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                             boxesRenderer.drawBox(this, box)
                             // This can still be optimized since there will be a lot of useless matrix muls...
 
-                            outlinesRenderer.drawBox(this, box)
+                            outlinesRenderer?.drawBox(this, box)
 
                         }
                     }
@@ -109,7 +112,9 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
 
                 withColor(baseColor) { boxesRenderer.draw() }
 
-                withColor(outlineColor) { outlinesRenderer.draw() }
+                if(outline) {
+                    withColor(outlineColor) { outlinesRenderer?.draw() }
+                }
 
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -104,7 +104,7 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                             boxesRenderer.drawBox(this, box)
                             // This can still be optimized since there will be a lot of useless matrix muls...
 
-                            outlinesRenderer?.drawBox(this, box)
+                            outlinesRenderer?.drawBox(this, box, true)
 
                         }
                     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -18,25 +18,24 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
-import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.config.Choice
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
-import net.ccbluex.liquidbounce.render.*
+import net.ccbluex.liquidbounce.render.BoxesRenderer
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.Vec3
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.utils.rainbow
+import net.ccbluex.liquidbounce.render.withPosition
 import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
 import net.ccbluex.liquidbounce.utils.block.ChunkScanner
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks
-import net.minecraft.client.render.VertexFormat
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
-import java.util.Collections
 
 /**
  * BlockESP module

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -72,7 +72,7 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
             val baseColor = base.alpha(50)
             val outlineColor = base.alpha(100)
 
-            val boxRenderer = boxesRenderer()
+            val boxRenderer = BoxesRenderer()
 
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -93,19 +93,19 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
 
             renderEnvironmentForWorld(matrixStack) {
 
-                    synchronized(BlockTracker.trackedBlockMap) {
-                        for (pos in BlockTracker.trackedBlockMap.keys) {
-                            val vec3 = Vec3(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble())
+                synchronized(BlockTracker.trackedBlockMap) {
+                    for (pos in BlockTracker.trackedBlockMap.keys) {
+                        val vec3 = Vec3(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble())
 
-                            withPosition(vec3) {
-                                boxesRenderer.drawBox(this, box)
-                                // This can still be optimized since there will be a lot of useless matrix muls...
+                        withPosition(vec3) {
+                            boxesRenderer.drawBox(this, box)
+                            // This can still be optimized since there will be a lot of useless matrix muls...
 
-                                outlinesRenderer.drawBox(this, box)
+                            outlinesRenderer.drawBox(this, box)
 
-                            }
                         }
                     }
+                }
 
                 withColor(baseColor) { boxesRenderer.draw() }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -72,25 +72,7 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
             val baseColor = base.alpha(50)
             val outlineColor = base.alpha(100)
 
-
-
-
-
-
-            val boxesRenderer = RenderBufferBuilder(
-                VertexFormat.DrawMode.QUADS,
-                VertexInputType.Pos,
-                RenderBufferBuilder.TESSELATOR_A
-            )
-            val outlinesRenderer =
-                if(outline)
-                    RenderBufferBuilder(
-                        VertexFormat.DrawMode.DEBUG_LINES,
-                        VertexInputType.Pos,
-                        RenderBufferBuilder.TESSELATOR_B
-                    )
-                else
-                    null
+            val boxRenderer = boxesRenderer()
 
 
 
@@ -101,20 +83,13 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                         val vec3 = Vec3(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble())
 
                         withPosition(vec3) {
-                            boxesRenderer.drawBox(this, box)
-                            // This can still be optimized since there will be a lot of useless matrix muls...
-
-                            outlinesRenderer?.drawBox(this, box, true)
+                            boxRenderer.drawBox(this, box, outline)
 
                         }
                     }
                 }
 
-                withColor(baseColor) { boxesRenderer.draw() }
-
-                if(outline) {
-                    withColor(outlineColor) { outlinesRenderer?.draw() }
-                }
+                boxRenderer.draw(this, baseColor, outlineColor)
 
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -77,11 +77,16 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                 VertexInputType.Pos,
                 RenderBufferBuilder.TESSELATOR_A
             )
-            val outlinesRenderer = RenderBufferBuilder(
-                VertexFormat.DrawMode.DEBUG_LINES,
-                VertexInputType.Pos,
-                RenderBufferBuilder.TESSELATOR_B
-            )
+            val outlinesRenderer =
+                if(outline)
+                    RenderBufferBuilder(
+                        VertexFormat.DrawMode.DEBUG_LINES,
+                        VertexInputType.Pos,
+                        RenderBufferBuilder.TESSELATOR_C
+                    )
+                else
+                    null
+
 
             renderEnvironmentForWorld(matrixStack) {
                 for (pos in markedBlocks) {
@@ -90,13 +95,17 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                     withPosition(vec3) {
                         boxesRenderer.drawBox(this, box)
                         // This can still be optimized since there will be a lot of useless matrix muls...
-                        outlinesRenderer.drawBox(this, box)
+                        if(outline) {
+                            outlinesRenderer!!.drawBox(this, box)
+                        }
                     }
                 }
 
                 withColor(baseColor) { boxesRenderer.draw() }
 
-                withColor(outlineColor) { outlinesRenderer.draw() }
+                if(outline) {
+                    withColor(outlineColor) { outlinesRenderer!!.draw() }
+                }
 
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -94,13 +94,9 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                     }
                 }
 
-                withColor(baseColor) {
-                    boxesRenderer.draw()
-                }
+                withColor(baseColor) { boxesRenderer.draw() }
 
-                withColor(outlineColor) {
-                    outlinesRenderer.draw()
-                }
+                withColor(outlineColor) { outlinesRenderer.draw() }
 
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.config.Choice
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.WorldRenderEvent
@@ -51,7 +52,6 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
 
     private val color by color("Color", Color4b(255, 179, 72, 255))
     private val colorRainbow by boolean("Rainbow", false)
-    val markedBlocks = Collections.synchronizedSet(BlockTracker.trackedBlockMap.keys)
 
     private object Box : Choice("Box") {
         override val parent: ChoiceConfigurable
@@ -74,6 +74,9 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
 
 
 
+
+
+
             val boxesRenderer = RenderBufferBuilder(
                 VertexFormat.DrawMode.QUADS,
                 VertexInputType.Pos,
@@ -87,27 +90,30 @@ object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
                 )
 
 
+
             renderEnvironmentForWorld(matrixStack) {
 
-                synchronized(markedBlocks) {
-                    for (pos in markedBlocks) {
-                        val vec3 = Vec3(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble())
+                    synchronized(BlockTracker.trackedBlockMap) {
+                        for (pos in BlockTracker.trackedBlockMap.keys) {
+                            val vec3 = Vec3(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble())
 
-                        withPosition(vec3) {
-                            boxesRenderer.drawBox(this, box)
-                            // This can still be optimized since there will be a lot of useless matrix muls...
+                            withPosition(vec3) {
+                                boxesRenderer.drawBox(this, box)
+                                // This can still be optimized since there will be a lot of useless matrix muls...
 
-                            outlinesRenderer.drawBox(this, box)
+                                outlinesRenderer.drawBox(this, box)
 
+                            }
                         }
                     }
-                }
-
-
 
                 withColor(baseColor) { boxesRenderer.draw() }
 
                 withColor(outlineColor) { outlinesRenderer.draw() }
+
+
+
+
 
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -66,7 +66,7 @@ object ModuleItemESP : Module("ItemESP", Category.RENDER) {
 
             val filtered = world.entities.filter { it is ItemEntity || it is ArrowEntity }
 
-            val boxRenderer = boxesRenderer()
+            val boxRenderer = BoxesRenderer()
 
             renderEnvironmentForWorld(matrixStack) {
                 for (entity in filtered) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -84,7 +84,7 @@ object ModuleItemESP : Module("ItemESP", Category.RENDER) {
                     withPosition(pos) {
                         boxesRenderer.drawBox(this, box)
                         // This can still be optimized since there will be a lot of useless matrix muls...
-                        outlinesRenderer.drawBox(this, box)
+                        outlinesRenderer.drawBox(this, box, true)
                     }
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -66,35 +66,21 @@ object ModuleItemESP : Module("ItemESP", Category.RENDER) {
 
             val filtered = world.entities.filter { it is ItemEntity || it is ArrowEntity }
 
-            val boxesRenderer = RenderBufferBuilder(
-                VertexFormat.DrawMode.QUADS,
-                VertexInputType.Pos,
-                RenderBufferBuilder.TESSELATOR_A
-            )
-            val outlinesRenderer = RenderBufferBuilder(
-                VertexFormat.DrawMode.DEBUG_LINES,
-                VertexInputType.Pos,
-                RenderBufferBuilder.TESSELATOR_B
-            )
+            val boxRenderer = boxesRenderer()
 
             renderEnvironmentForWorld(matrixStack) {
                 for (entity in filtered) {
                     val pos = entity.interpolateCurrentPosition(event.partialTicks).toVec3()
 
                     withPosition(pos) {
-                        boxesRenderer.drawBox(this, box)
-                        // This can still be optimized since there will be a lot of useless matrix muls...
-                        outlinesRenderer.drawBox(this, box, true)
+                        boxRenderer.drawBox(this, box, true)
                     }
                 }
 
-                withColor(baseColor) {
-                    boxesRenderer.draw()
-                }
 
-                withColor(outlineColor) {
-                    outlinesRenderer.draw()
-                }
+                boxRenderer.draw(this, baseColor, outlineColor)
+
+
             }
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -24,12 +24,13 @@ import net.ccbluex.liquidbounce.event.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
-import net.ccbluex.liquidbounce.render.*
+import net.ccbluex.liquidbounce.render.BoxesRenderer
 import net.ccbluex.liquidbounce.render.engine.Color4b
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.utils.rainbow
+import net.ccbluex.liquidbounce.render.withPosition
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.math.toVec3
-import net.minecraft.client.render.VertexFormat
 import net.minecraft.entity.ItemEntity
 import net.minecraft.entity.projectile.ArrowEntity
 import net.minecraft.util.math.Box

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -68,30 +68,34 @@ object ModuleStorageESP : Module("StorageESP", Category.RENDER) {
         // todo: use box of block, not hardcoded
         private val box = Box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
 
+
+
+
         val renderHandler = handler<WorldRenderEvent> { event ->
             val matrixStack = event.matrixStack
-            val blocksToRender = locations.entries.filter { it.value.shouldRender(it.key) }
+            val blocksToRender =
+                locations.entries.filter { it.value.shouldRender(it.key) }
+                    .groupBy {it.value}
+
 
             renderEnvironmentForWorld(matrixStack) {
-                for ((pos, type) in blocksToRender) {
+
+                for ((type, blocks) in blocksToRender) {
+                    val boxRenderer = BoxesRenderer()
+
                     val color = type.color
-
-                    val vec3 = Vec3(pos)
-
                     val baseColor = color.alpha(50)
                     val outlineColor = color.alpha(100)
 
-                    withPosition(vec3) {
-                        withColor(baseColor) {
-                            drawSolidBox(box)
-                        }
+                    for ((pos, _) in blocks) {
+                        val vec3 = Vec3(pos)
 
-                        if (outline) {
-                            withColor(outlineColor) {
-                                drawOutlinedBox(box)
-                            }
+                        withPosition(vec3) {
+                            boxRenderer.drawBox(this, box, outline)
                         }
                     }
+
+                    boxRenderer.draw(this, baseColor, outlineColor)
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -94,6 +94,7 @@ class RenderBufferBuilder<I: VertexInputType>(
         val TESSELATOR_A: Tessellator = Tessellator(0x200000)
         val TESSELATOR_B: Tessellator = Tessellator(0x200000)
         val TESSELATOR_C: Tessellator = Tessellator(0x200000)
+        val TESSELATOR_D: Tessellator = Tessellator(0x200000)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -125,8 +125,6 @@ class RenderBufferBuilder<I: VertexInputType>(
     companion object {
         val TESSELATOR_A: Tessellator = Tessellator(0x200000)
         val TESSELATOR_B: Tessellator = Tessellator(0x200000)
-        val TESSELATOR_C: Tessellator = Tessellator(0x200000)
-        val TESSELATOR_D: Tessellator = Tessellator(0x200000)
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -134,12 +134,11 @@ class BoxesRenderer() {
         VertexInputType.Pos,
         RenderBufferBuilder.TESSELATOR_A
     )
-    private val outlinesRenderer =
-        RenderBufferBuilder(
+    private val outlinesRenderer = RenderBufferBuilder(
             DrawMode.DEBUG_LINES,
             VertexInputType.Pos,
             RenderBufferBuilder.TESSELATOR_B
-        )
+    )
 
     fun drawBox(env: RenderEnvironment, box: Box, outline: Boolean) {
         boxesRenderer.drawBox(env, box)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -3,18 +3,12 @@
 package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.systems.RenderSystem
-import it.unimi.dsi.fastutil.booleans.BooleanObjectImmutablePair
-import net.ccbluex.liquidbounce.features.module.modules.render.ModuleBlockESP
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.UV2f
 import net.ccbluex.liquidbounce.render.engine.Vec3
 import net.minecraft.client.gl.ShaderProgram
-import net.minecraft.client.render.BufferBuilder
-import net.minecraft.client.render.GameRenderer
-import net.minecraft.client.render.Tessellator
-import net.minecraft.client.render.VertexFormat
+import net.minecraft.client.render.*
 import net.minecraft.client.render.VertexFormat.DrawMode
-import net.minecraft.client.render.VertexFormats
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -129,7 +129,7 @@ class RenderBufferBuilder<I: VertexInputType>(
 }
 
 class BoxesRenderer() {
-    private val boxesRenderer = RenderBufferBuilder(
+    private val faceRenderer = RenderBufferBuilder(
         DrawMode.QUADS,
         VertexInputType.Pos,
         RenderBufferBuilder.TESSELATOR_A
@@ -141,7 +141,7 @@ class BoxesRenderer() {
     )
 
     fun drawBox(env: RenderEnvironment, box: Box, outline: Boolean) {
-        boxesRenderer.drawBox(env, box)
+        faceRenderer.drawBox(env, box)
         // This can still be optimized since there will be a lot of useless matrix muls...
         if(outline) {
             outlinesRenderer.drawBox(env, box, true)
@@ -150,7 +150,7 @@ class BoxesRenderer() {
 
     fun draw(env: RenderEnvironment, boxColor: Color4b, outlineColor: Color4b) {
         env.withColor(boxColor) {
-            boxesRenderer.draw()
+            faceRenderer.draw()
         }
         env.withColor(outlineColor) {
             outlinesRenderer.draw()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -3,6 +3,7 @@
 package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.systems.RenderSystem
+import it.unimi.dsi.fastutil.booleans.BooleanObjectImmutablePair
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.UV2f
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -38,11 +39,17 @@ class RenderBufferBuilder<I: VertexInputType>(
      *
      * @param box The bounding box of the box.
      */
-    fun drawBox(env: RenderEnvironment, box: Box) {
+    fun drawBox(env: RenderEnvironment, box: Box, useOutlineVertices: Boolean = false) {
         val matrix = env.currentMvpMatrix
 
+        val vertexPositions =
+            if(useOutlineVertices)
+                boxOutlineVertexPositions(box)
+            else
+                boxVertexPositions(box)
+
         // Draw the vertices of the box
-        boxVertexPositions(box).forEach { (x, y, z) ->
+        vertexPositions.forEach { (x, y, z) ->
             bufferBuilder.vertex(matrix, x, y, z).next()
         }
     }
@@ -71,6 +78,36 @@ class RenderBufferBuilder<I: VertexInputType>(
             Vec3(box.minX, box.maxY, box.maxZ),
             Vec3(box.minX, box.minY, box.minZ),
             Vec3(box.minX, box.minY, box.maxZ),
+            Vec3(box.minX, box.maxY, box.maxZ),
+            Vec3(box.minX, box.maxY, box.minZ)
+        )
+        return vertices
+    }
+
+    private fun boxOutlineVertexPositions(box: Box): List<Vec3> {
+        val vertices = listOf(
+            Vec3(box.minX, box.minY, box.minZ),
+            Vec3(box.maxX, box.minY, box.minZ),
+            Vec3(box.maxX, box.minY, box.minZ),
+            Vec3(box.maxX, box.minY, box.maxZ),
+            Vec3(box.maxX, box.minY, box.maxZ),
+            Vec3(box.minX, box.minY, box.maxZ),
+            Vec3(box.minX, box.minY, box.maxZ),
+            Vec3(box.minX, box.minY, box.minZ),
+            Vec3(box.minX, box.minY, box.minZ),
+            Vec3(box.minX, box.maxY, box.minZ),
+            Vec3(box.maxX, box.minY, box.minZ),
+            Vec3(box.maxX, box.maxY, box.minZ),
+            Vec3(box.maxX, box.minY, box.maxZ),
+            Vec3(box.maxX, box.maxY, box.maxZ),
+            Vec3(box.minX, box.minY, box.maxZ),
+            Vec3(box.minX, box.maxY, box.maxZ),
+            Vec3(box.minX, box.maxY, box.minZ),
+            Vec3(box.maxX, box.maxY, box.minZ),
+            Vec3(box.maxX, box.maxY, box.minZ),
+            Vec3(box.maxX, box.maxY, box.maxZ),
+            Vec3(box.maxX, box.maxY, box.maxZ),
+            Vec3(box.minX, box.maxY, box.maxZ),
             Vec3(box.minX, box.maxY, box.maxZ),
             Vec3(box.minX, box.maxY, box.minZ)
         )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -93,6 +93,7 @@ class RenderBufferBuilder<I: VertexInputType>(
     companion object {
         val TESSELATOR_A: Tessellator = Tessellator(0x200000)
         val TESSELATOR_B: Tessellator = Tessellator(0x200000)
+        val TESSELATOR_C: Tessellator = Tessellator(0x200000)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -136,7 +136,7 @@ class RenderBufferBuilder<I: VertexInputType>(
     }
 }
 
-class boxesRenderer() {
+class BoxesRenderer() {
     private val boxesRenderer = RenderBufferBuilder(
         DrawMode.QUADS,
         VertexInputType.Pos,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -4,6 +4,7 @@ package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.systems.RenderSystem
 import it.unimi.dsi.fastutil.booleans.BooleanObjectImmutablePair
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleBlockESP
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.UV2f
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -132,6 +133,37 @@ class RenderBufferBuilder<I: VertexInputType>(
         val TESSELATOR_B: Tessellator = Tessellator(0x200000)
         val TESSELATOR_C: Tessellator = Tessellator(0x200000)
         val TESSELATOR_D: Tessellator = Tessellator(0x200000)
+    }
+}
+
+class boxesRenderer() {
+    private val boxesRenderer = RenderBufferBuilder(
+        DrawMode.QUADS,
+        VertexInputType.Pos,
+        RenderBufferBuilder.TESSELATOR_A
+    )
+    private val outlinesRenderer =
+        RenderBufferBuilder(
+            DrawMode.DEBUG_LINES,
+            VertexInputType.Pos,
+            RenderBufferBuilder.TESSELATOR_B
+        )
+
+    fun drawBox(env: RenderEnvironment, box: Box, outline: Boolean) {
+        boxesRenderer.drawBox(env, box)
+        // This can still be optimized since there will be a lot of useless matrix muls...
+        if(outline) {
+            outlinesRenderer.drawBox(env, box, true)
+        }
+    }
+
+    fun draw(env: RenderEnvironment, boxColor: Color4b, outlineColor: Color4b) {
+        env.withColor(boxColor) {
+            boxesRenderer.draw()
+        }
+        env.withColor(outlineColor) {
+            outlinesRenderer.draw()
+        }
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -128,7 +128,7 @@ class RenderBufferBuilder<I: VertexInputType>(
     }
 }
 
-class BoxesRenderer() {
+class BoxesRenderer {
     private val faceRenderer = RenderBufferBuilder(
         DrawMode.QUADS,
         VertexInputType.Pos,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -148,8 +148,8 @@ class BoxesRenderer() {
         }
     }
 
-    fun draw(env: RenderEnvironment, boxColor: Color4b, outlineColor: Color4b) {
-        env.withColor(boxColor) {
+    fun draw(env: RenderEnvironment, faceColor: Color4b, outlineColor: Color4b) {
+        env.withColor(faceColor) {
             faceRenderer.draw()
         }
         env.withColor(outlineColor) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AbstractBlockLocationTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AbstractBlockLocationTracker.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.utils.block
 
 import net.minecraft.block.BlockState
 import net.minecraft.util.math.BlockPos
+import java.util.Collections
 
 /**
  * Tracks locations of specific blocks in the world
@@ -29,7 +30,7 @@ import net.minecraft.util.math.BlockPos
  */
 abstract class AbstractBlockLocationTracker<T> : ChunkScanner.BlockChangeSubscriber {
 
-    val trackedBlockMap = hashMapOf<TargetBlockPos, T>()
+    val trackedBlockMap: MutableMap<TargetBlockPos, T> = Collections.synchronizedMap(hashMapOf<TargetBlockPos, T>())
 
 
     abstract fun getStateFor(pos: BlockPos, state: BlockState): T?


### PR DESCRIPTION
Went from 17 fps to 60+ fps

Thanks to @superblaubeere27 for showing this way more performant way to render things.

Interestingly, it also closes #1399

It also fixes a small visual bug in itemEsp where the outline would look weird

I am now getting 108 fps whilst rendering this:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/ee73d0c7-a633-47aa-a04e-693074f8d244)

which means that I lose about 2-6 fps on rendering it

And don't worry, we keep storageEsp's pretty colors:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/f415cb51-2f79-4946-9db7-8dec64195bfa)

