### PR TITLE
fix: TargetHUD avatar not displayed correctly

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -17,6 +17,7 @@
     <ID>CyclomaticComplexMethod:RegistryRest.kt$fun RestNode.registriesRest()</ID>
     <ID>CyclomaticComplexMethod:RotationsUtil.kt$RotationManager$fun update()</ID>
     <ID>CyclomaticComplexMethod:ScaffoldBreezilyFeature.kt$ScaffoldBreezilyFeature$fun doBreezilyIfNeeded(event: MovementInputEvent)</ID>
+    <ID>CyclomaticComplexMethod:TextureRest.kt$fun RestNode.resourceRest()</ID>
     <ID>CyclomaticComplexMethod:Value.kt$Value$open fun setByString(string: String)</ID>
     <ID>DestructuringDeclarationWithTooManyEntries:ModuleAimbot.kt$ModuleAimbot$val (fromPoint, toPoint, box, cutOffBox) = pointTracker.gatherPoint(target, PointTracker.AimSituation.FOR_NOW)</ID>
     <ID>DestructuringDeclarationWithTooManyEntries:ModuleAutoShoot.kt$ModuleAutoShoot$val (fromPoint, toPoint, _, _) = pointTracker.gatherPoint(target, PointTracker.AimSituation.FOR_NEXT_TICK)</ID>

--- a/src-theme/src/integration/types.ts
+++ b/src-theme/src/integration/types.ts
@@ -140,7 +140,7 @@ export interface Scoreboard {
 
 export interface PlayerData {
     username: string;
-    textures: SkinTextures;
+    uuid: string;
     selectedSlot: number;
     gameMode: string;
     health: number,
@@ -157,13 +157,6 @@ export interface PlayerData {
     offHandStack: ItemStack;
     armorItems: ItemStack[];
     scoreboard: Scoreboard;
-}
-
-export interface SkinTextures {
-    texture: string,
-    textureUrl: string,
-    capeTexture: string,
-    elytraTexture: string,
 }
 
 export interface StatusEffect {

--- a/src-theme/src/routes/hud/elements/targethud/TargetHud.svelte
+++ b/src-theme/src/routes/hud/elements/targethud/TargetHud.svelte
@@ -5,7 +5,7 @@
     import {REST_BASE} from "../../../../integration/host";
     import {fly} from "svelte/transition";
     import HealthProgress from "./HealthProgress.svelte";
-    import type { TargetChangeEvent } from "../../../../integration/events";
+    import type {TargetChangeEvent} from "../../../../integration/events";
 
     let target: PlayerData | null = null;
     let visible = true;
@@ -32,16 +32,7 @@
     <div class="targethud" transition:fly={{ y: -10, duration: 200 }}>
         <div class="main-wrapper">
             <div class="avatar">
-                {#if target.textures}
-                    {#if target.textures.textureUrl}
-                        <img src="{target.textures.textureUrl}" alt="avatar" />
-                    {:else}
-                        <img src="{REST_BASE}/api/v1/client/resource?id={target.textures.texture}" alt="avatar" />
-                    {/if}
-                {:else}
-                    <img src="{REST_BASE}/api/v1/client/resource?id=textures/entity/player/wide/steve.png" alt="avatar" />
-                {/if}
-
+                <img src="{REST_BASE}/api/v1/client/resource/skin?uuid={target.uuid}" alt="avatar" />
             </div>
     
             <div class="name">{target.username}</div>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/game/PlayerRest.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/protocol/rest/game/PlayerRest.kt
@@ -24,12 +24,10 @@ package net.ccbluex.liquidbounce.web.socket.protocol.rest.game
 import net.ccbluex.liquidbounce.features.module.modules.misc.sanitizeWithNameProtect
 import net.ccbluex.liquidbounce.utils.client.interaction
 import net.ccbluex.liquidbounce.utils.client.mc
-import net.ccbluex.liquidbounce.utils.client.network
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.web.socket.netty.httpOk
 import net.ccbluex.liquidbounce.web.socket.netty.rest.RestNode
 import net.ccbluex.liquidbounce.web.socket.protocol.protocolGson
-import net.minecraft.client.util.SkinTextures
 import net.minecraft.entity.effect.StatusEffectInstance
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
@@ -50,7 +48,7 @@ fun RestNode.playerRest() {
 
 data class PlayerData(
     val username: String,
-    val textures: SkinTextures? = null,
+    val uuid: String,
     val selectedSlot: Int,
     val gameMode: GameMode = GameMode.DEFAULT,
     val health: Float,
@@ -73,7 +71,7 @@ data class PlayerData(
 
         fun fromPlayer(player: PlayerEntity) = PlayerData(
             player.nameForScoreboard,
-            network.playerList.find { it.profile == player.gameProfile }?.skinTextures,
+            player.uuidAsString,
             player.inventory.selectedSlot,
             if (mc.player == player) interaction.currentGameMode else GameMode.DEFAULT,
             player.health.fixNaN(),

--- a/src/main/resources/liquidbounce.accesswidener
+++ b/src/main/resources/liquidbounce.accesswidener
@@ -141,3 +141,6 @@ accessible field net/minecraft/client/gui/hud/PlayerListHud footer Lnet/minecraf
 
 accessible class net/minecraft/client/render/OutlineVertexConsumerProvider$OutlineVertexConsumer
 accessible method net/minecraft/client/render/OutlineVertexConsumerProvider$OutlineVertexConsumer <init> (Lnet/minecraft/client/render/VertexConsumer;IIII)V
+
+accessible field net/minecraft/client/texture/PlayerSkinTexture url Ljava/lang/String;
+accessible field net/minecraft/client/texture/PlayerSkinTexture cacheFile Ljava/io/File;


### PR DESCRIPTION
- simplified frontend code
- introduced new /resource/skin endpoint
- fix corrupt skin display
- fix not using actual player skin but get by tablist (for bots or vanished)
- add fallback skin if player is not found by UUID