### PR TITLE
feat: Add sprint speed to vanilla fly

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes
 
 import net.ccbluex.liquidbounce.config.Choice
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable
+import net.ccbluex.liquidbounce.config.Configurable
 import net.ccbluex.liquidbounce.config.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -41,19 +42,22 @@ import net.minecraft.util.shape.VoxelShapes
 
 internal object FlyVanilla : Choice("Vanilla") {
 
-    private val horizontalSpeed by float("Horizontal", 0.44f, 0.1f..5f)
-    private val verticalSpeed by float("Vertical", 0.44f, 0.1f..5f)
-
-    object SprintSpeed : ToggleableConfigurable(this, "SprintSpeed", true) {
-        val horizontalSpeed by float("Horizontal", 0.8f, 0.1f..5f)
-        val verticalSpeed by float("Vertical", 0.8f, 0.1f..5f)
-    }
-
     private val glide by float("Glide", 0.0f, -1f..1f)
 
     private val bypassVanillaCheck by boolean("BypassVanillaCheck", true)
 
+    object BaseSpeed : Configurable("BaseSpeed") {
+        val horizontalSpeed by float("Horizontal", 0.44f, 0.1f..5f)
+        val verticalSpeed by float("Vertical", 0.44f, 0.1f..5f)
+    }
+
+    object SprintSpeed : ToggleableConfigurable(this, "SprintSpeed", true) {
+        val horizontalSpeed by float("Horizontal", 1f, 0.1f..5f)
+        val verticalSpeed by float("Vertical", 1f, 0.1f..5f)
+    }
+
     init {
+        tree(BaseSpeed)
         tree(SprintSpeed)
     }
 
@@ -63,9 +67,9 @@ internal object FlyVanilla : Choice("Vanilla") {
     val repeatable = repeatable {
         val useSprintSpeed = mc.options.sprintKey.isPressed && SprintSpeed.enabled
         val hSpeed =
-            if (useSprintSpeed) SprintSpeed.horizontalSpeed else horizontalSpeed
+            if (useSprintSpeed) SprintSpeed.horizontalSpeed else BaseSpeed.horizontalSpeed
         val vSpeed =
-            if (useSprintSpeed) SprintSpeed.verticalSpeed else verticalSpeed
+            if (useSprintSpeed) SprintSpeed.verticalSpeed else BaseSpeed.verticalSpeed
 
         player.strafe(speed = hSpeed.toDouble())
         player.velocity.y = when {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes
 
 import net.ccbluex.liquidbounce.config.Choice
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable
+import net.ccbluex.liquidbounce.config.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
@@ -40,21 +41,36 @@ import net.minecraft.util.shape.VoxelShapes
 
 internal object FlyVanilla : Choice("Vanilla") {
 
-    val horizontalSpeed by float("Horizontal", 0.44f, 0.1f..5f)
-    val verticalSpeed by float("Vertical", 0.44f, 0.1f..5f)
+    private val horizontalSpeed by float("Horizontal", 0.44f, 0.1f..5f)
+    private val verticalSpeed by float("Vertical", 0.44f, 0.1f..5f)
 
-    val glide by float("Glide", 0.0f, -1f..1f)
+    object SprintSpeed : ToggleableConfigurable(this, "SprintSpeed", true) {
+        val horizontalSpeed by float("Horizontal", 0.8f, 0.1f..5f)
+        val verticalSpeed by float("Vertical", 0.8f, 0.1f..5f)
+    }
 
-    val bypassVanillaCheck by boolean("BypassVanillaCheck", true)
+    private val glide by float("Glide", 0.0f, -1f..1f)
+
+    private val bypassVanillaCheck by boolean("BypassVanillaCheck", true)
+
+    init {
+        tree(SprintSpeed)
+    }
 
     override val parent: ChoiceConfigurable<*>
         get() = ModuleFly.modes
 
     val repeatable = repeatable {
-        player.strafe(speed = horizontalSpeed.toDouble())
+        val useSprintSpeed = mc.options.sprintKey.isPressed && SprintSpeed.enabled
+        val hSpeed =
+            if (useSprintSpeed) SprintSpeed.horizontalSpeed else horizontalSpeed
+        val vSpeed =
+            if (useSprintSpeed) SprintSpeed.verticalSpeed else verticalSpeed
+
+        player.strafe(speed = hSpeed.toDouble())
         player.velocity.y = when {
-            player.input.jumping -> verticalSpeed.toDouble()
-            player.input.sneaking -> (-verticalSpeed).toDouble()
+            player.input.jumping -> vSpeed.toDouble()
+            player.input.sneaking -> (-vSpeed).toDouble()
             else -> glide.toDouble()
         }
 


### PR DESCRIPTION
Lets the user define a sprint speed that gets used as the speed when the user presses the sprint key (normally ctrl). I chose to use the sprint speed when pressing the key instead of when the player is actually sprinting, so hunger wouldn't affect it.
![image](https://github.com/CCBlueX/LiquidBounce/assets/85990359/994dd9c9-5432-4f68-a5be-f28c1acf5854)
