### PR TITLE
feat(nextgen): Spigot antispam bypass using exclusions

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.event.events.ChunkLoadEvent;
 import net.ccbluex.liquidbounce.event.events.ChunkUnloadEvent;
 import net.ccbluex.liquidbounce.event.events.DeathEvent;
 import net.ccbluex.liquidbounce.event.events.HealthUpdateEvent;
+import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleDisabler;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiExploit;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleNoRotateSet;
 import net.ccbluex.liquidbounce.utils.aiming.Rotation;
@@ -46,6 +47,7 @@ import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -162,6 +164,14 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         }
 
         ci.cancel();
+    }
+
+    @ModifyVariable(method = "sendChatMessage", at = @At("HEAD"), ordinal = 0, argsOnly = true)
+    private String handleSendMessage(String content) {
+        if (ModuleDisabler.INSTANCE.getEnabled() && ModuleDisabler.SpigotSpam.INSTANCE.isActive()) {
+            return ModuleDisabler.SpigotSpam.INSTANCE.getMessage() + " " + content;
+        }
+        return content;
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDisabler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDisabler.kt
@@ -54,7 +54,8 @@ object ModuleDisabler : Module("Disabler", Category.EXPLOIT) {
             AdvancedAntiCheat1910,
             VulcanRiptide,
             GrimSpectate,
-            VulcanScaffold
+            VulcanScaffold,
+            SpigotSpam
         )
     )
 
@@ -62,6 +63,29 @@ object ModuleDisabler : Module("Disabler", Category.EXPLOIT) {
         chat(regular(message("info")))
         super.enable()
     }
+
+    /**
+     * Author: Nullable
+     * Original founder: unknown
+     *
+     * Spigot kicks people who spam messages.
+     * There is an exclusion list, which by default includes /skill
+     *
+     * Bukkit only checks if your message starts with the exclusion, it
+     * does not care if it's a command or not.
+     * By illegally adding /skill to the start of our message and
+     * not sending it as a command, we can bypass antispam.
+     */
+    object SpigotSpam : Choice("SpigotSpam") {
+
+        val message by text("Message", "/skill")
+
+        override val parent: ChoiceConfigurable<*>
+            get() = modes
+
+        // Handled in MixinClientPlayNetworkHandler.java
+    }
+
 
     /**
      * Tested on eu.loyisa.cn, anticheat-test.com


### PR DESCRIPTION
By default, spigot antispam has a execlude list which includes /skill. If you send /skill before your message without it being a command execution packet, spigot thinks you are execluded from the spam. Original founder is unknown.