### PR TITLE
fix: lag spike on chunk update

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/common/ChunkUpdateFlag.java
+++ b/src/main/java/net/ccbluex/liquidbounce/common/ChunkUpdateFlag.java
@@ -1,0 +1,5 @@
+package net.ccbluex.liquidbounce.common;
+
+public class ChunkUpdateFlag {
+    public static boolean chunkUpdate = false;
+}

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWorld.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWorld.java
@@ -20,6 +20,7 @@
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.client;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.ccbluex.liquidbounce.common.ChunkUpdateFlag;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.BlockChangeEvent;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleCustomAmbience;
@@ -37,7 +38,7 @@ public class MixinWorld {
 
     @Inject(method = "setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;II)Z", at = @At("RETURN"))
     private void injectBlockStateChange(BlockPos pos, BlockState state, int flags, int maxUpdateDepth, CallbackInfoReturnable<Boolean> cir) {
-        if (MinecraftClient.getInstance().world != (Object) this) {
+        if (MinecraftClient.getInstance().world != (Object) this || ChunkUpdateFlag.chunkUpdate) {
             return;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -74,7 +74,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         ChunkUpdateFlag.chunkUpdate = true;
     }
 
-    @Inject(method = "onChunkDeltaUpdate", at = @At("HEAD"))
+    @Inject(method = "onChunkDeltaUpdate", at = @At("RETURN"))
     private void onChunkDeltaUpdateEnd(ChunkDeltaUpdateS2CPacket packet, CallbackInfo ci) {
         var chunkPosition = packet.sectionPos.toChunkPos();
         EventManager.INSTANCE.callEvent(new ChunkDeltaUpdateEvent(chunkPosition.x, chunkPosition.z));

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -20,12 +20,10 @@
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.network;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.ccbluex.liquidbounce.common.ChunkUpdateFlag;
 import net.ccbluex.liquidbounce.config.Choice;
 import net.ccbluex.liquidbounce.event.EventManager;
-import net.ccbluex.liquidbounce.event.events.ChunkLoadEvent;
-import net.ccbluex.liquidbounce.event.events.ChunkUnloadEvent;
-import net.ccbluex.liquidbounce.event.events.DeathEvent;
-import net.ccbluex.liquidbounce.event.events.HealthUpdateEvent;
+import net.ccbluex.liquidbounce.event.events.*;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disablers.DisablerSpigotSpam;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiExploit;
@@ -69,6 +67,18 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
     @Inject(method = "onUnloadChunk", at = @At("RETURN"))
     private void injectUnloadEvent(UnloadChunkS2CPacket packet, CallbackInfo ci) {
         EventManager.INSTANCE.callEvent(new ChunkUnloadEvent(packet.pos().x, packet.pos().z));
+    }
+
+    @Inject(method = "onChunkDeltaUpdate", at = @At("HEAD"))
+    private void onChunkDeltaUpdateStart(ChunkDeltaUpdateS2CPacket packet, CallbackInfo ci) {
+        ChunkUpdateFlag.chunkUpdate = true;
+    }
+
+    @Inject(method = "onChunkDeltaUpdate", at = @At("HEAD"))
+    private void onChunkDeltaUpdateEnd(ChunkDeltaUpdateS2CPacket packet, CallbackInfo ci) {
+        var chunkPosition = packet.sectionPos.toChunkPos();
+        EventManager.INSTANCE.callEvent(new ChunkDeltaUpdateEvent(chunkPosition.x, chunkPosition.z));
+        ChunkUpdateFlag.chunkUpdate = false;
     }
 
     @Redirect(method = "onExplosion", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/Vec3d;add(DDD)Lnet/minecraft/util/math/Vec3d;"))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -31,6 +31,7 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     GameTickEvent::class,
     BlockChangeEvent::class,
     ChunkLoadEvent::class,
+    ChunkDeltaUpdateEvent::class,
     ChunkUnloadEvent::class,
     DisconnectEvent::class,
     GameRenderEvent::class,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/WorldEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/WorldEvents.kt
@@ -38,6 +38,9 @@ class ChunkUnloadEvent(val x: Int, val z: Int) : Event()
 @Nameable("chunkLoad")
 class ChunkLoadEvent(val x: Int, val z: Int) : Event()
 
+@Nameable("chunkDeltaUpdate")
+class ChunkDeltaUpdateEvent(val x: Int, val z: Int) : Event()
+
 @Nameable("blockChange")
 class BlockChangeEvent(val blockPos: BlockPos, val newState: BlockState) : Event()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
@@ -19,10 +19,7 @@
 package net.ccbluex.liquidbounce.utils.block
 
 import net.ccbluex.liquidbounce.event.Listenable
-import net.ccbluex.liquidbounce.event.events.BlockChangeEvent
-import net.ccbluex.liquidbounce.event.events.ChunkLoadEvent
-import net.ccbluex.liquidbounce.event.events.ChunkUnloadEvent
-import net.ccbluex.liquidbounce.event.events.DisconnectEvent
+import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -44,6 +41,12 @@ object ChunkScanner : Listenable {
         ChunkScannerThread.enqueueChunkUpdate(ChunkScannerThread.UpdateRequest.ChunkUpdateRequest(chunk))
 
         this.loadedChunks.add(ChunkLocation(event.x, event.z))
+    }
+
+    @Suppress("unused")
+    val chunkDeltaUpdateHandler = handler<ChunkDeltaUpdateEvent> { event ->
+        val chunk = mc.world!!.getChunk(event.x, event.z)
+        ChunkScannerThread.enqueueChunkUpdate(ChunkScannerThread.UpdateRequest.ChunkUpdateRequest(chunk))
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/WorldChangeNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/WorldChangeNotifier.kt
@@ -19,10 +19,7 @@
 package net.ccbluex.liquidbounce.utils.block
 
 import net.ccbluex.liquidbounce.event.Listenable
-import net.ccbluex.liquidbounce.event.events.BlockChangeEvent
-import net.ccbluex.liquidbounce.event.events.ChunkLoadEvent
-import net.ccbluex.liquidbounce.event.events.ChunkUnloadEvent
-import net.ccbluex.liquidbounce.event.events.DisconnectEvent
+import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 
 object WorldChangeNotifier : Listenable {
@@ -30,6 +27,16 @@ object WorldChangeNotifier : Listenable {
 
     @Suppress("unused")
     val chunkLoadHandler = handler<ChunkLoadEvent> { event ->
+        val region = Region.fromChunkPosition(event.x, event.z)
+
+        notifyAllSubscribers {
+            it.invalidateChunk(event.x, event.z, true)
+            it.invalidate(region, true)
+        }
+    }
+
+    @Suppress("unused")
+    val chunkDeltaUpdateHandler = handler<ChunkDeltaUpdateEvent> { event ->
         val region = Region.fromChunkPosition(event.x, event.z)
 
         notifyAllSubscribers {

--- a/src/main/resources/liquidbounce.accesswidener
+++ b/src/main/resources/liquidbounce.accesswidener
@@ -154,3 +154,5 @@ mutable field net/minecraft/network/packet/s2c/common/CommonPingS2CPacket parame
 accessible field net/minecraft/entity/LimbAnimator pos F
 
 accessible field net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket entityId I
+
+accessible field net/minecraft/network/packet/s2c/play/ChunkDeltaUpdateS2CPacket sectionPos Lnet/minecraft/util/math/ChunkSectionPos;


### PR DESCRIPTION
on every chunk delta update it triggered multiple [BlockChangeEvent] causing the chunk to be reloaded multiple times even though only one chunk was being updated. Now it is supposed to be handled once.


Current situation:
https://github.com/CCBlueX/LiquidBounce/assets/12410754/830c3307-ed80-4079-9889-8f600acc65ae

