### PR TITLE
fix: enter bypassing disabled check in modals

### DIFF
--- a/src-theme/src/routes/menu/altmanager/addaccount/CrackedAccountTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/addaccount/CrackedAccountTab.svelte
@@ -10,6 +10,9 @@
     $: disabled = validateUsername(username);
 
     async function addAccount() {
+        if (disabled) {
+            return;
+        }
         await addCrackedAccount(username);
     }
 

--- a/src-theme/src/routes/menu/altmanager/addaccount/SessionAccountTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/addaccount/SessionAccountTab.svelte
@@ -12,6 +12,9 @@
     }
 
     async function addAccount() {
+        if (disabled) {
+            return;
+        }
         await addSessionAccount(token);
     }
 </script>

--- a/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
@@ -12,6 +12,9 @@
     }
 
     async function addAccount() {
+        if (disabled) {
+            return;
+        }
         await addAlteningAccount(token);
     }
 </script>

--- a/src-theme/src/routes/menu/altmanager/directLogin/CrackedAccountDirectLoginTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/directLogin/CrackedAccountDirectLoginTab.svelte
@@ -10,6 +10,9 @@
     $: disabled = validateUsername(username);
 
     async function login() {
+        if (disabled) {
+            return;
+        }
         await directLoginToCrackedAccount(username);
     }
 

--- a/src-theme/src/routes/menu/altmanager/directLogin/SessionAccountDirectLoginTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/directLogin/SessionAccountDirectLoginTab.svelte
@@ -12,6 +12,9 @@
     }
 
     async function login() {
+        if (disabled) {
+            return;
+        }
         await directLoginToSessionAccount(token);
     }
 </script>

--- a/src-theme/src/routes/menu/multiplayer/AddServerModal.svelte
+++ b/src-theme/src/routes/menu/multiplayer/AddServerModal.svelte
@@ -21,6 +21,9 @@
     }
 
     async function addServer() {
+        if (disabled) {
+            return;
+        }
         await restAddServer(name, address, resourcePackPolicy);
         dispatch("serverAdd");
         cleanUp();

--- a/src-theme/src/routes/menu/multiplayer/DirectConnectModal.svelte
+++ b/src-theme/src/routes/menu/multiplayer/DirectConnectModal.svelte
@@ -14,7 +14,10 @@
         return address.length === 0;
     }
 
-    async function addServer() {
+    async function connect() {
+        if (disabled) {
+            return;
+        }
         visible = false;
         localStorage.setItem("multiplayer_direct_connect_address", address)
         await connectToServer(address);
@@ -27,5 +30,5 @@
 
 <Modal bind:visible={visible} title="Direct Connection" on:close={cleanUp}>
     <IconTextInput title="Address" icon="server" bind:value={address}/>
-    <ButtonSetting title="Join Server" on:click={addServer} {disabled} inset={true}/>
+    <ButtonSetting title="Join Server" on:click={connect} {disabled} inset={true}/>
 </Modal>

--- a/src-theme/src/routes/menu/multiplayer/EditServerModal.svelte
+++ b/src-theme/src/routes/menu/multiplayer/EditServerModal.svelte
@@ -21,6 +21,9 @@
     }
 
     async function editServer() {
+        if (disabled) {
+            return;
+        }
         await editServerRest(id, name, address, resourcePackPolicy);
         dispatch("serverEdit");
         visible = false;

--- a/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
+++ b/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
@@ -26,6 +26,9 @@
     }
 
     async function addProxy() {
+        if (disabled) {
+            return;
+        }
         const [host, port] = hostPort.split(":");
 
         await addProxyRest(host, parseInt(port), username, password);

--- a/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
+++ b/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
@@ -124,7 +124,7 @@
     }
 
     listen("proxyAdditionResult", async (e: ProxyAdditionResultEvent) => {
-        if (e.error === null) {
+        if (e.error !== null) {
             notification.set({
                 title: "ProxyManager",
                 message: "Couldn't connect to proxy",


### PR DESCRIPTION
Currently, enter will bypass the check that disables the major button of modals in menus.