### PR TITLE
fix: sliders not using full width of clickgui panels

### DIFF
--- a/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
@@ -100,6 +100,6 @@
 
   .slider {
     grid-area: d;
-    margin-right: 10px;
+    padding-right: 10px;
   }
 </style>

--- a/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
@@ -94,6 +94,6 @@
 
     .slider {
         grid-area: d;
-        margin-right: 10px;
+        padding-right: 10px;
     }
 </style>

--- a/src-theme/src/routes/clickgui/setting/IntRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/IntRangeSetting.svelte
@@ -100,6 +100,6 @@
 
     .slider {
         grid-area: d;
-        margin-right: 10px;
+        padding-right: 10px;
     }
 </style>

--- a/src-theme/src/routes/clickgui/setting/IntSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/IntSetting.svelte
@@ -95,6 +95,6 @@
 
     .slider {
         grid-area: d;
-        margin-right: 10px;
+        padding-right: 10px;
     }
 </style>


### PR DESCRIPTION
Before:
![image](https://github.com/CCBlueX/LiquidBounce/assets/18741573/c341036b-de87-4ed7-9cac-d0c936ff36f7)

After:
![image](https://github.com/CCBlueX/LiquidBounce/assets/18741573/0169698f-9c4f-4ee4-b97d-a2199ea19656)

