### PR TITLE
fix: clickgui scaling not working properly

### DIFF
--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -19,7 +19,7 @@
 
     onMount(async () => {
         const gameWindow = await getGameWindow();
-        scaleFactor = gameWindow.scaleFactor;
+        minecraftScaleFactor = gameWindow.scaleFactor;
 
         modules = await getModules();
         categories = groupByCategory(modules);
@@ -29,7 +29,7 @@
     });
 
     listen("scaleFactorChange", (e: ScaleFactorChangeEvent) => {
-        scaleFactor = e.scaleFactor;
+        minecraftScaleFactor = e.scaleFactor;
     });
 
     listen("clickGuiScaleChange", (e: ClickGuiScaleChangeEvent) => {


### PR DESCRIPTION
Currently, the configured ClickGUI scale is ignored under some circumstances, which causes scaling to behave unexpectedly.