### PR TITLE
feat: netty server default port

### DIFF
--- a/src-theme/README.md
+++ b/src-theme/README.md
@@ -9,8 +9,7 @@ This directory contains the source code of LiquidBounce's default theme made wit
 1. Install [Node.js](https://nodejs.org/en) on your computer (either latest or stable should be fine).
 2. Install required dependencies using `npm install`.
 3. Set `IN_DEV` in [host.ts](https://github.com/CCBlueX/LiquidBounce/blob/nextgen/src-theme/src/integration/host.ts) to `true`.
-4. Change `PORT` to `15000` in [NettyServer.kt](https://github.com/CCBlueX/LiquidBounce/blob/nextgen/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/NettyServer.kt).
-5. Launch the client.
-6. Run `npm run dev` to start a development server.
+4. Launch the client.
+5. Run `npm run dev` to start a development server.
 
 Make sure not to push the changes made to `host.ts` and `NettyServer.kt`!

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/NettyServer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/NettyServer.kt
@@ -42,6 +42,7 @@ internal class NettyServer {
         val PORT = findAvailablePort()
         val NETTY_ROOT = "http://127.0.0.1:$PORT"
 
+        @Suppress("SwallowedException")
         private fun findAvailablePort() = try {
             Socket("localhost", DEFAULT_PORT).use {
                 logger.info("Default port unavailable. Falling back to random port.")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/NettyServer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/NettyServer.kt
@@ -30,15 +30,27 @@ import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import net.ccbluex.liquidbounce.utils.client.ErrorHandler
 import net.ccbluex.liquidbounce.utils.client.logger
+import java.net.Socket
 
 
 internal class NettyServer {
 
     companion object {
 
-        val PORT = (15000..17000).random()
+        private const val DEFAULT_PORT = 15000
+
+        val PORT = findAvailablePort()
         val NETTY_ROOT = "http://127.0.0.1:$PORT"
 
+        private fun findAvailablePort() = try {
+            Socket("localhost", DEFAULT_PORT).use {
+                logger.info("Default port unavailable. Falling back to random port.")
+                (15001..17000).random()
+            }
+        } catch (e: Exception) {
+            logger.info("Default port $DEFAULT_PORT available.")
+            DEFAULT_PORT
+        }
     }
 
     fun startServer(port: Int = PORT) {


### PR DESCRIPTION
Currently, a random port between 15000 and 17000 will be selected on launch. This makes it annoying for theme developers to connect to the correct port. This pull request sets the default port to 15000 and only falls back to a random port if it isn't available.