### PR TITLE
fix: raycast range not dynamically adjusting

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
@@ -107,7 +107,7 @@ public abstract class MixinGameRenderer {
                         RotationManager.INSTANCE.getServerRotation() :
                         new Rotation(camera.getYaw(tickDelta), camera.getPitch(tickDelta));
 
-        return RaytracingExtensionsKt.raycast(Math.max(blockInteractionRange, entityInteractionRange), rotation,
+        return RaytracingExtensionsKt.raycast(rotation, Math.max(blockInteractionRange, entityInteractionRange),
                 false, tickDelta);
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
@@ -183,7 +183,7 @@ object AutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking", false)
             return
         }
 
-        val hitResult = raycast(range.toDouble(), rotationToTheServer, includeFluids = false) ?: return
+        val hitResult = raycast(rotationToTheServer) ?: return
 
         if (hitResult.type != HitResult.Type.BLOCK) {
             return

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
@@ -71,7 +71,7 @@ object ModuleClickTp : Module("ClickTp", Category.EXPLOIT, aliases = arrayOf("Cl
     private val fullBox = Box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
 
     val repeatable = repeatable {
-        val raycast = raycast(range.toDouble(), player.rotation, false)
+        val raycast = raycast(player.rotation, range = range.toDouble())
         val blockPos = raycast?.blockPos.apply {
             highlightBlock = this
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallMLG.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallMLG.kt
@@ -100,7 +100,7 @@ internal object NoFallMLG : Choice("MLG") {
         val target = currentTarget ?: return@repeatable
         val rotation = RotationManager.serverRotation
 
-        val rayTraceResult = raycast(4.5, rotation) ?: return@repeatable
+        val rayTraceResult = raycast(rotation) ?: return@repeatable
 
         if (rayTraceResult.type != HitResult.Type.BLOCK
             || rayTraceResult.blockPos != target.placementTarget.interactedBlockPos

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleIgnite.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleIgnite.kt
@@ -125,7 +125,7 @@ object ModuleIgnite : Module("Ignite", Category.WORLD) {
     @Suppress("unused")
     val placementHandler = repeatable {
         val target = targetTracker.lockedOnTarget ?: return@repeatable
-        val raycast = raycast(4.5, RotationManager.serverRotation) ?: return@repeatable
+        val raycast = raycast(RotationManager.serverRotation) ?: return@repeatable
 
         if (raycast.type != HitResult.Type.BLOCK || raycast.blockPos != target.blockPos.down()) {
             return@repeatable

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
@@ -392,7 +392,8 @@ object ModuleScaffold : Module("Scaffold", Category.WORLD) {
         } else {
             RotationManager.serverRotation
         }
-        val currentCrosshairTarget = raycast(3.0, currentRotation)
+
+        val currentCrosshairTarget = raycast(currentRotation)
 
         val currentDelay = delay.random()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldGodBridgeTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldGodBridgeTechnique.kt
@@ -68,7 +68,7 @@ object ScaffoldGodBridgeTechnique : ScaffoldTechnique("GodBridge"), ScaffoldLedg
 
         // todo: introduce rotation prediction because currently I abuse [howLongItTakes] to get the ticks
         //   and simply check for the correct rotation without considering the Rotation Manager at all
-        val currentCrosshairTarget = raycast(3.0, rotation)
+        val currentCrosshairTarget = raycast(rotation)
 
         if (target == null || currentCrosshairTarget == null) {
             if (ledgeSoon) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsInteractionUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/JsInteractionUtil.kt
@@ -72,7 +72,7 @@ object JsInteractionUtil {
         val bestPlacement = findBestBlockPlacementTarget(blockPos, blockPlacementOptions)
             ?: return false
         val rotation = bestPlacement.rotation.fixedSensitivity()
-        val rayTraceResult = raycast(4.5, rotation) ?: return false
+        val rayTraceResult = raycast(rotation) ?: return false
 
         if (rayTraceResult.type != HitResult.Type.BLOCK) {
             return false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RaytracingExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RaytracingExtensions.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.entity.eyes
 import net.minecraft.block.BlockState
 import net.minecraft.block.ShapeContext
@@ -30,6 +31,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import net.minecraft.util.math.Vec3d
 import net.minecraft.world.RaycastContext
+import kotlin.math.max
 
 fun rayTraceCollidingBlocks(start: Vec3d, end: Vec3d): BlockHitResult? {
     val result = mc.world!!.raycast(
@@ -97,8 +99,8 @@ fun raytraceBlock(
 }
 
 fun raycast(
-    range: Double,
     rotation: Rotation,
+    range: Double = max(player.blockInteractionRange, player.entityInteractionRange),
     includeFluids: Boolean = false,
     tickDelta: Float = 1.0f,
 ): BlockHitResult? {


### PR DESCRIPTION
- fixes possible detection method (for upcoming 1.20.5+ anti-cheat)
- fixes scaffold being too slow to keep up with SameY
- fix KillAura AutoBlock interaction range too short or high (depending on what was configured)