### PR TITLE
LEGACY: Bunch of Updates & Fixes pt.2

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -28,7 +28,7 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
 
     val mode by ListValue(
         "Mode",
-        arrayOf("Packet", "NCPPacket", "BlocksMC", "NoGround", "Hop", "TPHop", "Jump", "LowJump", "CustomMotion", "Visual"),
+        arrayOf("Packet", "NCPPacket", "BlocksMC", "BlocksMC2", "NoGround", "Hop", "TPHop", "Jump", "LowJump", "CustomMotion", "Visual"),
         "Packet"
     )
 
@@ -80,6 +80,16 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
                         C04PacketPlayerPosition(x, y + 0.001091981, z, true),
                         C04PacketPlayerPosition(x, y, z, false)
                     )
+                }
+
+                "blocksmc2" -> {
+                    if (thePlayer.ticksExisted % 5 == 0) {
+                        sendPackets(
+                            C04PacketPlayerPosition(x, y + 0.001, z, false),
+                            C04PacketPlayerPosition(x, y + 0.0010353, z, false),
+                            C04PacketPlayerPosition(x, y, z, false)
+                        )
+                    }
                 }
 
                 "hop" -> {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
@@ -148,6 +148,7 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
 
     // Settings
     private val onScaffold by BoolValue("OnScaffold", false)
+    private val onDestroyBlock by BoolValue("OnDestroyBlock", false)
 
     // AutoBlock
     private val autoBlock by ListValue("AutoBlock", arrayOf("Off", "Packet", "Fake"), "Packet")
@@ -541,6 +542,9 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
         if (!onScaffold && Scaffold.state)
             return
 
+        if (!onDestroyBlock && mc.playerController.isHittingBlock)
+            return
+
         // Reset fixed target to null
         target = null
 
@@ -670,6 +674,9 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
         if (!onScaffold && Scaffold.state)
             return
 
+        if (!onDestroyBlock && mc.playerController.isHittingBlock)
+            return
+
         if ((thePlayer.isBlocking || renderBlocking) && (autoBlock == "Off" && blockStatus || autoBlock == "Packet" && releaseAutoBlock)) {
             stopBlocking()
 
@@ -745,6 +752,9 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
         val player = mc.thePlayer ?: return false
 
         if (!onScaffold && Scaffold.state)
+            return false
+
+        if (!onDestroyBlock && mc.playerController.isHittingBlock)
             return false
 
         val (predictX, predictY, predictZ) = entity.currPos.subtract(entity.prevPos)
@@ -828,6 +838,9 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
         if (!onScaffold && Scaffold.state)
             return
 
+        if (!onDestroyBlock && mc.playerController.isHittingBlock)
+            return
+
         var chosenEntity: Entity? = null
 
         if (raycast) {
@@ -908,6 +921,9 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
             return
 
         if (!onScaffold && Scaffold.state)
+            return
+
+        if (!onDestroyBlock && mc.playerController.isHittingBlock)
             return
 
         if (mc.thePlayer.isBlocking) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
@@ -502,7 +502,7 @@ object TimerRange : Module("TimerRange", ModuleCategory.COMBAT) {
             }
         }
 
-        if (isPlayerMoving() && shouldResetTimer() && playerTicks > 0) {
+        if (shouldResetTimer()) {
 
             // Check for lagback
             if (resetOnlagBack && packet is S08PacketPlayerPosLook) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
@@ -49,9 +49,9 @@ object PingSpoof : Module("PingSpoof", ModuleCategory.EXPLOIT) {
         } else {
             // This should bypass simulation AntiCheat better.
             // Example: Grim (Still Flag for Reach due to S32PacketConfirmTransaction)
-            if (packet is S32PacketConfirmTransaction || packet is S00PacketKeepAlive ||
-                packet is S39PacketPlayerAbilities || packet is S19PacketEntityStatus ||
-                (packet is S12PacketEntityVelocity && !Velocity.delayMode) ||  packet is S08PacketPlayerPosLook) {
+            if (packet is S32PacketConfirmTransaction || packet is S00PacketKeepAlive
+                || packet is S19PacketEntityStatus || (packet is S12PacketEntityVelocity && !Velocity.delayMode)
+                || packet is S08PacketPlayerPosLook) {
                 event.cancelEvent()
 
                 // Use nano time for the registration time since there are chances

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/StaffDetector.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/StaffDetector.kt
@@ -14,6 +14,7 @@ import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.init.Items
 import net.minecraft.network.Packet
 import net.minecraft.network.play.server.*
+import sun.audio.AudioPlayer.player
 
 object StaffDetector : Module("StaffDetector", ModuleCategory.MISC, gameDetecting = false) {
 
@@ -89,9 +90,13 @@ object StaffDetector : Module("StaffDetector", ModuleCategory.MISC, gameDetectin
                     }
 
                     miscSpectatorList.forEach { player ->
-                        if (player in blocksMCStaff) {
+                        val isStaff = player in blocksMCStaff
+
+                        if (isStaff && spectator) {
                             Chat.print("§c[STAFF] §d${player} §3is using the spectator menu §e(compass/left)")
-                        } else {
+                        }
+
+                        if (!isStaff && otherSpectator) {
                             Chat.print("§d${player} §3is using the spectator menu §e(compass/left)")
                         }
                         checkedSpectator.remove(player)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
@@ -109,7 +109,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, Keyboard.KEY_F) {
     val extraBoost by FloatValue("ExtraSpeed", 0.25f, 0.0F..2f) { mode == "BlocksMC" }
     val stopOnLanding by BoolValue("StopOnLanding", true) { mode == "BlocksMC" }
     val stopOnNoMove by BoolValue("StopOnNoMove", true) { mode == "BlocksMC" }
-    val debugFly by BoolValue("Debug", false)
+    val debugFly by BoolValue("Debug", false) { mode == "BlocksMC" }
 
     // Visuals
     private val mark by BoolValue("Mark", true, subjective = true)


### PR DESCRIPTION
- Revamped & Improved STap -> SprintTap2.
- Added onDestroyBlock option to KillAura.
- Added BlocksMC2 mode to Criticals.
- Fixed NameProtect, should render name correctly now.
- Fixed StaffDetector, should warn miscspectator correctly.
- Fixed PingSpoof, conflicted with GameDetector Ability mode.
- Fixed TimerRange, now it should detect lagback. (Closes #2437)
- Fixed debugFly option, now it should be an option only for BlocksMC Fly mode.