### PR TITLE
fix: CEF rendering at wrong refresh rate

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/RefreshRate.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/RefreshRate.kt
@@ -29,4 +29,4 @@ const val CHROME_MAX_REFRESH_RATE = 240
 const val LOWEST_REFRESH_RATE = 60
 
 val refreshRate: Int
-    get() = max(CHROME_MAX_REFRESH_RATE, min(LOWEST_REFRESH_RATE, mc.window.refreshRate))
+    get() = min(CHROME_MAX_REFRESH_RATE, max(LOWEST_REFRESH_RATE, mc.window.refreshRate))


### PR DESCRIPTION
Currently, CEF will always render at 240hz regardless of the monitor's refresh rate. This was caused by a mistake in the target refresh rate calculation. This fix should greatly improve performance on weaker computers.

Fixes https://github.com/CCBlueX/LiquidBounce/issues/2726