### PR TITLE
feat: increase max alignment offsets

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/Alignment.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/Alignment.kt
@@ -31,9 +31,9 @@ class Alignment(
 ) : Configurable("Alignment") {
 
     val horizontalAlignment by enumChoice("Horizontal", horizontalAlignment)
-    val horizontalOffset by int("HorizontalOffset", horizontalOffset, -256..256)
+    val horizontalOffset by int("HorizontalOffset", horizontalOffset, -1000..1000)
     val verticalAlignment by enumChoice("Vertical", verticalAlignment)
-    val verticalOffset by int("VerticalOffset", verticalOffset, -256..256)
+    val verticalOffset by int("VerticalOffset", verticalOffset, -1000..1000)
 
     fun getBounds(
         width: Float,


### PR DESCRIPTION
Currently, the maximum (vertical or horizontal) offset that can be applied to an element is 256. This is too little even for the default HUD. This pull request increases the maximum offsets to (-)1000.