### PR TITLE
LEGACY: AtAllProvider, TimerRange & AutoF5 Fixes

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
@@ -328,8 +328,11 @@ object KillAura : Module("KillAura", ModuleCategory.COMBAT, Keyboard.KEY_R) {
         // Update target
         updateTarget()
 
-        if (autoF5)
-            mc.gameSettings.thirdPersonView = if (target != null || mc.thePlayer.swingProgress > 0) 1 else 0
+        if (autoF5) {
+            if (mc.gameSettings.thirdPersonView != 1 && (target != null || mc.thePlayer.swingProgress > 0)) {
+                mc.gameSettings.thirdPersonView = 1
+            }
+        }
     }
 
     @EventTarget

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
@@ -406,9 +406,9 @@ object TimerRange : Module("TimerRange", ModuleCategory.COMBAT) {
     /**
      * Get all entities in the world.
      */
-    private fun getAllEntities(): List<Entity> {
-        return mc.theWorld.loadedEntityList.toList()
-            .filter { EntityUtils.isSelected(it, true) }
+    private fun getAllEntities(): List<Entity?>? {
+        return mc.theWorld?.loadedEntityList?.toList()
+            ?.filter { EntityUtils.isSelected(it, true) }
     }
 
     /**
@@ -417,10 +417,10 @@ object TimerRange : Module("TimerRange", ModuleCategory.COMBAT) {
     private fun getNearestEntityInRange(): Entity? {
         val player = mc.thePlayer ?: return null
 
-        val entitiesInRange = getAllEntities().filter { entity ->
+        val entitiesInRange = getAllEntities()?.filter { entity ->
             var isInRange = false
 
-            Backtrack.runWithNearestTrackedDistance(entity) {
+            Backtrack.runWithNearestTrackedDistance(entity!!) {
                 val distance = player.getDistanceToEntityBox(entity)
                 isInRange = when (timerBoostMode.lowercase()) {
                     "normal" -> distance <= rangeValue
@@ -433,7 +433,7 @@ object TimerRange : Module("TimerRange", ModuleCategory.COMBAT) {
         }
 
         // Find the nearest entity
-        return entitiesInRange.minByOrNull { player.getDistanceToEntityBox(it) }
+        return entitiesInRange?.minByOrNull { player.getDistanceToEntityBox(it!!) }
     }
 
     /**

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AtAllProvider.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/AtAllProvider.kt
@@ -79,12 +79,17 @@ object AtAllProvider : Module("AtAllProvider", ModuleCategory.MISC, subjective =
             if ("@a" in message) {
                 synchronized(sendQueue) {
                     for (playerInfo in mc.netHandler.playerInfoMap) {
-                        val playerName = playerInfo.gameProfile.name
+                        val playerName = playerInfo?.gameProfile?.name
 
                         if (playerName == mc.thePlayer.name)
                             continue
 
-                        sendQueue += message.replace("@a", playerName)
+                        // Replace out illegal characters
+                        val filteredName = playerName?.replace("[^a-zA-Z0-9_]", "")?.let {
+                            message.replace("@a", it)
+                        }
+
+                        sendQueue += filteredName
                     }
                     if (retry) {
                         synchronized(retryQueue) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -1206,7 +1206,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I) {
             if (autoF5) mc.gameSettings.thirdPersonView = 0
             return false
         } else {
-            if (autoF5) mc.gameSettings.thirdPersonView = 1
+            if (autoF5 && mc.gameSettings.thirdPersonView != 1) mc.gameSettings.thirdPersonView = 1
         }
 
         val maxReach = mc.playerController.blockReachDistance


### PR DESCRIPTION
- Fixed AtAllProvider, now should filter illegal characters player name correctly. (Closes #2679)
- Fixed TimerRange, now it should filter out nulled entities/targets. (Fixed #2674 ??)
- Fixed KillAura & Scaffold AutoF5, it should now work properly. (Closes #2673)