### PR TITLE
fix(nextgen): Renamed `.localconfig create` to `.localconfig save`

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
@@ -101,6 +101,7 @@ object CommandLocalConfig {
             .subcommand(
                 CommandBuilder
                     .begin("create")
+                    .alias("save")
                     .parameter(
                         ParameterBuilder
                             .begin<String>("name")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
@@ -100,8 +100,8 @@ object CommandLocalConfig {
             }.build())
             .subcommand(
                 CommandBuilder
-                    .begin("create")
-                    .alias("save")
+                    .begin("save")
+                    .alias("create")
                     .parameter(
                         ParameterBuilder
                             .begin<String>("name")


### PR DESCRIPTION
`create` is the opposite of `load`. An alias was added to keep the option to use `create`