### PR TITLE
LEGACY: Added noPackets option to Sprint module and improved Freeze module

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
@@ -61,7 +61,7 @@ object AutoPot : Module("AutoPot", ModuleCategory.COMBAT) {
                 if (potionInHotbar != null && thePlayer.health <= health) {
                     if (thePlayer.onGround) {
                         when (mode.lowercase()) {
-                            "jump" -> thePlayer.jump()
+                            "jump" -> thePlayer.tryJump()
                             "port" -> thePlayer.moveEntity(0.0, 0.42, 0.0)
                         }
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
@@ -16,6 +16,7 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.Rotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.serverRotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.inventory.InventoryUtils
 import net.ccbluex.liquidbounce.utils.inventory.InventoryUtils.serverOpenInventory
 import net.ccbluex.liquidbounce.utils.inventory.isSplashPotion

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -39,12 +39,12 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
 
     override fun onEnable() {
         if (mode == "NoGround")
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
     }
 
     private fun verusJump() {
         mc.thePlayer.isInWeb = true
-        mc.thePlayer.jump()
+        mc.thePlayer.tryJump()
         mc.thePlayer.prevPosY = mc.thePlayer.posY
 
         mc.thePlayer.isInWeb = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -15,6 +15,7 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.extensions.component1
 import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.timing.MSTimer
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.IntegerValue

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TeleportHit.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TeleportHit.java
@@ -65,7 +65,7 @@ public class TeleportHit extends Module {
                 shouldHit = false;
                 targetEntity = null;
             } else if (thePlayer.onGround)
-                thePlayer.jump();
+                thePlayer.tryJump();
         } else
             shouldHit = false;
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TeleportHit.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TeleportHit.java
@@ -65,7 +65,7 @@ public class TeleportHit extends Module {
                 shouldHit = false;
                 targetEntity = null;
             } else if (thePlayer.onGround)
-                thePlayer.tryJump();
+                thePlayer.jump();
         } else
             shouldHit = false;
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.Speed
 import net.ccbluex.liquidbounce.utils.MovementUtils.isOnGround
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
 import net.ccbluex.liquidbounce.utils.extensions.toDegrees
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextInt
 import net.ccbluex.liquidbounce.utils.realMotionX
 import net.ccbluex.liquidbounce.utils.realMotionY

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Velocity.kt
@@ -327,7 +327,7 @@ object Velocity : Module("Velocity", ModuleCategory.COMBAT) {
 
         if (mode == "Jump" && hasReceivedVelocity) {
             if (!player.isJumping && nextInt(endExclusive = 100) < chance && shouldJump() && player.isSprinting && player.onGround && player.hurtTime == 9) {
-                player.jump()
+                player.tryJump()
                 limitUntilJump = 0
             }
             hasReceivedVelocity = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ItemTeleport.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ItemTeleport.java
@@ -111,7 +111,7 @@ public class ItemTeleport extends Module {
 
                 ClientUtils.INSTANCE.displayChatMessage("§7[§8§lItemTeleport§7] §3Tried to collect items");
             } else
-                mc.thePlayer.tryJump();
+                mc.thePlayer.jump();
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ItemTeleport.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ItemTeleport.java
@@ -111,7 +111,7 @@ public class ItemTeleport extends Module {
 
                 ClientUtils.INSTANCE.displayChatMessage("§7[§8§lItemTeleport§7] §3Tried to collect items");
             } else
-                mc.thePlayer.jump();
+                mc.thePlayer.tryJump();
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
@@ -115,7 +115,7 @@ public class Teleport extends Module {
                 flyTimer.update();
 
                 if(mc.thePlayer.onGround) {
-                    mc.thePlayer.jump();
+                    mc.thePlayer.tryJump();
                 }else{
                     MovementUtils.INSTANCE.forward(zitter ? -0.21 : 0.21);
                     zitter = !zitter;

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Teleport.java
@@ -115,7 +115,7 @@ public class Teleport extends Module {
                 flyTimer.update();
 
                 if(mc.thePlayer.onGround) {
-                    mc.thePlayer.tryJump();
+                    mc.thePlayer.jump();
                 }else{
                     MovementUtils.INSTANCE.forward(zitter ? -0.21 : 0.21);
                     zitter = !zitter;

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
@@ -97,7 +97,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
             fastHop = false
 
             if (slime && (getBlock(blockPos.down()) is BlockSlime || getBlock(blockPos) is BlockSlime)) {
-                thePlayer.jump()
+                thePlayer.tryJump()
 
                 thePlayer.motionX = thePlayer.motionY * 1.132
                 thePlayer.motionY = 0.08
@@ -115,7 +115,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
                     "new" -> {
                         fastHop = true
                         if (legitHop) {
-                            thePlayer.jump()
+                            thePlayer.tryJump()
                             thePlayer.onGround = false
                             legitHop = false
                             return
@@ -124,7 +124,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
 
                         strafe(0.375f)
 
-                        thePlayer.jump()
+                        thePlayer.tryJump()
                         thePlayer.motionY = 0.41
                         return
                     }
@@ -140,7 +140,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
                         fastHop = true
 
                         if (legitHop) {
-                            thePlayer.jump()
+                            thePlayer.tryJump()
                             thePlayer.onGround = false
                             legitHop = false
                             return
@@ -148,7 +148,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
 
                         thePlayer.onGround = false
                         strafe(0.375f)
-                        thePlayer.jump()
+                        thePlayer.tryJump()
                         thePlayer.motionY = 0.41
                         return
                     }
@@ -170,7 +170,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
                 if (thePlayer.posY - thePlayer.posY.toInt() >= 0.12500) {
                     boost(snowBoost)
                 } else {
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     forceDown = true
                 }
                 return
@@ -184,7 +184,7 @@ object BufferSpeed : Module("BufferSpeed", ModuleCategory.MOVEMENT) {
                     }
                     "new" ->
                         if (isNearBlock && !thePlayer.movementInput.jump) {
-                            thePlayer.jump()
+                            thePlayer.tryJump()
                             thePlayer.motionY = 0.08
                             thePlayer.motionX *= 0.99
                             thePlayer.motionZ *= 0.99

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
@@ -14,6 +14,7 @@ import net.ccbluex.liquidbounce.utils.MovementUtils
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.block.BlockStairs

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
@@ -79,7 +79,7 @@ object FastStairs : Module("FastStairs", ModuleCategory.MOVEMENT) {
             canJump = true
         } else if (mode.startsWith("AAC") && canJump) {
             if (longJump) {
-                thePlayer.jump()
+                thePlayer.tryJump()
                 thePlayer.motionX *= 1.35
                 thePlayer.motionZ *= 1.35
             }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Freeze.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Freeze.kt
@@ -6,21 +6,59 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.event.EventTarget
+import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.server.S08PacketPlayerPosLook
 
 object Freeze : Module("Freeze", ModuleCategory.MOVEMENT) {
+    private var motionX = 0.0
+    private var motionY = 0.0
+    private var motionZ = 0.0
+    private var x = 0.0
+    private var y = 0.0
+    private var z = 0.0
+
+    override fun onEnable() {
+        mc.thePlayer ?: return
+
+        x = mc.thePlayer.posX
+        y = mc.thePlayer.posY
+        z = mc.thePlayer.posZ
+        motionX = mc.thePlayer.motionX
+        motionY = mc.thePlayer.motionY
+        motionZ = mc.thePlayer.motionZ
+    }
+
     @EventTarget
     fun onUpdate(event: UpdateEvent) {
-        val thePlayer = mc.thePlayer
+        mc.thePlayer.motionX = 0.0
+        mc.thePlayer.motionY = 0.0
+        mc.thePlayer.motionZ = 0.0
+        mc.thePlayer.setPositionAndRotation(x, y, z, mc.thePlayer.rotationYaw, mc.thePlayer.rotationPitch)
+    }
 
-        thePlayer.isDead = true
-        thePlayer.rotationYaw = thePlayer.cameraYaw
-        thePlayer.rotationPitch = thePlayer.cameraPitch
+    @EventTarget
+    fun onPacket(event: PacketEvent) {
+        if (event.packet is C03PacketPlayer) {
+            event.cancelEvent()
+        }
+        if (event.packet is S08PacketPlayerPosLook) {
+            x = event.packet.x
+            y = event.packet.y
+            z = event.packet.z
+            motionX = 0.0
+            motionY = 0.0
+            motionZ = 0.0
+        }
     }
 
     override fun onDisable() {
-        mc.thePlayer?.isDead = false
+        mc.thePlayer.motionX = motionX
+        mc.thePlayer.motionY = motionY
+        mc.thePlayer.motionZ = motionZ
+        mc.thePlayer.setPositionAndRotation(x, y, z, mc.thePlayer.rotationYaw, mc.thePlayer.rotationPitch)
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.o
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjumpmodes.other.Buzz
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/LongJump.kt
@@ -77,7 +77,7 @@ object LongJump : Module("LongJump", ModuleCategory.MOVEMENT) {
         }
         if (autoJump && mc.thePlayer.onGround && isMoving) {
             jumped = true
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Parkour.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Parkour.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object Parkour : Module("Parkour", ModuleCategory.MOVEMENT, subjective = true, gameDetecting = false) {
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Parkour.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Parkour.kt
@@ -17,9 +17,9 @@ object Parkour : Module("Parkour", ModuleCategory.MOVEMENT, subjective = true, g
     fun onUpdate(event: UpdateEvent) {
         val thePlayer = mc.thePlayer ?: return
 
-        if (isMoving && thePlayer.onGround && !thePlayer.isSneaking && !mc.gameSettings.keyBindSneak.isKeyDown && !mc.gameSettings.keyBindJump.isKeyDown &&
+        if (isMoving && thePlayer.onGround && !thePlayer.isSneaking && !mc.gameSettings.keyBindSneak.isKeyDown &&
                 mc.theWorld.getCollidingBoundingBoxes(thePlayer, thePlayer.entityBoundingBox
                         .offset(0.0, -0.5, 0.0).expand(-0.001, 0.0, -0.001)).isEmpty())
-            thePlayer.jump()
+            thePlayer.tryJump()
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sprint.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sprint.kt
@@ -5,6 +5,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
+import net.ccbluex.liquidbounce.event.EventTarget
+import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.world.Scaffold
@@ -16,6 +18,7 @@ import net.ccbluex.liquidbounce.utils.inventory.InventoryUtils.serverOpenInvento
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue
+import net.minecraft.network.play.client.C0BPacketEntityAction
 import net.minecraft.potion.Potion
 import net.minecraft.util.MovementInput
 import kotlin.math.abs
@@ -42,6 +45,7 @@ object Sprint : Module("Sprint", ModuleCategory.MOVEMENT, gameDetecting = false)
         private val checkServerSide by BoolValue("CheckServerSide", false) { mode == "Vanilla" }
         private val checkServerSideGround by BoolValue("CheckServerSideOnlyGround", false)
             { mode == "Vanilla" && checkServerSide }
+        private val noPackets by BoolValue("NoPackets", false) { mode == "Vanilla" }
 
     private var isSprinting = false
 
@@ -142,5 +146,16 @@ object Sprint : Module("Sprint", ModuleCategory.MOVEMENT, gameDetecting = false)
         }
 
         return modifiedForward < threshold
+    }
+
+    @EventTarget
+    fun onPacket(event: PacketEvent) {
+        val packet = event.packet
+        if (packet !is C0BPacketEntityAction || !noPackets || event.isCancelled) {
+            return
+        }
+        if (packet.action == C0BPacketEntityAction.Action.STOP_SPRINTING || packet.action == C0BPacketEntityAction.Action.START_SPRINTING) {
+            event.cancelEvent()
+        }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sprint.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sprint.kt
@@ -150,6 +150,10 @@ object Sprint : Module("Sprint", ModuleCategory.MOVEMENT, gameDetecting = false)
 
     @EventTarget
     fun onPacket(event: PacketEvent) {
+        if (mode == "Legit") {
+            return
+        }
+
         val packet = event.packet
         if (packet !is C0BPacketEntityAction || !noPackets || event.isCancelled) {
             return

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
@@ -95,7 +95,7 @@ object Step : Module("Step", ModuleCategory.MOVEMENT, gameDetecting = false) {
                     if (thePlayer.onGround && couldStep()) {
                         thePlayer.motionX *= 1.26
                         thePlayer.motionZ *= 1.26
-                        thePlayer.jump()
+                        thePlayer.tryJump()
                         isAACStep = true
                     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
@@ -14,6 +14,7 @@ import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.timing.MSTimer
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.IntegerValue

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Strafe.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Strafe.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
 import net.ccbluex.liquidbounce.utils.extensions.toDegreesF
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import kotlin.math.cos

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Strafe.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Strafe.kt
@@ -45,7 +45,7 @@ object Strafe : Module("Strafe", ModuleCategory.MOVEMENT, gameDetecting = false)
             }
             val yaw = mc.thePlayer.rotationYaw
             mc.thePlayer.rotationYaw = direction.toDegreesF()
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
             mc.thePlayer.rotationYaw = yaw
             jump = true
             if (wasDown) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/WallClimb.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/WallClimb.kt
@@ -54,7 +54,7 @@ object WallClimb : Module("WallClimb", ModuleCategory.MOVEMENT) {
                 if (thePlayer.isCollidedHorizontally) {
                     when (clipMode.lowercase()) {
                         "jump" -> if (thePlayer.onGround)
-                            thePlayer.jump()
+                            thePlayer.tryJump()
                         "fast" -> if (thePlayer.onGround)
                             thePlayer.motionY = 0.42
                         else if (thePlayer.motionY < 0)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/WallClimb.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/WallClimb.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.collideBlockIntersects
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.init.Blocks

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/hypixel/BoostHypixel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/hypixel/BoostHypixel.kt
@@ -59,7 +59,7 @@ object BoostHypixel : FlyMode("BoostHypixel") {
 
 		sendPacket(C04PacketPlayerPosition(x, y, z, true))
 
-		mc.thePlayer.jump()
+		mc.thePlayer.tryJump()
 
 		mc.thePlayer.posY += 0.42f // Visual
 		

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/hypixel/BoostHypixel.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/hypixel/BoostHypixel.kt
@@ -16,6 +16,7 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.extensions.component1
 import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.timing.TickTimer
 import net.minecraft.init.Blocks.air
 import net.minecraft.network.play.client.C03PacketPlayer

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/ncp/OldNCP.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/ncp/OldNCP.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.extensions.component1
 import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 
 object OldNCP : FlyMode("OldNCP") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/ncp/OldNCP.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/ncp/OldNCP.kt
@@ -27,7 +27,7 @@ object OldNCP : FlyMode("OldNCP") {
 			)
 		}
 
-		mc.thePlayer.jump()
+		mc.thePlayer.tryJump()
 		mc.thePlayer.swingItem()
 	}
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/Jump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/Jump.kt
@@ -26,7 +26,7 @@ object Jump : FlyMode("Jump") {
         if (mc.thePlayer == null)
             return
         if (mc.thePlayer.onGround && !mc.thePlayer.isJumping)
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
         if ((mc.gameSettings.keyBindJump.isKeyDown && !mc.gameSettings.keyBindSneak.isKeyDown) || mc.thePlayer.onGround)
             jumpY = mc.thePlayer.posY
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/Jump.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/Jump.kt
@@ -7,18 +7,11 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.other
 
 import net.ccbluex.liquidbounce.event.BlockBBEvent
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.jumpY
-import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.startY
 import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.FlyMode
-import net.ccbluex.liquidbounce.injection.forge.mixins.entity.MixinEntity
-import net.ccbluex.liquidbounce.injection.forge.mixins.entity.MixinEntityLivingBase
-import net.ccbluex.liquidbounce.utils.ClientUtils.displayChatMessage
-import net.ccbluex.liquidbounce.utils.MovementUtils
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.minecraft.block.BlockLadder
 import net.minecraft.block.material.Material
-import net.minecraft.entity.EntityLivingBase
-import net.minecraft.init.Blocks.air
 import net.minecraft.util.AxisAlignedBB
-import kotlin.math.floor
 
 object Jump : FlyMode("Jump") {
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/aac/LAAC.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/aac/LAAC.kt
@@ -19,6 +19,6 @@ object LAAC : NoWebMode("LAAC") {
             mc.thePlayer.motionY = 0.0
 
         if (mc.thePlayer.onGround)
-            mc.thePlayer.jump()    
+            mc.thePlayer.tryJump()    
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/aac/LAAC.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/aac/LAAC.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.nowebmodes.aac
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.nowebmodes.NoWebMode
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object LAAC : NoWebMode("LAAC") {
     override fun onUpdate() {
@@ -19,6 +20,6 @@ object LAAC : NoWebMode("LAAC") {
             mc.thePlayer.motionY = 0.0
 
         if (mc.thePlayer.onGround)
-            mc.thePlayer.tryJump()    
+            mc.thePlayer.tryJump()
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/other/Rewi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/other/Rewi.kt
@@ -15,6 +15,6 @@ object Rewi : NoWebMode("Rewi") {
         mc.thePlayer.jumpMovementFactor = 0.42f
 
         if (mc.thePlayer.onGround)
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/other/Rewi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/nowebmodes/other/Rewi.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.nowebmodes.other
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.nowebmodes.NoWebMode
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object Rewi : NoWebMode("Rewi") {
     override fun onUpdate() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC2BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC2BHop.kt
@@ -18,7 +18,7 @@ object AAC2BHop : SpeedMode("AAC2BHop") {
 
         if (isMoving) {
             if (thePlayer.onGround) {
-                thePlayer.jump()
+                thePlayer.tryJump()
                 thePlayer.motionX *= 1.02
                 thePlayer.motionZ *= 1.02
             } else if (thePlayer.motionY > -0.2) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC2BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC2BHop.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AAC2BHop : SpeedMode("AAC2BHop") {
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC3BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC3BHop.kt
@@ -24,7 +24,7 @@ object AAC3BHop : SpeedMode("AAC3BHop") {
             when {
                 thePlayer.onGround -> {
                     if (legitJump) {
-                        thePlayer.jump()
+                        thePlayer.tryJump()
                         legitJump = false
                         return
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC3BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC3BHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AAC3BHop : SpeedMode("AAC3BHop") {
     private var legitJump = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC4BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC4BHop.kt
@@ -22,7 +22,7 @@ object AAC4BHop : SpeedMode("AAC4BHop") {
         if (isMoving) {
             if (legitHop) {
                 if (thePlayer.onGround) {
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     thePlayer.onGround = false
                     legitHop = false
                 }
@@ -31,7 +31,7 @@ object AAC4BHop : SpeedMode("AAC4BHop") {
             if (thePlayer.onGround) {
                 thePlayer.onGround = false
                 strafe(0.375f)
-                thePlayer.jump()
+                thePlayer.tryJump()
                 thePlayer.motionY = 0.41
             } else thePlayer.speedInAir = 0.0211f
         } else {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC4BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC4BHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AAC4BHop : SpeedMode("AAC4BHop") {
     private var legitHop = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC5BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC5BHop.kt
@@ -23,7 +23,7 @@ object AAC5BHop : SpeedMode("AAC5BHop") {
             when {
                 thePlayer.onGround -> {
                     if (legitJump) {
-                        thePlayer.jump()
+                        thePlayer.tryJump()
                         legitJump = false
                         return
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC5BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC5BHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AAC5BHop : SpeedMode("AAC5BHop") {
     private var legitJump = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC7BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC7BHop.kt
@@ -20,7 +20,7 @@ object AAC7BHop : SpeedMode("AAC7BHop") {
             return
 
         if (thePlayer.onGround) {
-            thePlayer.jump()
+            thePlayer.tryJump()
             thePlayer.motionY = 0.405
             thePlayer.motionX *= 1.004
             thePlayer.motionZ *= 1.004

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC7BHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AAC7BHop.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.Spee
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
 import net.ccbluex.liquidbounce.utils.extensions.toRadiansD
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import kotlin.math.cos
 import kotlin.math.sin
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop350.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop350.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.MotionEvent
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AACHop350 : SpeedMode("AACHop3.5.0") {
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop350.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop350.kt
@@ -21,7 +21,7 @@ object AACHop350 : SpeedMode("AACHop3.5.0") {
             thePlayer.jumpMovementFactor += 0.00208f
             if (thePlayer.fallDistance <= 1f) {
                 if (thePlayer.onGround) {
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     thePlayer.motionX *= 1.0118f
                     thePlayer.motionZ *= 1.0118f
                 } else {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop438.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop438.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AACHop438 : SpeedMode("AACHop4.3.8") {
     override fun onUpdate() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop438.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACHop438.kt
@@ -18,7 +18,7 @@ object AACHop438 : SpeedMode("AACHop4.3.8") {
             return
 
         if (thePlayer.onGround)
-            thePlayer.jump()
+            thePlayer.tryJump()
         else {
             if (thePlayer.fallDistance <= 0.1)
                 mc.timer.timerSpeed = 1.5f

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AACLowHop : SpeedMode("AACLowHop") {
     private var legitJump = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop.kt
@@ -22,7 +22,7 @@ object AACLowHop : SpeedMode("AACLowHop") {
         if (isMoving) {
             if (thePlayer.onGround) {
                 if (legitJump) {
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     legitJump = false
                     return
                 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop2.kt
@@ -34,7 +34,7 @@ object AACLowHop2 : SpeedMode("AACLowHop2") {
 
             if (thePlayer.onGround) {
                 if (legitJump) {
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     legitJump = false
 
                     return

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop2.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AACLowHop2 : SpeedMode("AACLowHop2") {
     private var legitJump = false

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop3.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop3.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.MovementUtils.forward
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import kotlin.math.cos
 import kotlin.math.sin
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop3.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACLowHop3.kt
@@ -28,7 +28,7 @@ object AACLowHop3 : SpeedMode("AACLowHop3") {
                 if (thePlayer.onGround) {
                     waitForGround = false
                     if (!firstJump) firstJump = true
-                    thePlayer.jump()
+                    thePlayer.tryJump()
                     thePlayer.motionY = 0.41
                 } else {
                     if (waitForGround) return

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACYPort2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACYPort2.kt
@@ -15,7 +15,7 @@ object AACYPort2 : SpeedMode("AACYPort2") {
 
             thePlayer.cameraPitch = 0f
             if (thePlayer.onGround) {
-                thePlayer.jump()
+                thePlayer.tryJump()
                 thePlayer.motionY = 0.3851
                 thePlayer.motionX *= 1.01
                 thePlayer.motionZ *= 1.01

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACYPort2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/aac/AACYPort2.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.aac
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object AACYPort2 : SpeedMode("AACYPort2") {
     override fun onMotion() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/Frame.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/Frame.kt
@@ -18,7 +18,7 @@ object Frame : SpeedMode("Frame") {
         if (isMoving) {
             val speed = 4.25
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 if (motionTicks == 1) {
                     tickTimer.reset()
                     if (move) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/Frame.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/Frame.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ncp
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.timing.TickTimer
 
 object Frame : SpeedMode("Frame") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPFHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPFHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ncp
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object NCPFHop : SpeedMode("NCPFHop") {
     override fun onEnable() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPFHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPFHop.kt
@@ -24,7 +24,7 @@ object NCPFHop : SpeedMode("NCPFHop") {
     override fun onUpdate() {
         if (isMoving) {
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 mc.thePlayer.motionX *= 1.01
                 mc.thePlayer.motionZ *= 1.01
                 mc.thePlayer.speedInAir = 0.0223f

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ncp
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object NCPHop : SpeedMode("NCPHop") {
     override fun onEnable() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/NCPHop.kt
@@ -24,7 +24,7 @@ object NCPHop : SpeedMode("NCPHop") {
     override fun onUpdate() {
         if (isMoving) {
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 mc.thePlayer.speedInAir = 0.0223f
             }
             strafe()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/UNCPHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/UNCPHop.kt
@@ -33,7 +33,7 @@ object UNCPHop : SpeedMode("UNCPHop") {
 
         if (isMoving) {
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 strafe(0.035f)
                 mc.thePlayer.speedInAir = 0.035f
             } else {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/UNCPHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/UNCPHop.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.Spee
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
 import net.ccbluex.liquidbounce.utils.extensions.stopXZ
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object UNCPHop : SpeedMode("UNCPHop") {
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/YPort2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/YPort2.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ncp
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object YPort2 : SpeedMode("YPort2") {
     override fun onMotion() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/YPort2.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/ncp/YPort2.kt
@@ -13,7 +13,7 @@ object YPort2 : SpeedMode("YPort2") {
     override fun onMotion() {
         if (mc.thePlayer.isOnLadder || mc.thePlayer.isInWater || mc.thePlayer.isInLava || mc.thePlayer.isInWeb || !isMoving)
             return
-        if (mc.thePlayer.onGround) mc.thePlayer.jump() else mc.thePlayer.motionY = -1.0
+        if (mc.thePlayer.onGround) mc.thePlayer.tryJump() else mc.thePlayer.motionY = -1.0
         strafe()
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/HypixelHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/HypixelHop.kt
@@ -16,9 +16,9 @@ object HypixelHop : SpeedMode("HypixelHop") {
 
         if (mc.thePlayer.onGround && isMoving) {
             if (mc.thePlayer.isUsingItem) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
             } else {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 strafe(0.4f)
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/HypixelHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/HypixelHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object HypixelHop : SpeedMode("HypixelHop") {
     override fun onStrafe() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Legit.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Legit.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object Legit : SpeedMode("Legit") {
     override fun onStrafe() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Legit.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Legit.kt
@@ -12,8 +12,8 @@ object Legit : SpeedMode("Legit") {
     override fun onStrafe() {
         val player = mc.thePlayer ?: return
 
-        if (mc.thePlayer.onGround && isMoving && !mc.gameSettings.keyBindJump.isKeyDown) {
-            player.jump()
+        if (mc.thePlayer.onGround && isMoving) {
+            player.tryJump()
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Matrix.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Matrix.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object Matrix : SpeedMode("Matrix") {
     

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Matrix.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/Matrix.kt
@@ -15,7 +15,7 @@ object Matrix : SpeedMode("Matrix") {
         if (mc.thePlayer.isInWater) return
         if (isMoving) {
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 mc.thePlayer.speedInAir = 0.02098f
                 mc.timer.timerSpeed = 1.055f
             } else {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeHop.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object MineBlazeHop : SpeedMode("MineBlazeHop") {
     override fun onUpdate() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeHop.kt
@@ -14,7 +14,7 @@ object MineBlazeHop : SpeedMode("MineBlazeHop") {
             return
         }
         if (mc.thePlayer.onGround && isMoving) {
-            mc.thePlayer.jump()
+            mc.thePlayer.tryJump()
         }
         if (mc.thePlayer.motionY > 0.003) {
             mc.thePlayer.motionX *= 1.0015

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeTimer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeTimer.kt
@@ -18,7 +18,7 @@ object MineBlazeTimer : SpeedMode("MineBlazeTimer") {
             return
 
         if (thePlayer.onGround)
-            thePlayer.jump()
+            thePlayer.tryJump()
         else {
             if (thePlayer.fallDistance <= 0.1)
                 mc.timer.timerSpeed = 1.7f

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeTimer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/MineBlazeTimer.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object MineBlazeTimer : SpeedMode("MineBlazeTimer") {
     override fun onUpdate() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/SlowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/SlowHop.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.oth
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.speed
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 
 object SlowHop : SpeedMode("SlowHop") {
     override fun onMotion() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/SlowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/other/SlowHop.kt
@@ -13,7 +13,7 @@ object SlowHop : SpeedMode("SlowHop") {
     override fun onMotion() {
         if (mc.thePlayer.isInWater) return
         if (isMoving) {
-            if (mc.thePlayer.onGround) mc.thePlayer.jump() else speed *= 1.011f
+            if (mc.thePlayer.onGround) mc.thePlayer.tryJump() else speed *= 1.011f
         } else {
             mc.thePlayer.motionX = 0.0
             mc.thePlayer.motionZ = 0.0

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/spartan/SpartanYPort.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/spartan/SpartanYPort.kt
@@ -11,9 +11,9 @@ import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextDouble
 object SpartanYPort : SpeedMode("SpartanYPort") {
     private var airMoves = 0
     override fun onMotion() {
-        if (mc.gameSettings.keyBindForward.isKeyDown && !mc.gameSettings.keyBindJump.isKeyDown) {
+        if (mc.gameSettings.keyBindForward.isKeyDown) {
             if (mc.thePlayer.onGround) {
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
                 airMoves = 0
             } else {
                 mc.timer.timerSpeed = 1.08f

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/spartan/SpartanYPort.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/spartan/SpartanYPort.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.spartan
 
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextDouble
 
 object SpartanYPort : SpeedMode("SpartanYPort") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/NewVerusLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/NewVerusLowHop.kt
@@ -3,6 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ver
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.minecraft.potion.Potion
 
 object NewVerusLowHop : SpeedMode("NewVerusLowHop") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/NewVerusLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/NewVerusLowHop.kt
@@ -15,7 +15,7 @@ object NewVerusLowHop : SpeedMode("NewVerusLowHop") {
 
         if (isMoving) {
             if (mc.thePlayer.onGround) {
-                player.jump()
+                player.tryJump()
                 airTicks = 0
 
                 // Checks the presence of Speed potion effect 1 & 2+

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusHop.kt
@@ -19,7 +19,7 @@ object VerusHop : SpeedMode("VerusHop") {
                     && mc.thePlayer.getActivePotionEffect(Potion.moveSpeed).amplifier >= 1)
                         0.46f else 0.34f
 
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
             } else {
                 speed *= 0.98f
             }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusHop.kt
@@ -3,6 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ver
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.minecraft.potion.Potion
 
 object VerusHop : SpeedMode("VerusHop") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusLowHop.kt
@@ -3,6 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.ver
 import net.ccbluex.liquidbounce.features.module.modules.movement.speedmodes.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.minecraft.potion.Potion
 
 object VerusLowHop : SpeedMode("VerusLowHop") {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusLowHop.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speedmodes/verus/VerusLowHop.kt
@@ -18,7 +18,7 @@ object VerusLowHop : SpeedMode("VerusLowHop") {
                     && mc.thePlayer.getActivePotionEffect(Potion.moveSpeed).amplifier >= 1)
                         0.5f else 0.36f
 
-                mc.thePlayer.jump()
+                mc.thePlayer.tryJump()
             } else {
                 if (airTicks == 0) {
                     mc.thePlayer.motionY = -0.09800000190734863

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiAFK.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiAFK.kt
@@ -61,7 +61,7 @@ object AntiAFK : Module("AntiAFK", ModuleCategory.PLAYER, gameDetecting = false)
                 randomTimerDelay = 500L
                 when (nextInt(0, 6)) {
                     0 -> {
-                        if (thePlayer.onGround) thePlayer.jump()
+                        if (thePlayer.onGround) thePlayer.tryJump()
                         delayTimer.reset()
                     }
                     1 -> {
@@ -93,7 +93,7 @@ object AntiAFK : Module("AntiAFK", ModuleCategory.PLAYER, gameDetecting = false)
                     mc.gameSettings.keyBindForward.pressed = true
 
                 if (jump && thePlayer.onGround)
-                    thePlayer.jump()
+                    thePlayer.tryJump()
 
                 if (rotateValue.get() && delayTimer.hasTimePassed(rotationDelay)) {
                     thePlayer.fixedSensitivityYaw += rotationAngle

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiAFK.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiAFK.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.extensions.fixedSensitivityPitch
 import net.ccbluex.liquidbounce.utils.extensions.fixedSensitivityYaw
+import net.ccbluex.liquidbounce.utils.extensions.tryJump
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextFloat
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextInt
 import net.ccbluex.liquidbounce.utils.timing.MSTimer

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/BedProtectionESP.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/BedProtectionESP.kt
@@ -44,7 +44,7 @@ object BedProtectionESP : Module("BedProtectionESP", ModuleCategory.RENDER) {
     private val blocksToRender = mutableSetOf<BlockPos>()
     private var thread: Thread? = null
 
-    private val breakableBlockIDs = arrayOf(35, 159, 121, 20, 5, 49) // wool, stained_clay, end_stone, glass, wood, obsidian
+    private val breakableBlockIDs = arrayOf(35, 24, 159, 121, 20, 5, 49) // wool, sandstone, stained_clay, end_stone, glass, wood, obsidian
 
     private fun getBlocksToRender(targetBlock: Block, maxLayers: Int, down: Boolean, allLayers: Boolean, blockLimit: Int) {
         val targetBlockID = getIdFromBlock(targetBlock)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -391,8 +391,8 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I) {
         val player = mc.thePlayer
 
         // Jumping needs to be done here, so it doesn't get detected by movement-sensitive anti-cheats.
-        if (mode == "Telly" && player.onGround && isMoving && currRotation == player.rotation && !mc.gameSettings.keyBindJump.isKeyDown && ticksUntilJump >= jumpTicks) {
-            player.jump()
+        if (mode == "Telly" && player.onGround && isMoving && currRotation == player.rotation && ticksUntilJump >= jumpTicks) {
+            player.tryJump()
 
             ticksUntilJump = 0
             jumpTicks = randomDelay(minJumpTicks.get(), maxJumpTicks.get())
@@ -883,7 +883,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I) {
                     if ((!isSneaking || speed != 0f) && it.blockPos == info.blockPos && (it.sideHit != info.enumFacing || shouldJumpForcefully) && isMoving && currRotation.yaw.roundToInt() % 45f == 0f) {
                         if (!isSneaking) {
                             if (player.onGround && !isLookingDiagonally) {
-                                player.jump()
+                                player.tryJump()
                             }
 
                             if (shouldJumpForcefully) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.kt
@@ -164,7 +164,7 @@ object Tower : Module("Tower", ModuleCategory.WORLD, Keyboard.KEY_O, gameDetecti
         when (mode.lowercase()) {
             "jump" -> if (thePlayer.onGround && tickTimer.hasTimePassed(jumpDelay)) {
                 fakeJump()
-                thePlayer.jump()
+                thePlayer.tryJump()
             } else if (!thePlayer.onGround) {
                 thePlayer.isAirBorne = false
                 tickTimer.reset()

--- a/src/main/java/net/ccbluex/liquidbounce/utils/extensions/PlayerExtension.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/extensions/PlayerExtension.kt
@@ -198,3 +198,9 @@ fun EntityPlayerSP.sendUseItem(stack: ItemStack): Boolean {
         true
     } else false
 }
+
+fun EntityPlayerSP.tryJump() {
+    if (!mc.gameSettings.keyBindJump.isKeyDown) {
+        this.jump()
+    }
+}


### PR DESCRIPTION
Added noPackets option to Sprint module. It can bypass some anticheats. 
(For example, old matrix allows only AllDirectionsLimitSpeed <= 0.82 but if noPackets is enabled the anticheat allows it being up to 1.0)
Fixed BedProtectionESP not being able to detect sandstone blocks.
Improved Freeze module so it can bypass some anticheats (it's from FDPClient actually)
Added EntityPlayerSP.tryJump() extension which jumps if the player can do that. It prevents double jumping when the key for jumping is pressed and jump() method called at the same time.

