### PR TITLE
feat(nextgen): Lock feature

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/Module.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/Module.kt
@@ -50,7 +50,7 @@ open class Module(
     state: Boolean = false, // default state
     @Exclude val disableActivation: Boolean = false, // disable activation
     hide: Boolean = false, // default hide
-    @Exclude val disableOnQuit: Boolean = false // disables module when player leaves the world
+    @Exclude val disableOnQuit: Boolean = false // disables module when player leaves the world,
 ) : Listenable, Configurable(name) {
 
     val valueEnabled = boolean("Enabled", state).also {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
@@ -45,6 +45,10 @@ import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
  */
 object ModuleCriticals : Module("Criticals", Category.COMBAT) {
 
+    init {
+        enableLock()
+    }
+
     val modes = choices("Mode", { PacketCrit }) {
         arrayOf(
             NoneChoice(it),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleVelocity.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleVelocity.kt
@@ -48,6 +48,10 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
 
 object ModuleVelocity : Module("Velocity", Category.COMBAT) {
 
+    init {
+        enableLock()
+    }
+
     val modes = choices("Mode", { Modify }) {
         arrayOf(
             Modify, Strafe, AAC442, ExemptGrim117, Dexland, JumpReset

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoWeb.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoWeb.kt
@@ -33,6 +33,10 @@ import net.ccbluex.liquidbounce.utils.client.notification
  */
 object ModuleNoWeb : Module("NoWeb", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     val modes = choices("Mode", Air, arrayOf(Air))
 
     val repeatable = repeatable {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
@@ -34,6 +34,10 @@ import net.minecraft.entity.MovementType
  */
 object ModuleStrafe : Module("Strafe", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     private var strength by float("Strength", 1f, 0.1f..1f)
     private var strictMovement by boolean("StrictMovement", false)
     private var notDuringAir by boolean("NotDuringAir", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
@@ -34,6 +34,10 @@ import net.ccbluex.liquidbounce.utils.entity.strafe
  */
 object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     private val speedVertical by float("Vertical", 0.32f, 0.1f..1f)
     private val glideVertical by float("GlideVertical", -0.2f, -0.3f..0.3f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
@@ -41,6 +41,10 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.vulca
 
 object ModuleFly : Module("Fly", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     internal val modes = choices(
         "Mode", FlyVanilla, arrayOf(
             // Generic fly modes

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
@@ -35,6 +35,10 @@ import net.ccbluex.liquidbounce.features.module.Module
  */
 object ModuleHighJump : Module("HighJump", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     private val modes = choices(
         "Mode", Vanilla, arrayOf(
             Vanilla, Vulcan

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
@@ -42,6 +42,10 @@ import net.minecraft.util.shape.VoxelShapes
  */
 object ModuleLiquidWalk : Module("LiquidWalk", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     internal val modes = choices("Mode", LiquidWalkVanilla, arrayOf(
         LiquidWalkVanilla,
         LiquidWalkNoCheatPlus

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
@@ -31,6 +31,10 @@ import net.ccbluex.liquidbounce.utils.entity.moving
 
 object ModuleLongJump : Module("LongJump", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     val mode = choices(
         "Mode", NoCheatPlusBoost, arrayOf(
             // NoCheatPlus

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -35,6 +35,10 @@ import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleSca
 
 object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
 
+    init {
+        enableLock()
+    }
+
     val modes = choices(
         "Mode", SpeedLegitHop, arrayOf(
             SpeedLegitHop,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
@@ -33,6 +33,10 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.ic
 object ModuleTerrainSpeed : Module("TerrainSpeed", Category.MOVEMENT) {
 
     init {
+        enableLock()
+    }
+
+    init {
         tree(FastClimb)
         tree(IceSpeed)
     }

--- a/src/main/resources/assets/liquidbounce/lang/en_us.json
+++ b/src/main/resources/assets/liquidbounce/lang/en_us.json
@@ -273,6 +273,7 @@
   "liquidbounce.generic.forum": "Forum",
   "liquidbounce.generic.guilded": "Guilded",
   "liquidbounce.generic.notifyDeveloper": "Check your game log and notify us.",
+  "liquidbounce.generic.locked": "The module is locked and cannot be enabled. It is likely not bypassing.",
   "liquidbounce.liquidchat.authenticationFailed": "Authentication failed! LiquidChat requires Minecraft premium account.",
   "liquidbounce.liquidchat.jwtTokenReceived": "Received JWT token! Relogging...",
   "liquidbounce.liquidchat.states.connected": "Connected to chat server!",


### PR DESCRIPTION
Allows you to lock certain modules as config creator, which keeps the user from accidently enabling certain modules.
However so far we only enabled this option in specific modules which are known to require bypass, however if there is one missing feel free to add.

On the start of the class:
```kotlin
init {
    enableLock()
}
```

![image](https://github.com/CCBlueX/LiquidBounce/assets/12410754/97429613-8191-4a8f-849f-f29bc72010dc)
