### PR TITLE
fix: Sentinel20thApr (CC) fly boost w/o damage

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
@@ -30,7 +30,9 @@ import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModulePingSpoof
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.lang.translation
+import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.notification
+import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
@@ -60,6 +62,8 @@ internal object FlySentinel20thApr : Choice("Sentinel20thApr") {
             ModulePingSpoof.enabled = true
         }
         hasBeenHurt = false
+
+        chat(regular(translation("liquidbounce.module.fly.messages.cubecraft20thAprBoostUsage")))
         super.enable()
     }
 
@@ -71,6 +75,7 @@ internal object FlySentinel20thApr : Choice("Sentinel20thApr") {
     val moveHandler = handler<PlayerMoveEvent> { event ->
         if (player.hurtTime > 0  && !hasBeenHurt) {
             hasBeenHurt = true
+            player.strafe(speed = horizontalSpeed.toDouble())
             notification(
                 "Fly",
                 translation("liquidbounce.module.fly.messages.cubecraft20thAprBoostMessage"),
@@ -100,7 +105,6 @@ internal object FlySentinel20thApr : Choice("Sentinel20thApr") {
             false))
         network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false))
         network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true))
-        player.strafe(speed = horizontalSpeed.toDouble())
     }
 
 

--- a/src/main/resources/assets/liquidbounce/lang/en_us.json
+++ b/src/main/resources/assets/liquidbounce/lang/en_us.json
@@ -388,6 +388,7 @@
   "liquidbounce.module.fly.description": "Allows you to fly in survival mode.",
   "liquidbounce.module.fly.messages.vulcanGhostNewMessage": "Fly anywhere where you want to go in ghost mode. When you are ready, press your use button, jump up and walk anywhere and you will be setback to wherever you moved.",
   "liquidbounce.module.fly.messages.vulcanGhostOldMessage": "Fly anywhere where you want to go. When you want to land, walk off a ledge or jump up and walk in any direction. If AutoDisable is disabled, disable module.",
+  "liquidbounce.module.fly.messages.cubecraft20thAprBoostUsage": "Fly only works through damage abuse. Wait a few seconds until you're ready to fly on a round start!",
   "liquidbounce.module.fly.messages.cubecraft20thAprBoostMessage": "You have been hurt, boosting..",
   "liquidbounce.module.focus.description": "Makes you attack only one specific enemy.",
   "liquidbounce.module.forceUnicodeChat.description": "Translates all chat messages you send to unicode.",


### PR DESCRIPTION
This fixes an issue where people would accidentally get banned if they activated fly too early at the start of a round.