### PR TITLE
fix: unnecessary padding below choice settings

### DIFF
--- a/src-theme/src/routes/clickgui/setting/ChoiceSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/ChoiceSetting.svelte
@@ -50,7 +50,7 @@
             <ExpandArrow bind:expanded on:click={() => skipAnimationDelay = true} />
         </div>
     {:else}
-        <div class="head" class:expanded>
+        <div class="head">
             <Dropdown
                 bind:value={cSetting.active}
                 {options}


### PR DESCRIPTION
Currently, choices without nested settings will still have unnecessary padding below them.