### PR TITLE
fix: ArrayList glitching modules

### DIFF
--- a/src-theme/src/routes/hud/elements/ArrayList.svelte
+++ b/src-theme/src/routes/hud/elements/ArrayList.svelte
@@ -30,7 +30,7 @@
 
 <div class="arraylist">
     {#each enabledModules as { name } (name)}
-        <div class="module" animate:flip={{ duration: 200 }} in:fly={{ x: 50, duration: 200 }} out:fly={{ x: 50, duration: 200 }}>
+        <div class="module" animate:flip={{ duration: 200 }} in:fly={{ x: 50, duration: 200 }}>
             {name}
         </div>
     {/each}


### PR DESCRIPTION
Sometimes, modules in the array list can get stuck in each other. This is a known issue related to Svelte transitions. I disabled out transitions for now.