### PR TITLE
Add shadow setting to clickgui

### DIFF
--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -2,7 +2,7 @@
     import Panel from "./clickgui/Panel.svelte";
     import SearchBar from "./SearchBar.svelte";
 
-    import { listen } from "../../client/ws.svelte";
+    
     import { getModules, toggleModule, getClickGuiOptions } from "../../client/api.svelte";
     import {fade, blur} from "svelte/transition";
 
@@ -59,7 +59,8 @@
         textColor: "#ffffff",
         textDimmed: "rgba(211,211,211,255)",
         searchAlwaysOnTop: true,
-        autoFocus: true
+        autoFocus: true,
+        shadow: true
     };
 
     getClickGuiOptions().then(opts => {
@@ -77,9 +78,9 @@
         --accent-dimmed: {options.accentColor};
         --text: {options.textColor};
         --textdimmed: {options.textDimmed};">
-            <SearchBar settings={options} modules={modules} listen={listen} toggleModule={toggleModule} />
+            <SearchBar settings={options} {modules} toggleModule={toggleModule} />
             {#each panels as panel}
-                <Panel name={panel.name} modules={panel.modules} listen={listen} toggleModule={toggleModule} startTop={panel.top}
+                <Panel name={panel.name} modules={panel.modules} settings={options} toggleModule={toggleModule} startTop={panel.top}
                        startLeft={panel.left}/>
             {/each}
         </div>
@@ -98,5 +99,9 @@
         -ms-user-select: none;
         user-select: none;
         cursor: default;
+    }
+
+    :global(.clickgui-shadow) {
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     }
 </style>

--- a/src-theme/src/routes/clickgui/SearchBar.svelte
+++ b/src-theme/src/routes/clickgui/SearchBar.svelte
@@ -1,7 +1,7 @@
 <script>
     export let settings;
     export let modules;
-    export let listen;
+    import { listen } from "../../client/ws.svelte";
 
     export let toggleModule;
 
@@ -142,7 +142,7 @@
 </script>
 
 {#if visible}
-    <div class="search-bar" on:keydown={handleKeyDown}>
+    <div class="search-bar" class:shadow={settings.shadow} on:keydown={handleKeyDown}>
         <div class="search-bar-input-container">
             <input bind:value type="text" placeholder="Search" on:input={onInput} autofocus={autofocus}>
         </div>
@@ -190,11 +190,14 @@
         height: 50px;
         padding: 10px 20px;
         transition: all 0.2s ease-in-out;
-        box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
         backdrop-filter: blur(4px);
 
         &:not(:placeholder-shown) {
           border-radius: 10px 10px 0 0;
+        }
+
+        &:shadow {
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
         }
       }
     }

--- a/src-theme/src/routes/clickgui/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/clickgui/Panel.svelte
@@ -2,19 +2,19 @@
     import {sineInOut} from "svelte/easing";
     import {slide} from "svelte/transition";
     import Module from "./Module.svelte";
+    import { listen } from "../../../client/ws.svelte";
 
     export let name;
     export let modules;
 
-    export let listen;
+    export let settings
+
     export let toggleModule;
 
     export let startTop;
     export let startLeft;
 
     let expanded = localStorage.getItem(`clickgui.panel.${name}.expanded`) === "true" || false;
-
-    let renderedModules = expanded ? modules : [];
 
     let top = parseInt(localStorage.getItem(`clickgui.panel.${name}.top`)) || startTop;
     let left = parseInt(localStorage.getItem(`clickgui.panel.${name}.left`)) || startLeft;
@@ -57,13 +57,7 @@
     }
 
     function toggleExpanded(e) {
-        if (expanded) {
-            expanded = false;
-            renderedModules = [];
-        } else {
-            expanded = true;
-            renderedModules = modules;
-        }
+        expanded = !expanded
         localStorage.setItem(`clickgui.panel.${name}.expanded`, expanded);
     }
 
@@ -79,9 +73,7 @@
             return;
 
         mod.enabled = moduleEnabled;
