### PR TITLE
LEGACY: KillAura, Auto/LocalSettings, StaffDetector, Velocity Updates

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/AutoSettingsCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/AutoSettingsCommand.kt
@@ -5,6 +5,7 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands
 
+import kotlinx.coroutines.*
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.api.ClientApi
 import net.ccbluex.liquidbounce.api.Status
@@ -19,9 +20,9 @@ import net.ccbluex.liquidbounce.utils.misc.HttpUtils.get
 import net.ccbluex.liquidbounce.utils.misc.StringUtils
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
-import kotlin.concurrent.thread
 
 object AutoSettingsCommand : Command("autosettings", "autosetting", "settings", "setting", "config") {
+
     /**
      * Execute commands with provided [args]
      */
@@ -30,119 +31,122 @@ object AutoSettingsCommand : Command("autosettings", "autosetting", "settings", 
 
         if (args.size <= 1) {
             chatSyntax("$usedAlias <load/list/upload/report>")
-
             return
         }
 
-        when (args[1].lowercase()) {
-            // Load subcommand
-            "load" -> {
-                if (args.size < 3) {
-                    chatSyntax("$usedAlias load <name/url>")
-                    return
-                }
+        GlobalScope.launch {
+            when (args[1].lowercase()) {
+                "load" -> loadSettings(args)
+                "report" -> reportSettings(args)
+                "upload" -> uploadSettings(args)
+                "list" -> listSettings()
+                else -> chatSyntax("$usedAlias <load/list/upload/report>")
+            }
+        }
+    }
 
-                thread {
-                    runCatching {
-                        chat("Loading settings...")
-
-                        // Load settings and apply them
-                        val settings = if (args[2].startsWith("http")) {
-                            val (text, code) = get(args[2])
-                            if (code != 200) {
-                                error(text)
-                            }
-
-                            text
-                        } else {
-                            ClientApi.requestSettingsScript(args[2])
-                        }
-
-                        chat("Applying settings...")
-                        SettingsUtils.applyScript(settings)
-                    }.onSuccess {
-                        chat("§6Settings applied successfully")
-                        addNotification(Notification("Updated Settings"))
-                        playEdit()
-                    }.onFailure {
-                        LOGGER.error("Failed to load settings", it)
-                        chat("Failed to load settings: ${it.message}")
-                    }
-                }
+    // Load subcommand
+    private suspend fun loadSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            if (args.size < 3) {
+                chatSyntax("${args[0].lowercase()} load <name/url>")
+                return@withContext
             }
 
-            // Report subcommand
-            "report" -> {
-                if (args.size < 3) {
-                    chatSyntax("$usedAlias report <name>")
-                    return
-                }
-
-                thread {
-                    runCatching {
-                        val response = ClientApi.reportSettings(args[2])
-
-                        when (response.status) {
-                            Status.SUCCESS -> chat("§6${response.message}")
-                            Status.ERROR -> chat("§c${response.message}")
-                        }
-                    }.onFailure {
-                        LOGGER.error("Failed to report settings", it)
-                        chat("Failed to report settings: ${it.message}")
+            try {
+                val settings = if (args[2].startsWith("http")) {
+                    val (text, code) = get(args[2])
+                    if (code != 200) {
+                        error(text)
                     }
+
+                    text
+                } else {
+                    ClientApi.requestSettingsScript(args[2])
                 }
+
+                chat("Applying settings...")
+                SettingsUtils.applyScript(settings)
+                chat("§6Settings applied successfully")
+                addNotification(Notification("Updated Settings"))
+                playEdit()
+            } catch (e: Exception) {
+                LOGGER.error("Failed to load settings", e)
+                chat("Failed to load settings: ${e.message}")
+            }
+        }
+    }
+
+    // Report subcommand
+    private suspend fun reportSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            if (args.size < 3) {
+                chatSyntax("${args[0].lowercase()} report <name>")
+                return@withContext
             }
 
-            // Report subcommand
-            "upload" -> {
-                val option = if (args.size > 3) StringUtils.toCompleteString(args, 3).lowercase() else "values"
-                val all = "all" in option
-                val values = all || "values" in option
-                val binds = all || "binds" in option
-                val states = all || "states" in option
-
-                if (!values && !binds && !states) {
-                    chatSyntax("$usedAlias upload [all/values/binds/states]...")
-                    return
+            try {
+                val response = ClientApi.reportSettings(args[2])
+                when (response.status) {
+                    Status.SUCCESS -> chat("§6${response.message}")
+                    Status.ERROR -> chat("§c${response.message}")
                 }
+            } catch (e: Exception) {
+                LOGGER.error("Failed to report settings", e)
+                chat("Failed to report settings: ${e.message}")
+            }
+        }
+    }
 
-                thread {
-                    runCatching {
-                        chat("§9Creating settings...")
-                        val settingsScript = SettingsUtils.generateScript(values, binds, states)
-                        chat("§9Uploading settings...")
+    // Upload subcommand
+    private suspend fun uploadSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            val option = if (args.size > 3) StringUtils.toCompleteString(args, 3).lowercase() else "all"
+            val all = "all" in option
+            val values = all || "values" in option
+            val binds = all || "binds" in option
+            val states = all || "states" in option
 
-                        val serverData = mc.currentServerData ?: error("You need to be on a server to upload settings.")
-
-                        val name = "${LiquidBounce.clientCommit}-${serverData.serverIP.replace(".", "_")}"
-                        val response = ClientApi.uploadSettings(name, mc.session.username, settingsScript)
-
-                        when (response.status) {
-                            Status.SUCCESS -> {
-                                chat("§6${response.message}")
-                                chat("§9Token: §6${response.token}")
-
-                                // Store token in clipboard
-                                val stringSelection = StringSelection(response.token)
-                                Toolkit.getDefaultToolkit().systemClipboard.setContents(stringSelection, stringSelection)
-                            }
-                            Status.ERROR -> chat("§c${response.message}")
-                        }
-                    }.onFailure {
-                        LOGGER.error("Failed to upload settings", it)
-                        chat("Failed to upload settings: ${it.message}")
-                    }
-                }
+            if (!values && !binds && !states) {
+                chatSyntax("${args[0].lowercase()} upload [all/values/binds/states]...")
+                return@withContext
             }
 
-            // List subcommand
-            "list" -> {
-                chat("Loading settings...")
+            try {
+                chat("§9Creating settings...")
+                val settingsScript = SettingsUtils.generateScript(values, binds, states)
+                chat("§9Uploading settings...")
 
-                loadSettings(false) {
-                    for (setting in it) {
-                        chat("> ${setting.settingId} (Last updated: ${setting.date}, Status: ${setting.statusType.displayName})")
+                val serverData = mc.currentServerData ?: error("You need to be on a server to upload settings.")
+
+                val name = "${LiquidBounce.clientCommit}-${serverData.serverIP.replace(".", "_")}"
+                val response = ClientApi.uploadSettings(name, mc.session.username, settingsScript)
+
+                when (response.status) {
+                    Status.SUCCESS -> {
+                        chat("§6${response.message}")
+                        chat("§9Token: §6${response.token}")
+
+                        // Store token in clipboard
+                        val stringSelection = StringSelection(response.token)
+                        Toolkit.getDefaultToolkit().systemClipboard.setContents(stringSelection, stringSelection)
                     }
+                    Status.ERROR -> chat("§c${response.message}")
+                }
+            } catch (e: Exception) {
+                LOGGER.error("Failed to upload settings", e)
+                chat("Failed to upload settings: ${e.message}")
+            }
+        }
+    }
+
+    // List subcommand
+    private suspend fun listSettings() {
+        withContext(Dispatchers.IO) {
+            chat("Loading settings...")
+            loadSettings(false) {
+                for (setting in it) {
+                    chat("> ${setting.settingId} (Last updated: ${setting.date}, Status: ${setting.statusType.displayName})")
                 }
             }
         }
@@ -156,16 +160,20 @@ object AutoSettingsCommand : Command("autosettings", "autosetting", "settings", 
         return when (args.size) {
             1 -> listOf("list", "load", "upload", "report").filter { it.startsWith(args[0], true) }
             2 -> {
-                if (args[0].equals("load", true) || args[0].equals("report", true)) {
-                    if (autoSettingsList == null) {
-                        loadSettings(true, 500) {}
-                    }
+                when (args[0].lowercase()) {
+                    "load", "report" -> {
+                        if (autoSettingsList == null) {
+                            loadSettings(true, 500) {}
+                        }
 
-                    if (autoSettingsList != null) {
-                        return autoSettingsList!!.filter { it.settingId.startsWith(args[1], true) }.map { it.settingId }
+                        return autoSettingsList?.filter { it.settingId.startsWith(args[1], true) }?.map { it.settingId }
+                            ?: emptyList()
                     }
+                    "upload" -> {
+                        return listOf("all", "values", "binds", "states").filter { it.startsWith(args[1], true) }
+                    }
+                    else -> emptyList()
                 }
-                return emptyList()
             }
             else -> emptyList()
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/LocalSettingsCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/LocalSettingsCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 
+import kotlinx.coroutines.*
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.file.FileManager.settingsDir
 import net.ccbluex.liquidbounce.ui.client.hud.HUD.addNotification
@@ -18,6 +19,7 @@ import java.io.File
 import java.io.IOException
 
 object LocalSettingsCommand : Command("localsettings", "localsetting", "localconfig") {
+
     /**
      * Execute commands with provided [args]
      */
@@ -29,103 +31,128 @@ object LocalSettingsCommand : Command("localsettings", "localsetting", "localcon
             return
         }
 
-        when (args[1].lowercase()) {
-            "load" -> {
-                if (args.size <= 2) {
-                    chatSyntax("$usedAlias load <name>")
-                    return
-                }
-
-                val settingsFile = File(settingsDir, args[2])
-
-                if (!settingsFile.exists()) {
-                    chat("§cSettings file does not exist!")
-                    return
-                }
-
-                try {
-                    chat("§9Loading settings...")
-                    val settings = settingsFile.readText()
-                    chat("§9Set settings...")
-                    SettingsUtils.applyScript(settings)
-                    chat("§6Settings applied successfully.")
-                    addNotification(Notification("Updated Settings"))
-                    playEdit()
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                }
-            }
-
-            "save" -> {
-                if (args.size <= 2) {
-                    chatSyntax("$usedAlias save <name> [all/values/binds/states]...")
-                    return
-                }
-
-                val settingsFile = File(settingsDir, args[2])
-
-                try {
-                    if (settingsFile.exists())
-                        settingsFile.delete()
-
-                    settingsFile.createNewFile()
-
-                    val option = if (args.size > 3) StringUtils.toCompleteString(args, 3).lowercase() else "values"
-                    val all = "all" in option
-                    val values = all || "values" in option
-                    val binds = all || "binds" in option
-                    val states = all || "states" in option
-
-                    if (!values && !binds && !states) {
-                        chatSyntaxError()
-                        return
-                    }
-
-                    chat("§9Creating settings...")
-                    val settingsScript = SettingsUtils.generateScript(values, binds, states)
-
-                    chat("§9Saving settings...")
-                    settingsFile.writeText(settingsScript)
-
-                    chat("§6Settings saved successfully.")
-                } catch (throwable: Throwable) {
-                    chat("§cFailed to create local config: §3${throwable.message}")
-                    LOGGER.error("Failed to create local config.", throwable)
-                }
-            }
-
-            "delete" -> {
-                if (args.size <= 2) {
-                    chatSyntax("$usedAlias delete <name>")
-                    return
-                }
-
-                val settingsFile = File(settingsDir, args[2])
-
-                if (!settingsFile.exists()) {
-                    chat("§cSettings file does not exist!")
-                    return
-                }
-
-                settingsFile.delete()
-                chat("§6Settings file deleted successfully.")
-            }
-
-            "list" -> {
-                chat("§cSettings:")
-
-                val settings = getLocalSettings() ?: return
-
-                for (file in settings) {
-                    chat("> " + file.name)
-                }
-            }
-
-            "folder" -> {
-                Desktop.getDesktop().open(settingsDir)
+        GlobalScope.launch {
+            when (args[1].lowercase()) {
+                "load" -> loadSettings(args)
+                "save" -> saveSettings(args)
+                "delete" -> deleteSettings(args)
+                "list" -> listSettings()
+                "folder" -> openSettingsFolder()
+                else -> chatSyntax("$usedAlias <load/save/list/delete/folder>")
             }
         }
     }
+
+    private suspend fun loadSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            if (args.size <= 2) {
+                chatSyntax("${args[0].lowercase()} load <name>")
+                return@withContext
+            }
+
+            val settingsFile = File(settingsDir, args[2])
+
+            if (!settingsFile.exists()) {
+                chat("§cSettings file does not exist!")
+                return@withContext
+            }
+
+            try {
+                chat("§9Loading settings...")
+                val settings = settingsFile.readText()
+                chat("§9Set settings...")
+                SettingsUtils.applyScript(settings)
+                chat("§6Settings applied successfully.")
+                addNotification(Notification("Updated Settings"))
+                playEdit()
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private suspend fun saveSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            if (args.size <= 2) {
+                chatSyntax("${args[0].lowercase()} save <name> [all/values/binds/states]...")
+                return@withContext
+            }
+
+            val settingsFile = File(settingsDir, args[2])
+
+            try {
+                if (settingsFile.exists())
+                    settingsFile.delete()
+
+                settingsFile.createNewFile()
+
+                val option = if (args.size > 3) StringUtils.toCompleteString(args, 3).lowercase() else "all"
+                val all = "all" in option
+                val values = all || "values" in option
+                val binds = all || "binds" in option
+                val states = all || "states" in option
+
+                if (!values && !binds && !states) {
+                    chatSyntaxError()
+                    return@withContext
+                }
+
+                chat("§9Creating settings...")
+                val settingsScript = SettingsUtils.generateScript(values, binds, states)
+
+                chat("§9Saving settings...")
+                settingsFile.writeText(settingsScript)
+
+                chat("§6Settings saved successfully.")
+            } catch (throwable: Throwable) {
+                chat("§cFailed to create local config: §3${throwable.message}")
+                LOGGER.error("Failed to create local config.", throwable)
+            }
+        }
+    }
+
+    private suspend fun deleteSettings(args: Array<String>) {
+        withContext(Dispatchers.IO) {
+            if (args.size <= 2) {
+                chatSyntax("${args[0].lowercase()} delete <name>")
+                return@withContext
+            }
+
+            val settingsFile = File(settingsDir, args[2])
+
+            if (!settingsFile.exists()) {
+                chat("§cSettings file does not exist!")
+                return@withContext
+            }
+
+            settingsFile.delete()
+            chat("§6Settings file deleted successfully.")
+        }
+    }
+
+    private suspend fun listSettings() {
+        withContext(Dispatchers.IO) {
+            chat("§cSettings:")
+
+            val settings = settingsDir.listFiles() ?: return@withContext
+
+            for (file in settings) {
+                chat("> " + file.name)
+            }
+        }
+    }
+
+    private suspend fun openSettingsFolder() {
+        withContext(Dispatchers.IO) {
+            try {
+                Desktop.getDesktop().open(settingsDir)
+            } catch (e: IOException) {
+                LOGGER.error("Failed to open settings folder.", e)
+                chat("§cFailed to open settings folder.")
+            }
+        }
+    }
+
 
     override fun tabComplete(args: Array<String>): List<String> {
         if (args.isEmpty()) return emptyList()
@@ -133,22 +160,31 @@ object LocalSettingsCommand : Command("localsettings", "localsetting", "localcon
         return when (args.size) {
             1 -> listOf("delete", "list", "load", "save", "folder").filter { it.startsWith(args[0], true) }
 
-            2 ->
+            2 -> {
                 when (args[0].lowercase()) {
                     "delete", "load" -> {
-                        val settings = getLocalSettings() ?: return emptyList()
-
-                        settings
-                            .map { it.name }
-                            .filter { it.startsWith(args[1], true) }
+                        val settings = settingsDir.listFiles() ?: return emptyList()
+                        settings.map { it.name }.filter { it.startsWith(args[1], true) }
                     }
-
+                    "save" -> {
+                        if (args.getOrNull(1)?.isNotBlank() == true) {
+                            return emptyList()
+                        } else {
+                            emptyList()
+                        }
+                    }
                     else -> emptyList()
                 }
+            }
+
+            3 -> {
+                when (args[0].lowercase()) {
+                    "save" -> listOf("all", "values", "binds", "states").filter { it.startsWith(args[2], true) }
+                    else -> emptyList()
+                }
+            }
 
             else -> emptyList()
         }
     }
-
-    private fun getLocalSettings() = settingsDir.listFiles()
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Fucker.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Fucker.kt
@@ -53,7 +53,7 @@ object Fucker : Module("Fucker", ModuleCategory.WORLD, hideModule = false) {
 
     private val switch by IntegerValue("SwitchDelay", 250, 0..1000)
     private val swing by BoolValue("Swing", true)
-    private val noHit by BoolValue("NoHit", false)
+    val noHit by BoolValue("NoHit", false)
 
     private val rotations by BoolValue("Rotations", true)
     private val strafe by ListValue("Strafe", arrayOf("Off", "Strict", "Silent"), "Off") { rotations }
@@ -76,7 +76,7 @@ object Fucker : Module("Fucker", ModuleCategory.WORLD, hideModule = false) {
      * VALUES
      */
 
-    private var pos: BlockPos? = null
+    var pos: BlockPos? = null
     private var oldPos: BlockPos? = null
     private var blockHitDelay = 0
     private val switchTimer = MSTimer()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -320,7 +320,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I, hideM
     private val safetyLines by BoolValue("SafetyLines", false, subjective = true) { isGodBridgeEnabled }
 
     // Target placement
-    private var placeRotation: PlaceRotation? = null
+    var placeRotation: PlaceRotation? = null
 
     // Launch position
     private var launchY = 0
@@ -408,7 +408,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, Keyboard.KEY_I, hideM
      */
 
     // Target block
-    private var placeInfo: PlaceInfo? = null
+    var placeInfo: PlaceInfo? = null
 
     // Rotation lock
     private var lockRotation: Rotation? = null


### PR DESCRIPTION
- Fixed Killaura Switch mode, for temporary fixes, it will skip new target if the target is not hittable. (Closes #2811)
- Fixed Killaura SwitchDelay, now should be working.
- Fixed Velocity SmoothReverse (Speed stuck).
- Optimized StaffDetector retrieving staff list, and now it should run on start.
- Optimized AutoSettings & LocalSettings Command, now should load online config slightly faster & optimize.
- Optimized ClickGui Online Config Loading, using async.
- Tweaked LocalSettings Command to save `all` by default.
- Added LocalSettings TABComplete for saving local config, which is `all`, `values`, `binds`, and `states`. `(default = all)`
- Improved Killaura onDestroyBlock & onScaffold Checks, properly handle checks of f*cker & scaffold module.