### PR TITLE
fix: missing organisation information showing undefined in proxy manager

### DIFF
--- a/src-theme/src/integration/types.ts
+++ b/src-theme/src/integration/types.ts
@@ -292,14 +292,14 @@ export interface Proxy {
         password: string;
     } | undefined;
     ipInfo: {
-        city: string;
-        country: string;
+        city?: string;
+        country?: string;
         ip: string;
-        loc: string;
-        org: string;
-        postal: string;
-        region: string;
-        timezone: string;
+        loc?: string;
+        org?: string;
+        postal?: string;
+        region?: string;
+        timezone?: string;
     } | undefined;
 }
 

--- a/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
+++ b/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
@@ -184,7 +184,7 @@
                     favorite={proxy.favorite}
                     on:dblclick={() => connectToProxy(proxy.id)}>
                 <svelte:fragment slot="subtitle">
-                    <span class="subtitle">{proxy.ipInfo?.org}</span>
+                    <span class="subtitle">{proxy.ipInfo?.org ?? "Unknown"}</span>
                 </svelte:fragment>
 
                 <svelte:fragment slot="tag">


### PR DESCRIPTION
It now says "Unknown" instead.

![image](https://github.com/CCBlueX/LiquidBounce/assets/18741573/9bf1c69a-12c7-45a3-97dc-5e0693427b41)
