### PR TITLE
fix(nextgen): Disable crit visuals by default

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleCriticals.kt
@@ -264,7 +264,7 @@ object ModuleCriticals : Module("Criticals", Category.COMBAT) {
     /**
      * Just some visuals.
      */
-    private object VisualsConfigurable : ToggleableConfigurable(this, "Visuals", true) {
+    private object VisualsConfigurable : ToggleableConfigurable(this, "Visuals", false) {
 
         val fake by boolean("Fake", false)
 


### PR DESCRIPTION
Fixes #2434