-        if (expanded) {
-            renderedModules = modules;
-        }
+        modules = modules
     }
 
     function handleToggleClick(event) {
@@ -93,18 +85,20 @@
     listen("toggleModule", handleToggleModule);
 </script>
 
-<div class="panel" style="left: {left}px; top: {top}px;">
+<div class="panel" class:clickgui-shadow={settings.shadow} style="left: {left}px; top: {top}px;">
     <div on:mousedown={handleToggleClick} on:mousedown={onMouseDown} class="title-wrapper">
         <img class="icon" src="img/{name.toLowerCase()}.svg" alt="icon"/>
         <div class="title">{name}</div>
         <div on:click={toggleExpanded} class="visibility-toggle" class:expanded={expanded}></div>
     </div>
     <div class="modules">
-        {#each renderedModules as m}
-            <div transition:slide={{duration: 400, easing: sineInOut}}>
-                <Module name={m.name} enabled={m.enabled} toggleModule={toggleModule} />
-            </div>
-        {/each}
+        {#if expanded}
+           {#each modules as m}
+               <div transition:slide={{duration: 400, easing: sineInOut}}>
+                   <Module name={m.name} enabled={m.enabled} toggleModule={toggleModule} />
+               </div>
+           {/each}
+        {/if}
     </div>
 </div>
 
@@ -115,7 +109,6 @@
     width: 225px;
     position: absolute;
     backdrop-filter: blur(4px);
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   }
 
   .title-wrapper {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -55,7 +55,7 @@ object ModuleClickGui : Module("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY
             addProperty("searchAlwaysOnTop", searchAlwaysOnTop)
             addProperty("autoFocus", searchAutoFocus)
             addProperty("shadow", shadow)
-    }
+        }
 
     override fun enable() {
         // Pretty sure we are not in a game, so we can't open the clickgui

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -19,6 +19,7 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import com.google.gson.JsonObject
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
@@ -35,13 +36,26 @@ import org.lwjgl.glfw.GLFW
 object ModuleClickGui : Module("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY_RIGHT_SHIFT, disableActivation = true) {
 
     // Specifies whether the search bar should always be visible or only after pressing Ctrl + F.
-    val searchAlwaysOnTop by boolean("SearchAlwaysOnTop", true)
-    val searchAutoFocus by boolean("SearchAutoFocus", true)
-    val moduleColor by color("ModuleColor", Color4b(0, 0, 0, 127)) // rgba(0, 0, 0, 0.5)
-    val headerColor by color("HeaderColor", Color4b(0, 0, 0, 173)) // rgba(0, 0, 0, 0.68)
-    val accentColor by color("AccentColor", Color4b(70, 119, 255, 255)) // #4677ff
-    val textColor by color("TextColor", Color4b(255, 255, 255, 255)) // White
-    val dimmedTextColor by color("DimmedTextColor", Color4b(211, 211, 211, 255)) // lightgrey
+    private val searchAlwaysOnTop by boolean("SearchAlwaysOnTop", true)
+    private val searchAutoFocus by boolean("SearchAutoFocus", true)
+    private val shadow by boolean("Shadow", true)
+    private val moduleColor by color("ModuleColor", Color4b(0, 0, 0, 127)) // rgba(0, 0, 0, 0.5)
+    private val headerColor by color("HeaderColor", Color4b(0, 0, 0, 173)) // rgba(0, 0, 0, 0.68)
+    private val accentColor by color("AccentColor", Color4b(70, 119, 255, 255)) // #4677ff
+    private val textColor by color("TextColor", Color4b(255, 255, 255, 255)) // White
+    private val dimmedTextColor by color("DimmedTextColor", Color4b(211, 211, 211, 255)) // lightgrey
+
+    fun settingsAsJson() =
+         JsonObject().apply {
+            addProperty("modulesColor", moduleColor.toHex(true))
+            addProperty("headerColor", headerColor.toHex(true))
+            addProperty("accentColor", accentColor.toHex(true))
+            addProperty("textColor", textColor.toHex(true))
+            addProperty("textDimmed", dimmedTextColor.toHex(true))
+            addProperty("searchAlwaysOnTop", searchAlwaysOnTop)
+            addProperty("autoFocus", searchAutoFocus)
+            addProperty("shadow", shadow)
+    }
 
     override fun enable() {
         // Pretty sure we are not in a game, so we can't open the clickgui

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/client/module/ModuleEndpoints.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/client/module/ModuleEndpoints.kt
@@ -83,15 +83,7 @@ internal fun RestNode.setupOptions() {
     get("/options/clickgui") {
         val clickGui = ModuleClickGui
 
-        httpOk(JsonObject().apply {
-            addProperty("modulesColor", clickGui.moduleColor.toHex(true))
-            addProperty("headerColor", clickGui.headerColor.toHex(true))
-            addProperty("accentColor", clickGui.accentColor.toHex(true))
-            addProperty("textColor", clickGui.textColor.toHex(true))
-            addProperty("textDimmed", clickGui.dimmedTextColor.toHex(true))
-            addProperty("searchAlwaysOnTop", clickGui.searchAlwaysOnTop)
-            addProperty("autoFocus", clickGui.searchAutoFocus)
-        })
+        httpOk(clickGui.settingsAsJson())
     }
 }
 


### PR DESCRIPTION
This setting enables and disables the rendering of shadows behind the panels and the search bar.

Other things that this PR changes:
- Imports the listen function separately inside the pan [SearchBar.svelte](https://github.com/CCBlueX/LiquidBounce/compare/nextgen...Ell1ott:LiquidBounce:shadow-setting?expand=1#diff-8c64e4c447ca612e3bb0c3be4f1226ff9249be9802b8ef0cd0f7fe0552e0f3d2) and [Panel.svelte](https://github.com/CCBlueX/LiquidBounce/compare/nextgen...Ell1ott:LiquidBounce:shadow-setting?expand=1#diff-94140a9b549df322825a0f800e2092eecf5b540282349ff5a47e07cdf7fbeb61)
- Moves the conversion of the click GUI settings to JSON settings into the [ModuleClickGui.kt](https://github.com/CCBlueX/LiquidBounce/compare/nextgen...Ell1ott:LiquidBounce:shadow-setting?expand=1#diff-ecf16cc1878674a3ba78bf5b000cb7e37605194220d9b84c199849f13bb6dbe1), to make it faster to add new settings, by reducing the amount of files that need changing
- Cleans up some of the svelte logic

![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/a1ec440e-1576-4d71-bb67-3ee80961dafa)

Enabled:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/77712caa-c43f-4a5a-9226-2ad2bab98c02)
Disabled:
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/12d88146-6487-4b63-a949-4e568de0e629)
