### PR TITLE
LEGACY: Fixed KeyPearl slot switching and AntiFireball not hitting the fireballs

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/KeyPearl.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/KeyPearl.kt
@@ -36,7 +36,6 @@ object KeyPearl : Module("KeyPearl", ModuleCategory.PLAYER, subjective = true, g
     private var wasMouseDown = false
     private var wasKeyDown = false
     private var hasThrown = false
-    private var prevSlot = 0
 
     private fun throwEnderPearl() {
         val pearlInHotbar = InventoryUtils.findItem(36, 44, Items.ender_pearl)
@@ -57,21 +56,18 @@ object KeyPearl : Module("KeyPearl", ModuleCategory.PLAYER, subjective = true, g
             return
         }
 
-        prevSlot = mc.thePlayer.inventory.currentItem
         sendPackets(
             C09PacketHeldItemChange(pearlInHotbar - 36),
             C08PacketPlayerBlockPlacement(mc.thePlayer.heldItem))
         hasThrown = true
     }
 
-
     @EventTarget
     fun onTick(event: TickEvent) {
         if (hasThrown) {
-            if (mc.thePlayer.inventory.currentItem != prevSlot) {
-                sendPackets(C09PacketHeldItemChange(prevSlot))
-            }
+            sendPackets(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
             hasThrown = false
+            
         }
 
         if (mc.currentScreen != null || mc.playerController.currentGameType == WorldSettings.GameType.SPECTATOR

--- a/src/main/java/net/ccbluex/liquidbounce/utils/RaycastUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/RaycastUtils.kt
@@ -18,6 +18,7 @@ import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityItemFrame
 import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.entity.projectile.EntityLargeFireball
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.BlockPos
 import net.minecraft.util.MovingObjectPosition
@@ -42,8 +43,8 @@ object RaycastUtils : MinecraftInstance() {
         val entityLook = getVectorForRotation(yaw, pitch)
         val vec = eyePosition + (entityLook * blockReachDistance)
 
-        val entityList = mc.theWorld.getEntities(EntityLivingBase::class.java) {
-            it != null && (it !is EntityPlayer || !it.isSpectator) && it.canBeCollidedWith() && it != renderViewEntity
+        val entityList = mc.theWorld.getEntities(Entity::class.java) {
+            it != null && (it is EntityLivingBase || it is EntityLargeFireball) && (it !is EntityPlayer || !it.isSpectator) && it.canBeCollidedWith() && it != renderViewEntity
         }
 
         var pointedEntity: Entity? = null


### PR DESCRIPTION
Fixed KeyPearl not switching the item slot back correctly when DelayedSlotSwitch is being enabled.
Fixed AntiFireBall not hitting the fireball when Rotations option is being enabled.

I really hope I haven't broken the raycast logic so let me know if there is something wrong.