### PR TITLE
feat: splash handling

### DIFF
--- a/src-theme/src/routes.js
+++ b/src-theme/src/routes.js
@@ -1,4 +1,3 @@
-import Splashscreen from "./routes/splashscreen/Splashscreen.svelte";
 import Title from './routes/title/Title.svelte';
 import Hud from './routes/hud/Hud.svelte';
 import ClickGui from "./routes/clickgui/ClickGui.svelte";
@@ -10,7 +9,6 @@ import Inventory from "./routes/inventory/Inventory.svelte";
 import Disconnected from "./routes/disconnected/Disconnected.svelte";
 
 export const routes = {
-    '/splash': Splashscreen,
     '/title': Title,
     '/hud': Hud,
     '/clickgui': ClickGui,

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinSplashOverlay.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinSplashOverlay.java
@@ -27,7 +27,6 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.SplashOverlay;
 import net.minecraft.resource.ResourceReload;
 import net.minecraft.util.math.ColorHelper;
-import org.checkerframework.checker.units.qual.A;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -53,13 +52,13 @@ public class MixinSplashOverlay {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void hookInit(CallbackInfo ci) {
-        EventManager.INSTANCE.callEvent(new SplashOverlayEvent(SplashOverlayEvent.Action.SHOW));
+        EventManager.INSTANCE.callEvent(new SplashOverlayEvent(true));
         BRAND_ARGB = () -> ColorHelper.Argb.getArgb(255, 24, 26, 27);
     }
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setOverlay(Lnet/minecraft/client/gui/screen/Overlay;)V"))
     private void hookEnd(CallbackInfo ci) {
-        EventManager.INSTANCE.callEvent(new SplashOverlayEvent(SplashOverlayEvent.Action.HIDE));
+        EventManager.INSTANCE.callEvent(new SplashOverlayEvent(false));
     }
 
     @Unique

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/GameEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/GameEvents.kt
@@ -27,8 +27,6 @@ import net.ccbluex.liquidbounce.utils.client.Nameable
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.ccbluex.liquidbounce.web.socket.protocol.event.WebSocketEvent
 import net.minecraft.client.gui.screen.Screen
-import net.minecraft.client.network.ServerAddress
-import net.minecraft.client.network.ServerInfo.ServerType
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.text.Text
 
@@ -94,14 +92,7 @@ class ChatReceiveEvent(val message: String, val textData: Text, val type: ChatTy
 
 @Nameable("splashOverlay")
 @WebSocketEvent
-class SplashOverlayEvent(val action: Action) : Event() {
-
-    enum class Action {
-        @SerializedName("show") SHOW,
-        @SerializedName("hide") HIDE
-    }
-
-}
+class SplashOverlayEvent(val showingSplash: Boolean) : Event()
 
 @Nameable("splashProgress")
 @WebSocketEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/integration/IntegrationHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/integration/IntegrationHandler.kt
@@ -46,7 +46,7 @@ object IntegrationHandler : Listenable {
      * The client tab will be initialized when the browser is ready.
      */
     val clientJcef by lazy {
-        ThemeManager.openInputAwareImmediate(VirtualScreenType.SPLASH).preferOnTop()
+        ThemeManager.openInputAwareImmediate().preferOnTop()
     }
 
     var momentaryVirtualScreen: VirtualScreen? = null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/integration/VirtualScreenType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/integration/VirtualScreenType.kt
@@ -56,7 +56,6 @@ enum class VirtualScreenType(
     CLICK_GUI("clickgui"),
     ALT_MANAGER("altmanager"),
     PROXY_MANAGER("proxymanager"),
-    SPLASH("splash"),
 
     TITLE(
         "title",

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/client/ScreenRest.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/client/ScreenRest.kt
@@ -41,7 +41,7 @@ fun RestNode.screenRest() {
     get("/virtualScreen") {
         httpOk(JsonObject().apply {
             addProperty("name", IntegrationHandler.momentaryVirtualScreen?.type?.routeName)
-            addProperty("splash", mc.overlay is SplashOverlay)
+            addProperty("showingSplash", mc.overlay is SplashOverlay)
         })
     }
 


### PR DESCRIPTION
Improved the handling with the splash screen, which previously caused a route change and now instead simply disables the router rendering. The solution before likely caused bugs with the routing and is more complex, so this simplifies it and reduces future issues.