### PR TITLE
Added new Custom mode to NoFov

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
@@ -13,6 +13,7 @@ public abstract class MixinAbstractClientPlayerEntity {
     @Inject(method = "getFovMultiplier", cancellable = true, at = @At("HEAD"))
     private void injectFovMultiplier(CallbackInfoReturnable<Float> cir) {
         if (ModuleNoFov.INSTANCE.getEnabled())
-            cir.setReturnValue(ModuleNoFov.INSTANCE.getFov());
+
+            cir.setReturnValue(ModuleNoFov.INSTANCE.getNewFov(cir.getReturnValue()));
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
@@ -10,10 +10,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(AbstractClientPlayerEntity.class)
 public abstract class MixinAbstractClientPlayerEntity {
 
-    @Inject(method = "getFovMultiplier", cancellable = true, at = @At("HEAD"))
+    @Inject(method = "getFovMultiplier", cancellable = true, at = @At("RETURN"))
     private void injectFovMultiplier(CallbackInfoReturnable<Float> cir) {
         if (ModuleNoFov.INSTANCE.getEnabled())
-
-            cir.setReturnValue(ModuleNoFov.INSTANCE.getNewFov(cir.getReturnValue()));
+            cir.setReturnValue(ModuleNoFov.INSTANCE.getFov(cir.getReturnValue()));
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
@@ -41,9 +41,9 @@ object ModuleNoFov : Module("NoFOV", Category.RENDER) {
     }
 
     object Custom : FovMode("Custom") {
-        private val BaseFOV by float("BaseFOV", 1f, 0f..1.5f)
-        val limit by floatRange("Limit", 0f..1.5f, 0f..1.5f)
-        val multiplier by float("Multiplier", 1f, 0.1f..1.5f)
+        private val baseFOV by float("BaseFOV", 1f, 0f..1.5f)
+        private val limit by floatRange("Limit", 0f..1.5f, 0f..1.5f)
+        private val multiplier by float("Multiplier", 1f, 0.1f..1.5f)
         override fun getFov(orig: Float): Float {
             val newFov = (orig - 1) * multiplier + BaseFOV
             return newFov.coerceIn(limit)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.features.module.Module
  */
 
 object ModuleNoFov : Module("NoFOV", Category.RENDER) {
-    val mode = choices("Mode", ConstantFov, arrayOf(ConstantFov, LimitFov, AmplifyFov))
+    val mode = choices("Mode", ConstantFov, arrayOf(ConstantFov, Custom))
 
     fun getFov(orig: Float) = (mode.activeChoice as FovMode).getFov(orig)
 
@@ -40,16 +40,14 @@ object ModuleNoFov : Module("NoFOV", Category.RENDER) {
         override fun getFov(orig: Float) = fov
     }
 
-    object LimitFov : FovMode("Limit") {
-        private val fovRange by floatRange("FOVRange", 0.9f..1.1f, 0f..1.5f)
-        override fun getFov(orig: Float) = orig.coerceIn(fovRange)
-    }
-
-    object AmplifyFov : FovMode("Amplify") {
-        private val multiplier by float("Multiplier", 0.9f, 0.1f..2.5f)
-
-        override fun getFov(orig: Float) = orig * multiplier
-
+    object Custom : FovMode("Custom") {
+        private val BaseFOV by float("BaseFOV", 1f, 0f..1.5f)
+        val limit by floatRange("Limit", 0f..1.5f, 0f..1.5f)
+        val multiplier by float("Multiplier", 1f, 0.1f..1.5f)
+        override fun getFov(orig: Float): Float {
+            val newFov = (orig - 1) * multiplier + BaseFOV
+            return newFov.coerceIn(limit)
+        }
     }
 
     abstract class FovMode(name: String) : Choice(name) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
@@ -41,11 +41,11 @@ object ModuleNoFov : Module("NoFOV", Category.RENDER) {
     }
 
     object Custom : FovMode("Custom") {
-        private val baseFOV by float("BaseFOV", 1f, 0f..1.5f)
+        private val baseFov by float("BaseFOV", 1f, 0f..1.5f)
         private val limit by floatRange("Limit", 0f..1.5f, 0f..1.5f)
         private val multiplier by float("Multiplier", 1f, 0.1f..1.5f)
         override fun getFov(orig: Float): Float {
-            val newFov = (orig - 1) * multiplier + BaseFOV
+            val newFov = (orig - 1) * multiplier + baseFov
             return newFov.coerceIn(limit)
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
@@ -18,6 +18,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import net.ccbluex.liquidbounce.config.Choice
+import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 
@@ -28,5 +30,31 @@ import net.ccbluex.liquidbounce.features.module.Module
  */
 
 object ModuleNoFov : Module("NoFOV", Category.RENDER) {
-    val fov by float("FOV", 1f, 0f..1.5f)
+    val mode = choices("Mode", ConstantFov, arrayOf(ConstantFov, LimitFov, AmplifyFov))
+
+    fun getFov(orig: Float) = (mode.activeChoice as FovMode).getFov(orig)
+
+
+    object ConstantFov : FovMode("Constant") {
+        private val fov by float("FOV", 1f, 0f..1.5f)
+        override fun getFov(orig: Float) = fov
+    }
+
+    object LimitFov : FovMode("Limit") {
+        private val fovRange by floatRange("FOVRange", 0.9f..1.1f, 0f..1.5f)
+        override fun getFov(orig: Float) = orig.coerceIn(fovRange)
+    }
+
+    object AmplifyFov : FovMode("Amplify") {
+        private val multiplier by float("Multiplier", 0.9f, 0.1f..2.5f)
+
+        override fun getFov(orig: Float) = orig * multiplier
+
+    }
+
+    abstract class FovMode(name: String) : Choice(name) {
+        override val parent: ChoiceConfigurable
+            get() = mode
+        open fun getFov(orig: Float) = orig
+    }
 }


### PR DESCRIPTION
Very nice if you like the FOV effects, but you just don't want to get "blinded" by speed potions

The module should possibly be renamed to just FOV, now that it doesn't necessarily completely disable the fov but just changes it

This config will make the fov effects slightly less noticeable and make it so they won't go into the extreme:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/455a384b-b4d7-4bdb-89e7-314fc36fc7a8)
