### PR TITLE
feat(legacy): Vulcan Scaffold Disabler

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -24,7 +24,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT, hideModule = false) {
         // Grim
         GrimPlace,
 
-        //Vulcan
+        // Vulcan
         VulcanScaffold
     )
 
@@ -53,7 +53,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT, hideModule = false) {
 
     @EventTarget
     fun onUpdate(event: UpdateEvent) {
-        modeModule.onUpdate(event)
+        modeModule.onUpdate()
     }
 
     @EventTarget

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -8,8 +8,10 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.vulcan.VulcanScaffold
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.grim.GrimPlace
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.startsprint.StartSprint
+import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.Vulcan
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.ListValue
 
@@ -20,7 +22,10 @@ object Disabler : Module("Disabler", Category.EXPLOIT, hideModule = false) {
         StartSprint,
 
         // Grim
-        GrimPlace
+        GrimPlace,
+
+        //Vulcan
+        VulcanScaffold
     )
 
     private val modes = disablerModes.map { it.modeName }.toTypedArray()
@@ -48,7 +53,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT, hideModule = false) {
 
     @EventTarget
     fun onUpdate(event: UpdateEvent) {
-        modeModule.onUpdate()
+        modeModule.onUpdate(event)
     }
 
     @EventTarget

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/DisablerMode.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/DisablerMode.kt
@@ -12,7 +12,7 @@ import net.ccbluex.liquidbounce.utils.MinecraftInstance
 open class DisablerMode(val modeName: String) : MinecraftInstance() {
     open fun onPacket(event: PacketEvent) {}
     open fun onMotion() {}
-    open fun onUpdate(event: UpdateEvent) {}
+    open fun onUpdate() {}
     open fun onTick() {}
     open fun onStrafe() {}
     open fun onEnable() {}

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/DisablerMode.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/DisablerMode.kt
@@ -6,12 +6,13 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes
 
 import net.ccbluex.liquidbounce.event.PacketEvent
+import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.utils.MinecraftInstance
 
 open class DisablerMode(val modeName: String) : MinecraftInstance() {
     open fun onPacket(event: PacketEvent) {}
     open fun onMotion() {}
-    open fun onUpdate() {}
+    open fun onUpdate(event: UpdateEvent) {}
     open fun onTick() {}
     open fun onStrafe() {}
     open fun onEnable() {}

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
@@ -8,15 +8,11 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 object VulcanScaffold : DisablerMode("VulcanScaffold") {
 
     override fun onUpdate(event: UpdateEvent) {
-        if(mc.thePlayer.isInWater || mc.thePlayer.isInLava || mc.thePlayer.isDead || mc.thePlayer.isOnLadder) {
-            return
-        }
-        sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SPRINTING))
-        sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.STOP_SPRINTING))
-
-        if(mc.thePlayer.ticksExisted % 20 == 0) {
-            sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SNEAKING))
-            sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+        if(!(mc.thePlayer.isInWater || mc.thePlayer.isInLava || mc.thePlayer.isDead || mc.thePlayer.isOnLadder)) {
+            if(mc.thePlayer.ticksExisted % 20 == 0) {
+                sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SNEAKING))
+                sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+            }
         }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
@@ -1,13 +1,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.vulcan
 
-import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.DisablerMode
 import net.minecraft.network.play.client.C0BPacketEntityAction
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 
 object VulcanScaffold : DisablerMode("VulcanScaffold") {
 
-    override fun onUpdate(event: UpdateEvent) {
+    override fun onUpdate() {
         if(!(mc.thePlayer.isInWater || mc.thePlayer.isInLava || mc.thePlayer.isDead || mc.thePlayer.isOnLadder)) {
             if(mc.thePlayer.ticksExisted % 20 == 0) {
                 sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SNEAKING))

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/vulcan/VulcanScaffold.kt
@@ -1,0 +1,22 @@
+package net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.vulcan
+
+import net.ccbluex.liquidbounce.event.UpdateEvent
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.DisablerMode
+import net.minecraft.network.play.client.C0BPacketEntityAction
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
+
+object VulcanScaffold : DisablerMode("VulcanScaffold") {
+
+    override fun onUpdate(event: UpdateEvent) {
+        if(mc.thePlayer.isInWater || mc.thePlayer.isInLava || mc.thePlayer.isDead || mc.thePlayer.isOnLadder) {
+            return
+        }
+        sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SPRINTING))
+        sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.STOP_SPRINTING))
+
+        if(mc.thePlayer.ticksExisted % 20 == 0) {
+            sendPacket(C0BPacketEntityAction(mc.thePlayer ,C0BPacketEntityAction.Action.START_SNEAKING))
+            sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+        }
+    }
+}


### PR DESCRIPTION
Ported the Vulcan Scaffold Disabler from Nextgen. 
This disables the Scaffold limit check and other scaffold checks on vulcan aswell as the sprint direction checks.