### PR TITLE
feat(legacy): Added Smart delay for ChestStealer

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -47,11 +47,11 @@ object ChestStealer : Module("ChestStealer", Category.WORLD, hideModule = false)
     private val multiplier by IntegerValue("DelayMultiplier", 50, 0..500){ smartDelay}
 
     private val maxDelay: Int by object : IntegerValue("MaxDelay", 50, 0..500) {
+        override fun isSupported() = !smartDelay
         override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(minDelay)
     }
     private val minDelay by object : IntegerValue("MinDelay", 50, 0..500) {
-        override fun isSupported() = maxDelay > 0
-
+        override fun isSupported() = maxDelay > 0 && !smartDelay
         override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtMost(maxDelay)
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -177,10 +177,8 @@ object ChestStealer : Module("ChestStealer", Category.WORLD, hideModule = false)
 
                     if (smartDelay){
                         if (index + 1 < itemsToSteal.size) {
-                            println("from: (${getCords(slot)[0]},${getCords(slot)[1]}) to: (${getCords(itemsToSteal[index + 1].first)[0]},${getCords(itemsToSteal[index + 1].first)[1]})")
                             val dist = getDistance(getCords(slot), getCords(itemsToSteal[index + 1].first))
                             val trueDelay = sqrt(dist.toDouble())* multiplier
-                            println(trueDelay)
                             delay(randomDelay(trueDelay.toInt(), trueDelay.toInt()+20).toLong())
                         }
                     } else{


### PR DESCRIPTION
- Delay instead of being a randomly generated number between a range, it will be calculated by finding the distance between current and next item to steal.
- Increases chest steal speed for strict anticheat servers
### **Video of it in action.**



https://github.com/CCBlueX/LiquidBounce/assets/87639130/2bdf4562-fe0d-421a-8e0f-1835f6869ff1



