### PR TITLE
fix: FastClimb always active on Terrain Speed

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/fastclimb/FastClimb.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/fastclimb/FastClimb.kt
@@ -38,7 +38,7 @@ import net.minecraft.util.math.Direction
  */
 internal object FastClimb : ToggleableConfigurable(ModuleTerrainSpeed, "FastClimb", true) {
 
-    private val modes = choices(ModuleTerrainSpeed, "Mode", Motion, arrayOf(Motion, Clip))
+    private val modes = choices(this, "Mode", Motion, arrayOf(Motion, Clip))
 
     /**
      * Not server or anti-cheat-specific mode.


### PR DESCRIPTION
fixes https://github.com/CCBlueX/LiquidBounce/issues/2937