### PR TITLE
feat: clickgui scale setting

### DIFF
--- a/src-theme/src/integration/events.ts
+++ b/src-theme/src/integration/events.ts
@@ -80,3 +80,7 @@ export interface ProxyCheckResultEvent {
 export interface SpaceSeperatedNamesChangeEvent {
     value: boolean;
 }
+
+export interface ClickGuiScaleChangeEvent {
+    value: number;
+}

--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import {onMount} from "svelte";
-    import {getComponents, getGameWindow, getModules} from "../../integration/rest";
+    import {getComponents, getGameWindow, getModules, getModuleSettings} from "../../integration/rest";
     import {groupByCategory} from "../../integration/util";
     import type {GroupedModules, Module} from "../../integration/types";
     import Panel from "./Panel.svelte";
@@ -8,11 +8,13 @@
     import Description from "./Description.svelte";
     import {fade} from "svelte/transition";
     import {listen} from "../../integration/ws";
-    import type {ScaleFactorChangeEvent} from "../../integration/events";
+    import type {ClickGuiScaleChangeEvent, ScaleFactorChangeEvent} from "../../integration/events";
 
     let categories: GroupedModules = {};
     let modules: Module[] = [];
-    let scaleFactor = 2;
+    let minecraftScaleFactor = 2;
+    let clickGuiScaleFactor = 1;
+    $: scaleFactor = minecraftScaleFactor * clickGuiScaleFactor;
     $: zoom = scaleFactor * 50;
 
     onMount(async () => {
@@ -21,10 +23,17 @@
 
         modules = await getModules();
         categories = groupByCategory(modules);
+
+        const clickGuiSettings = await getModuleSettings("ClickGUI");
+        clickGuiScaleFactor = clickGuiSettings.value.find(v => v.name === "Scale")?.value as number ?? 1
     });
 
-    listen("scaleFactorChange", (data: ScaleFactorChangeEvent) => {
-        scaleFactor = data.scaleFactor;
+    listen("scaleFactorChange", (e: ScaleFactorChangeEvent) => {
+        scaleFactor = e.scaleFactor;
+    });
+
+    listen("clickGuiScaleChange", (e: ClickGuiScaleChangeEvent) => {
+        clickGuiScaleFactor = e.value;
     });
 </script>
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -114,7 +114,8 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     DrawOutlinesEvent::class,
     OverlayMessageEvent::class,
     ScheduleInventoryActionEvent::class,
-    SpaceSeperatedNamesChangeEvent::class
+    SpaceSeperatedNamesChangeEvent::class,
+    ClickGuiScaleChangeEvent::class
 )
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -37,6 +37,10 @@ import net.ccbluex.liquidbounce.web.theme.component.Component
 import net.minecraft.client.network.ServerInfo
 import net.minecraft.world.GameMode
 
+@Nameable("clickGuiScaleChange")
+@WebSocketEvent
+class ClickGuiScaleChangeEvent(val value: Float): Event()
+
 @Nameable("spaceSeperatedNamesChange")
 @WebSocketEvent
 class SpaceSeperatedNamesChangeEvent(val value: Boolean) : Event()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -18,6 +18,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.events.ClickGuiScaleChangeEvent
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.web.integration.VirtualScreenType
@@ -32,6 +34,11 @@ import org.lwjgl.glfw.GLFW
 
 object ModuleClickGui :
     Module("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY_RIGHT_SHIFT, disableActivation = true) {
+
+    @Suppress("UnusedPrivateProperty")
+    private val scale by float("Scale", 1f, 0.5f..2f).onChanged {
+        EventManager.callEvent(ClickGuiScaleChangeEvent(it))
+    }
 
     override fun enable() {
         // Pretty sure we are not in a game, so we can't open the clickgui

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/ClientSocket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/ClientSocket.kt
@@ -49,6 +49,7 @@ object ClientSocket {
 
         // Most essential events
         "spaceSeperatedNamesChange",
+        "clickGuiScaleChange",
         "toggleModule",
         "notification",
         "accountManagerMessage",


### PR DESCRIPTION
Currently, ClickGUI size is only affected by Minecraft's GUI scale. This pull request adds a `Scale` setting to the ClickGUI module that allows resizing it independently.

Closes https://github.com/CCBlueX/LiquidBounce/issues/2696