### PR TITLE
fix(legacy): Backtrack should now flush properly when not needed & Fakelag now properly work with Scaffold

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Backtrack.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Backtrack.kt
@@ -33,7 +33,6 @@ import net.minecraft.network.Packet
 import net.minecraft.network.handshake.client.C00Handshake
 import net.minecraft.network.play.server.*
 import net.minecraft.network.status.client.C00PacketServerQuery
-import net.minecraft.network.status.server.S01PacketPong
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.Vec3
 import org.lwjgl.opengl.GL11.*
@@ -169,15 +168,19 @@ object Backtrack : Module("Backtrack", Category.COMBAT, hideModule = false) {
                 if (packetQueue.isEmpty() && !shouldBacktrack())
                     return
 
-                when (packet) {
-                    // Ignore chat & pong packets
-                    is S02PacketChat, is S01PacketPong -> return
+                // Flush if packetQueue is not empty when not needed
+                if (packetQueue.isNotEmpty() && !shouldBacktrack()) {
+                    clearPackets()
+                    return
+                }
 
+                when (packet) {
                     // Ignore server related packets
-                    is C00Handshake, is C00PacketServerQuery, is S21PacketChunkData, is S26PacketMapChunkBulk -> return
+                    is C00Handshake, is C00PacketServerQuery, is S02PacketChat ->
+                        return
 
                     // Flush on teleport or disconnect
-                    is S08PacketPlayerPosLook, is S40PacketDisconnect -> {
+                    is S08PacketPlayerPosLook, is S40PacketDisconnect, is S21PacketChunkData, is S26PacketMapChunkBulk -> {
                         clearPackets()
                         return
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/FakeLag.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/FakeLag.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.modules.render.Breadcrumbs
+import net.ccbluex.liquidbounce.features.module.modules.world.Scaffold
 import net.ccbluex.liquidbounce.injection.implementations.IMixinEntity
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.Rotation
@@ -23,7 +24,6 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.network.Packet
 import net.minecraft.network.handshake.client.C00Handshake
 import net.minecraft.network.play.client.*
-import net.minecraft.network.play.server.S06PacketUpdateHealth
 import net.minecraft.network.play.server.S08PacketPlayerPosLook
 import net.minecraft.network.play.server.S12PacketEntityVelocity
 import net.minecraft.network.play.server.S27PacketExplosion
@@ -78,6 +78,12 @@ object FakeLag : Module("FakeLag", Category.COMBAT, gameDetecting = false, hideM
                 blink()
                 return
             }
+        }
+
+        // Proper check to prevent FakeLag while using Scaffold
+        if (Scaffold.handleEvents() && (Scaffold.placeInfo != null || Scaffold.placeRotation != null)) {
+            blink()
+            return
         }
 
         when (packet) {


### PR DESCRIPTION
Second attempt to fix #2965