### PR TITLE
feat: space seperated names for drop down values

### DIFF
--- a/src-theme/src/routes/clickgui/setting/common/Dropdown.svelte
+++ b/src-theme/src/routes/clickgui/setting/common/Dropdown.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import {createEventDispatcher} from "svelte";
+    import {convertToSpacedString, spaceSeperatedNames} from "../../../../theme/theme_config";
 
     export let name: string;
     export let options: string[];
@@ -27,7 +28,7 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="dropdown" class:expanded on:click={() => (expanded = !expanded)}>
     <div class="head" bind:this={dropdownHead}>
-        <span class="text">{name} &bull; {value}</span>
+        <span class="text">{name} &bull; {$spaceSeperatedNames ? convertToSpacedString(value) : value}</span>
     </div>
 
     {#if expanded}
@@ -38,7 +39,7 @@
                         class:active={o === value}
                         on:click={() => updateValue(o)}
                 >
-                    {o}
+                    {$spaceSeperatedNames ? convertToSpacedString(o) : o}
                 </div>
             {/each}
         </div>


### PR DESCRIPTION
Currently, space seperated names are only applied to value names. Drop down values should support it too.