### PR TITLE
LEGACY: BlocksMC Bypass & FlagCheck Fixes

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -83,10 +83,10 @@ object Criticals : Module("Criticals", ModuleCategory.COMBAT) {
                 }
 
                 "blocksmc2" -> {
-                    if (thePlayer.ticksExisted % 5 == 0) {
+                    if (thePlayer.ticksExisted % 6 == 0) {
                         sendPackets(
                             C04PacketPlayerPosition(x, y + 0.001, z, false),
-                            C04PacketPlayerPosition(x, y + 0.0010353, z, false),
+                            C04PacketPlayerPosition(x, y + 0.0010153, z, false),
                             C04PacketPlayerPosition(x, y, z, false)
                         )
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
@@ -110,6 +110,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, Keyboard.KEY_F) {
     val yBoost by FloatValue("YBoost", 0.42f, 0f..10f) { mode == "Verus" }
 
     // BlocksMC
+    val stable by BoolValue("Stable", false) { mode == "BlocksMC" }
     val timerSlowed by BoolValue("TimerSlowed", true) { mode == "BlocksMC" }
     val boostSpeed by FloatValue("BoostSpeed", 8f, 1f..15f) { mode == "BlocksMC" }
     val extraBoost by FloatValue("ExtraSpeed", 0.25f, 0.0F..2f) { mode == "BlocksMC" }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/BlocksMC.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/other/BlocksMC.kt
@@ -6,6 +6,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.Fly
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.boostSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.debugFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.extraBoost
+import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.stable
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.stopOnLanding
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.stopOnNoMove
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly.timerSlowed
@@ -65,6 +66,10 @@ object BlocksMC : FlyMode("BlocksMC") {
 
         if (shouldFly(player, world)) {
             if (isTeleported) {
+
+                if (stable)
+                    player.motionY = 0.0
+
                 handleTimerSlow(player)
                 handlePlayerFlying(player)
             } else {
@@ -134,7 +139,8 @@ object BlocksMC : FlyMode("BlocksMC") {
             sendPackets(
                 C04PacketPlayerPosition(
                     player.posX,
-                    player.posY - 0.1,
+                    // Clipping is now patch in BlocksMC
+                    player.posY - 0.05,
                     player.posZ,
                     false
                 )


### PR DESCRIPTION
- Fixed FlagCheck Force-Rotate
- Lower value for BlocksMC2 Criticals
- Added Stable option to BlocksMC Fly
- Fixed BlocksMC Fly, should no longer flag for clipping (Clipping is now patch, i think..)