### PR TITLE
refactor(legacy) rename the `VulcanGhost` fly mode to `VulcanBlink`

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
@@ -25,8 +25,8 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.sparta
 import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vanilla.SmoothVanilla
 import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vanilla.Vanilla
 import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.Vulcan
-import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.VulcanGhost
 import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.VulcanOld
+import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.VulcanBlink
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.extensions.stop
 import net.ccbluex.liquidbounce.utils.extensions.stopXZ
@@ -67,7 +67,7 @@ object Fly : Module("Fly", Category.MOVEMENT, Keyboard.KEY_F, hideModule = false
         Spartan, Spartan2, BugSpartan,
 
         // Vulcan
-        Vulcan, VulcanOld, VulcanGhost,
+        Vulcan, VulcanOld, VulcanBlink,
 
         // Other anti-cheats
         MineSecure, HawkEye, HAC, WatchCat, Verus,

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/vulcan/VulcanGhost.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/flymodes/vulcan/VulcanGhost.kt
@@ -14,11 +14,11 @@ import net.minecraft.block.material.Material
 import net.minecraft.network.play.server.S08PacketPlayerPosLook
 import net.minecraft.util.AxisAlignedBB
 
-object VulcanGhost : FlyMode("VulcanGhost") {
+object VulcanBlink : FlyMode("VulcanBlink") {
 
     override fun onEnable() {
         Chat.print("Ensure that you sneak on landing.")
-        Chat.print("After landing, go backward (Air) and go forward to landing location, then sneak again.")
+        Chat.print("After landing, go backwards (aka to the air) and go forward to landing location, then sneak again.")
         Chat.print("And then you can turn off fly.")
     }
 


### PR DESCRIPTION
If I was a new cheater, I'd be very confused by the current name; this pull request fixes that.