### PR TITLE
fix(nextgen): Changed default outline shader width back to 2.0

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
@@ -76,7 +76,7 @@ public abstract class MixinWorldRenderer {
         try {
             OutlineShader outlineShader = OutlineShader.INSTANCE;
 
-            outlineShader.begin(3.0F);
+            outlineShader.begin(2.0F);
 
             outlineShader.getFramebuffer().beginWrite(false);
 


### PR DESCRIPTION
Fixes #2357