### PR TITLE
feat: Improve vclip command to work with bigger distances

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandVClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandVClip.kt
@@ -23,10 +23,14 @@ import net.ccbluex.liquidbounce.features.command.CommandException
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
 import net.ccbluex.liquidbounce.features.module.QuickImports
+import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleCriticals
+import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.variable
 import java.text.DecimalFormat
+import kotlin.math.abs
+import kotlin.math.floor
 
 /**
  * VClip Command
@@ -50,6 +54,11 @@ object CommandVClip : QuickImports {
                 val y =
                     (args[0] as String).toDoubleOrNull() ?: throw CommandException(command.result("invalidDistance"))
 
+                repeat((floor(abs(y) / 10) - 1).toInt()) {
+                    network.sendPacket(MovePacketType.FULL.generatePacket())
+                }
+
+                network.sendPacket(MovePacketType.FULL.generatePacket().apply { this.y += y })
                 player.updatePosition(player.x, player.y + y, player.z)
                 chat(
                     regular(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandVClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandVClip.kt
@@ -55,10 +55,10 @@ object CommandVClip : QuickImports {
                     (args[0] as String).toDoubleOrNull() ?: throw CommandException(command.result("invalidDistance"))
 
                 repeat((floor(abs(y) / 10) - 1).toInt()) {
-                    network.sendPacket(MovePacketType.FULL.generatePacket())
+                    network.sendPacket(MovePacketType.POSITION_AND_ON_GROUND.generatePacket())
                 }
 
-                network.sendPacket(MovePacketType.FULL.generatePacket().apply { this.y += y })
+                network.sendPacket(MovePacketType.POSITION_AND_ON_GROUND.generatePacket().apply { this.y += y })
                 player.updatePosition(player.x, player.y + y, player.z)
                 chat(
                     regular(


### PR DESCRIPTION
By spamming the previous position packet, we can bypass paper's movement limits.

Inspired by https://youtu.be/3HSnDsfkJT8

Seems to be able to teleport up to 200 blocks up and down

