### PR TITLE
fix: gui scale being limited to two options

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinGameOptions.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinGameOptions.java
@@ -3,10 +3,13 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.client;
 import net.ccbluex.liquidbounce.utils.client.VanillaTranslationRecognizer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.GameOptions;
+import net.minecraft.client.option.SimpleOption;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.io.File;
 
@@ -22,4 +25,17 @@ public class MixinGameOptions {
         VanillaTranslationRecognizer.INSTANCE.setBuildingVanillaKeybinds(false);
     }
 
+    /**
+     * Hook GUI scale adjustment
+     * <p>
+     * This is used to set the default GUI scale to 2X on AUTO because the default is TOO HUGE.
+     * On WQHD and HD displays, the default GUI scale is way too big. 4K might be fine, but
+     * the majority of players are not using 4K displays.
+     */
+    @Inject(method = "getGuiScale", at = @At("RETURN"))
+    private void injectGuiScale(CallbackInfoReturnable<SimpleOption<Integer>> cir) {
+        if (cir.getReturnValue().getValue() == 0) {
+            cir.getReturnValue().setValue(2);
+        }
+    }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWindow.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWindow.java
@@ -98,23 +98,6 @@ public class MixinWindow {
         }
     }
 
-    /**
-     * Hook GUI scale adjustment
-     * <p>
-     * This is used to set the default GUI scale to 2X on AUTO because the default is TOO HUGE.
-     * On WQHD and HD displays, the default GUI scale is way too big. 4K might be fine, but
-     * the majority of players are not using 4K displays.
-     */
-    @ModifyVariable(method = "calculateScaleFactor", at = @At("HEAD"), index = 1, argsOnly = true)
-    public int hookGuiScale(int guiScale) {
-        // Default AUTO gui scale to 2X
-        if (guiScale == 0) {
-            return 2;
-        }
-
-        return guiScale;
-    }
-
     @Inject(method = "setScaleFactor", at = @At("RETURN"))
     public void hookScaleFactor(double scaleFactor, CallbackInfo ci) {
         EventManager.INSTANCE.callEvent(new ScaleFactorChangeEvent(scaleFactor));


### PR DESCRIPTION
Due to the way, we set the default GUI scale to 2, only two GUI scales are available at the moment. This isn't enough for high resolution monitor. This pull request fixes this issue.