### PR TITLE
fix: re-add chest stealer to module manager

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -48,6 +48,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.step.ModuleStep
 import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.ModuleTerrainSpeed
 import net.ccbluex.liquidbounce.features.module.modules.player.*
 import net.ccbluex.liquidbounce.features.module.modules.player.autoplay.ModuleAutoPlay
+import net.ccbluex.liquidbounce.features.module.modules.player.chestStealer.ModuleChestStealer
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ModuleInventoryCleaner
 import net.ccbluex.liquidbounce.features.module.modules.render.*
@@ -196,6 +197,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
             ModuleAutoTotem,
             ModuleAutoWalk,
             ModuleBlink,
+            ModuleChestStealer,
             ModuleEagle,
             ModuleFastUse,
             ModuleInventoryCleaner,


### PR DESCRIPTION
Module was erroneously removed from the module manager in 3e3ff43