### PR TITLE
fix: width of add account modal

### DIFF
--- a/src-theme/src/routes/menu/common/modal/Modal.svelte
+++ b/src-theme/src/routes/menu/common/modal/Modal.svelte
@@ -44,7 +44,7 @@
 
   .modal {
     background-color: rgba($menu-base-color, 0.7);
-    width: 500px;
+    min-width: 500px;
     position: fixed;
     left: 50%;
     top: 50%;

--- a/src-theme/src/routes/menu/common/modal/Tabs.svelte
+++ b/src-theme/src/routes/menu/common/modal/Tabs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import {type ComponentType, createEventDispatcher} from "svelte";
 
+    let availableTabsElement: HTMLElement | undefined;
+
     export let tabs: {
         title: string,
         icon: string,
@@ -19,7 +21,7 @@
 </script>
 
 <div class="tabs">
-    <div class="available-tabs">
+    <div class="available-tabs" bind:this={availableTabsElement}>
         {#each tabs as {title, icon}, index}
             <button class="tab-button" class:active={tabs[activeTab].title === title}
                     on:click={() => setActiveTab(index)}>
@@ -29,7 +31,9 @@
         {/each}
     </div>
 
-    <svelte:component this={tabs[activeTab].component}/>
+    <div style="width: {availableTabsElement?.clientWidth}px">
+        <svelte:component this={tabs[activeTab].component}/>
+    </div>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Currently, the width of all menu modals is hardcoded to be 500px. Relieving this constraint will lead to jumpy behaviour in certain situations. This pull request fixes those issues by applying a width to a tabs content by calculating the minimum required width of the tabs buttons.