### PR TITLE
feat(legacy): Added VerusFly Disabler

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -11,7 +11,7 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.vulcan.VulcanScaffold
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.grim.GrimPlace
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.startsprint.StartSprint
-import net.ccbluex.liquidbounce.features.module.modules.movement.flymodes.vulcan.Vulcan
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.verus.VerusFly
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.ListValue
 
@@ -25,7 +25,10 @@ object Disabler : Module("Disabler", Category.EXPLOIT, hideModule = false) {
         GrimPlace,
 
         // Vulcan
-        VulcanScaffold
+        VulcanScaffold,
+
+        //Verus
+        VerusFly
     )
 
     private val modes = disablerModes.map { it.modeName }.toTypedArray()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
@@ -1,0 +1,33 @@
+package net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.verus
+
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.DisablerMode
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
+import net.minecraft.init.Blocks
+import net.minecraft.item.ItemStack
+import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
+
+/*
+* Working on Verus: b3898
+* Tested on: anticheat-test.com, eu.loysia.cn
+*
+* Disables most Fly checks on the Verus Anticheat
+* Allowing for slow Vanilla fly and fast onGround speeds
+*/
+
+object VerusFly : DisablerMode("VerusFly") {
+    override fun onUpdate() {
+        val pos = mc.thePlayer.position.add(0.0, -1.5, 0.0)
+        sendPacket(
+            C08PacketPlayerBlockPlacement(
+                pos,
+                1,
+                ItemStack(Blocks.stone.getItem(mc.theWorld, pos)),
+                0.0F,
+                0.5F + Math.random().toFloat() * 0.44.toFloat(),
+                0.0F
+            )
+        )
+
+    }
+
+}


### PR DESCRIPTION

https://github.com/CCBlueX/LiquidBounce/assets/167036593/43dd0ce0-82bd-423b-ac79-c19b8eaffdf5

Added new Fly Disabler for the Verus Anticheat.
This Disabler disables most Fly checks on the Verus Anticheat, allowing for slow Vanilla fly and fast onGround speeds.