### PR TITLE
feat: Disable GraalVM concurrency checks

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/graaljs/MixinTruffleLanguage.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/graaljs/MixinTruffleLanguage.java
@@ -1,0 +1,17 @@
+package net.ccbluex.liquidbounce.injection.mixins.graaljs;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(targets = "com/oracle/truffle/api/TruffleLanguage")
+public class MixinTruffleLanguage {
+
+    /**
+     * @author Senk Ju
+     * @reason Prevent GraalVM from blocking multi threaded access to resources
+     */
+    @Overwrite(remap = false)
+    protected boolean isThreadAccessAllowed(Thread thread, boolean singleThreaded) {
+        return true;
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsContextProvider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsContextProvider.kt
@@ -59,6 +59,7 @@ object JsContextProvider {
         putMember("MovementUtil", JsMovementUtil)
         putMember("ReflectionUtil", JsReflectionUtil)
         putMember("ParameterValidator", JsParameterValidator(bindings))
+        putMember("UnsafeThread", JsUnsafeThread)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsUnsafeThread.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsUnsafeThread.kt
@@ -1,0 +1,11 @@
+package net.ccbluex.liquidbounce.script.bindings.api
+
+import kotlin.concurrent.thread
+
+object JsUnsafeThread {
+
+    @JvmName("run")
+    fun run(callback: () -> Unit) = thread {
+        callback()
+    }
+}

--- a/src/main/resources/liquidbounce.mixins.json
+++ b/src/main/resources/liquidbounce.mixins.json
@@ -6,6 +6,7 @@
   "priority": 1337,
   "mixinPriority": 1337,
   "client": [
+    "graaljs.MixinTruffleLanguage",
     "graaljs.MixinHostClassDesc",
     "graaljs.MixinHostClassLoader",
     "graaljs.MixinHostContext",


### PR DESCRIPTION
GraalJS does not allow multiple threads to access the same resource as it may lead to data races and JavaScript was designed to be a single-threaded language. When working with scripts, this can be become a nuisance. This pull request disables access checks. Be careful to use proper synchronisation when working with multiple threads,

It also adds a `UnsafeThread` class to the script API offering a `run` method which allows executing the callback function on a new thread.