### PR TITLE
feat: RequiresNoInput on AutoClicker

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -43,7 +43,7 @@ object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arra
     object Left : ToggleableConfigurable(this, "Attack", true) {
 
         val clickScheduler = tree(ClickScheduler(ModuleAutoClicker, true))
-
+        internal val requiresNoInput by boolean("RequiresNoInput", false)
         private val objectiveType by enumChoice("Objective", ObjectiveType.ANY)
         private val onItemUse by enumChoice("OnItemUse", Use.WAIT)
         private val weapon by enumChoice("Weapon", Weapon.ANY)
@@ -121,6 +121,7 @@ object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arra
 
     object Right : ToggleableConfigurable(this, "Use", false) {
         val clickScheduler = tree(ClickScheduler(ModuleAutoClicker, false))
+        internal val requiresNoInput by boolean("RequiresNoInput", false)
     }
 
     init {
@@ -129,10 +130,10 @@ object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arra
     }
 
     val attack: Boolean
-        get() = mc.options.attackKey.isPressed
+        get() = mc.options.attackKey.isPressed || Left.requiresNoInput
 
     val use: Boolean
-        get() = mc.options.useKey.isPressed
+        get() = mc.options.useKey.isPressed || Right.requiresNoInput
 
     val tickHandler = repeatable {
         Left.run {


### PR DESCRIPTION
ObjectiveType on Entity will do exactly the same thing as trigger-but with the mouse button held down. However, some may prefer to have the full trigger-bot instead by introducing 'requires no input', which will act exactly like trigger-bot. It is also ideal for auto farming purposes.