### PR TITLE
rename basic to vanilla ab

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
@@ -213,7 +213,7 @@ object AutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking", false)
     }
 
     enum class BlockMode(override val choiceName: String) : NamedChoice {
-        BASIC("Basic"),
+        VANILLA("Vanilla"),
         INTERACT("Interact"),
         FAKE("Fake")
     }


### PR DESCRIPTION
most people who are new to the client dont know what a basic autoblock mode is (because other clients have vanilla instead of basic) so renaming it to vanilla makes it easier for them to config