### PR TITLE
chore: removal of ktlint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           CI: true
         with:
-          arguments: genSources build -x test -x detekt -x ktlintCheck
+          arguments: genSources build -x test -x detekt
 
       - name: Upload artifact
         run: |
@@ -75,4 +75,4 @@ jobs:
         env:
           CI: true
         with:
-          arguments: genSources build -x ktlintCheck
+          arguments: genSources build

--- a/build.gradle
+++ b/build.gradle
@@ -23,23 +23,10 @@ plugins {
     id 'fabric-loom'
     id 'org.jetbrains.kotlin.jvm'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'org.jlleitschuh.gradle.ktlint' version '12.1.0'
     id 'com.gorylenko.gradle-git-properties' version '2.4.2'
     id "io.gitlab.arturbosch.detekt" version "1.23.6"
     id "com.github.node-gradle.node" version "7.0.2"
     id 'org.jetbrains.dokka' version '1.9.10'
-}
-
-ktlint {
-    enableExperimentalRules = true
-    ignoreFailures = true
-    disabledRules = ['no-wildcard-imports', 'no-blank-line-before-rbrace']
-
-    reporters {
-        reporter 'plain'
-        reporter 'checkstyle'
-    }
-
 }
 
 sourceCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
Removed ktlint due to parsing issues and conflicts with our preferred formatting style. We will rely on detekt for code smell detection and the IDE's built-in formatting tools, supplemented by manual formatting when needed. This aligns better with our development workflow and emphasis on code readability over strict automated formatting.