### PR TITLE
Make overlay target renderer's arrow default size smaller

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
@@ -288,7 +288,7 @@ class OverlayTargetRenderer(module: Module) : TargetRenderer(module) {
             get() = appearance
 
         private val color by color("Color", Color4b.RED)
-        private val size by float("Size", 5f, 1f..20f)
+        private val size by float("Size", 1f, 0.5f..20f)
         override fun render(env: RenderEnvironment, entity: Entity, partialTicks: Float) {
 
             val pos =

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
@@ -288,7 +288,7 @@ class OverlayTargetRenderer(module: Module) : TargetRenderer(module) {
             get() = appearance
 
         private val color by color("Color", Color4b.RED)
-        private val size by float("Size", 1f, 0.5f..20f)
+        private val size by float("Size", 1.5f, 0.5f..20f)
         override fun render(env: RenderEnvironment, entity: Entity, partialTicks: Float) {
 
             val pos =


### PR DESCRIPTION
Very small change that just changes the default sizes of the arrows being used by autoBow

Before:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/440bceb9-8d27-4756-9c8e-013269b74556)
After:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/4953aa9c-f817-46d9-bcdb-e483b2c17ed2)
