### PR TITLE
feat: implement gui scale for clickgui properly

### DIFF
--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -1,29 +1,40 @@
 <script lang="ts">
     import {onMount} from "svelte";
-    import {getModules} from "../../integration/rest";
+    import {getComponents, getGameWindow, getModules} from "../../integration/rest";
     import {groupByCategory} from "../../integration/util";
     import type {GroupedModules, Module} from "../../integration/types";
     import Panel from "./Panel.svelte";
     import Search from "./Search.svelte";
     import Description from "./Description.svelte";
     import {fade} from "svelte/transition";
+    import {listen} from "../../integration/ws";
+    import type {ScaleFactorChangeEvent} from "../../integration/events";
 
     let categories: GroupedModules = {};
     let modules: Module[] = [];
-    let highlightModuleName = "";
+    let scaleFactor = 2;
+    $: zoom = scaleFactor * 50;
 
     onMount(async () => {
+        const gameWindow = await getGameWindow();
+        scaleFactor = gameWindow.scaleFactor;
+
         modules = await getModules();
         categories = groupByCategory(modules);
     });
+
+    listen("scaleFactorChange", (data: ScaleFactorChangeEvent) => {
+        scaleFactor = data.scaleFactor;
+    });
 </script>
 
-<div class="clickgui" transition:fade|global={{duration: 200}}>
-    <Description />
+<div class="clickgui" transition:fade|global={{duration: 200}}
+     style="zoom: {zoom}%; width: {2 / scaleFactor * 100}vw; height: {2 / scaleFactor * 100}vh;">
+    <Description/>
     <Search modules={structuredClone(modules)}/>
 
     {#each Object.entries(categories) as [category, modules], panelIndex}
-        <Panel {category} {modules} {panelIndex}/>
+        <Panel {category} {modules} {panelIndex} {scaleFactor}/>
     {/each}
 </div>
 
@@ -31,10 +42,6 @@
   @import "../../colors.scss";
 
   .clickgui {
-    height: 100vh;
-    width: 100vw;
-    max-width: 100vw;
-    max-height: 100vh;
     background-color: rgba($clickgui-base-color, 0.6);
     overflow: hidden;
     position: relative;

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
-    import { afterUpdate, onMount } from "svelte";
-    import type { Module as TModule } from "../../integration/types";
-    import { listen } from "../../integration/ws";
+    import {afterUpdate, onMount} from "svelte";
+    import type {Module as TModule} from "../../integration/types";
+    import {listen} from "../../integration/ws";
     import Module from "./Module.svelte";
-    import type { ToggleModuleEvent } from "../../integration/events";
+    import type {ToggleModuleEvent} from "../../integration/events";
     import {fly} from "svelte/transition";
     import {quintOut} from "svelte/easing";
     import {highlightModuleName, maxPanelZIndex} from "./clickgui_store";
-    import { setItem } from "../../integration/persistent_storage";
+    import {setItem} from "../../integration/persistent_storage";
 
     export let category: string;
     export let modules: TModule[];
     export let panelIndex: number;
+    export let scaleFactor: number;
 
     let panelElement: HTMLElement;
     let modulesElement: HTMLElement;
@@ -76,8 +77,8 @@
     }
 
     function fixPosition() {
-        panelConfig.left = clamp(panelConfig.left, 0, document.documentElement.clientWidth - panelElement.offsetWidth);
-        panelConfig.top = clamp(panelConfig.top, 0, document.documentElement.clientHeight -panelElement.offsetHeight);
+        panelConfig.left = clamp(panelConfig.left, 0, document.documentElement.clientWidth * (2 / scaleFactor) - panelElement.offsetWidth);
+        panelConfig.top = clamp(panelConfig.top, 0, document.documentElement.clientHeight * (2 / scaleFactor) - panelElement.offsetHeight);
     }
 
     function onMouseDown() {
@@ -88,8 +89,8 @@
 
     function onMouseMove(e: MouseEvent) {
         if (moving) {
-            panelConfig.left += e.screenX - prevX;
-            panelConfig.top += e.screenY - prevY;
+            panelConfig.left += (e.screenX - prevX) * (2 / scaleFactor);
+            panelConfig.top += (e.screenY - prevY) * (2 / scaleFactor);
         }
 
         prevX = e.screenX;
@@ -163,7 +164,7 @@
     });
 </script>
 
-<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove} />
+<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove}/>
 
 <div
         class="panel"
@@ -191,8 +192,8 @@
     </div>
 
     <div class="modules" on:scroll={handleModulesScroll} bind:this={modulesElement}>
-        {#each renderedModules as { name, enabled, description, aliases } (name)}
-            <Module {name} {enabled} {description} {aliases} />
+        {#each renderedModules as {name, enabled, description, aliases} (name)}
+            <Module {name} {enabled} {description} {aliases}/>
         {/each}
     </div>
 </div>


### PR DESCRIPTION
Currently, ClickGUI ignores the selected Minecraft GUI scale.