### PR TITLE
feat: improve ping spoof

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
 
     private val delay by int("Delay", 500, 0..25000, "ms")
-    private val dynamic by boolean("Dynamic", true)
+    private val dynamic by boolean("Dynamic", false)
     private val pauseDeath by boolean("PauseWhileBeingDead", true)
 
     // stores all packets that have to be sent
@@ -51,8 +51,11 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
     // handles each packet and its delay
     var scope: CoroutineScope? = null
 
+    var starting = true
+
     override fun enable() {
         scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        starting = true
     }
 
     override fun disable() {
@@ -92,24 +95,41 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
         cancel()
         queue.clear()
         scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        starting = true
     }
 
     private fun schedulePacketSending(packet: Packet<*>) {
         scope!!.launch {
             val subtrahend = if (dynamic) {
-                val ping = player.ping
+                var ping = player.ping
 
-                // the ping might vary
-                // over 15 ms variation is probably not really to expect
-                roundDownToIncrement(ping, 15)
+                if (starting && ping > delay) {
+                    starting = false
+                }
+
+                // If the ping wasn't spoofed before, there is no need to correct it.
+                // (Actually, it needs some seconds before reaching the level,
+                // so the spoofed milliseconds will be wrong when joining a server
+                // or enabling this module for some seconds).
+                if (!starting) {
+                    // the player.ping variable is spoofed, so it needs to be corrected
+                    ping -= delay
+                } else {
+                    ping = 0
+                }
+
+                // The ping might vary,
+                // so it should rather keep it above the set ping
+                // over 10 ms variation is probably not really to expect.
+                roundDownToIncrement(ping, 10).coerceAtLeast(0)
             } else {
                 0
             }
 
             delay(delay.toLong() - subtrahend)
 
-            // removed the packet from the queue
-            // but only execute if the queue contained the packet
+            // Removes the packet from the queue,
+            // but only execute if the queue contained the packet.
             if (queue.remove(packet)) {
                 sendPacketSilently(packet)
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -52,7 +52,7 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
     var scope: CoroutineScope? = null
 
     override fun enable() {
-        scope = CoroutineScope(Dispatchers.Default + SupervisorSupervisorJob())
+        scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     }
 
     override fun disable() {
@@ -91,7 +91,7 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
     val worldChangeHandler = handler<WorldChangeEvent>(ignoreCondition = true) {
         cancel()
         queue.clear()
-        scope = CoroutineScope(Dispatchers.Default + SupervisorSupervisorSupervisorJob())
+        scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     }
 
     private fun schedulePacketSending(packet: Packet<*>) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -52,7 +52,7 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
     var scope: CoroutineScope? = null
 
     override fun enable() {
-        scope = CoroutineScope(Dispatchers.Default + Job())
+        scope = CoroutineScope(Dispatchers.Default + SupervisorSupervisorJob())
     }
 
     override fun disable() {
@@ -91,7 +91,7 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
     val worldChangeHandler = handler<WorldChangeEvent>(ignoreCondition = true) {
         cancel()
         queue.clear()
-        scope = CoroutineScope(Dispatchers.Default + Job())
+        scope = CoroutineScope(Dispatchers.Default + SupervisorSupervisorSupervisorJob())
     }
 
     private fun schedulePacketSending(packet: Packet<*>) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -18,86 +18,118 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
+import kotlinx.coroutines.*
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.fakelag.DelayData
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.client.chat
-import net.ccbluex.liquidbounce.utils.client.handlePacket
 import net.ccbluex.liquidbounce.utils.client.markAsError
-import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket
-import net.minecraft.network.packet.s2c.common.KeepAliveS2CPacket
+import net.ccbluex.liquidbounce.utils.client.sendPacketSilently
+import net.ccbluex.liquidbounce.utils.entity.ping
+import net.minecraft.network.packet.Packet
+import net.minecraft.network.packet.c2s.common.CommonPongC2SPacket
+import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket
+import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * PingSpoof module
  *
  * Spoofs your ping to a specified value.
  */
-
 object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
 
     private val delay by int("Delay", 500, 0..25000, "ms")
+    private val dynamic by boolean("Dynamic", true)
+    private val pauseDeath by boolean("PauseWhileBeingDead", true)
 
-    private val packetQueue = LinkedHashSet<DelayData>()
+    // stores all packets that have to be sent
+    val queue = ConcurrentLinkedQueue<Packet<*>>()
 
-    override fun disable() {
-        reset()
+    // handles each packet and its delay
+    var scope: CoroutineScope? = null
+
+    override fun enable() {
+        scope = CoroutineScope(Dispatchers.Default + Job())
     }
 
-    val packetHandler = handler<PacketEvent> { event ->
+    override fun disable() {
+        cancel()
+        while (queue.isNotEmpty()) {
+            sendPacketSilently(queue.poll())
+        }
+    }
+
+    // the packet handler should have a really low priority,
+    // so from other modules canceled events won't be sent
+    val packetHandler = handler<PacketEvent>(priority = -1000) { event ->
         val packet = event.packet
 
-        if (player.isDead || event.isCancelled) {
+        val pause = player.isDead && pauseDeath
+        if (pause || event.isCancelled) {
             return@handler
         }
 
-        if (packet is KeepAliveS2CPacket || packet is CommonPingS2CPacket) {
+        if (packet is KeepAliveC2SPacket || packet is CommonPongC2SPacket) {
             event.cancelEvent()
-
-            synchronized(packetQueue) {
-                packetQueue.add(DelayData(packet, System.currentTimeMillis()))
-            }
+            queue.add(packet)
+            schedulePacketSending(packet)
         }
     }
 
+    @Suppress("SpellCheckingInspection")
     val tickHandler = handler<GameTickEvent> {
         if (mc.isIntegratedServerRunning) {
             chat(markAsError(message("cantEnableInSingleplayer")))
             enabled = false
-            return@handler
         }
-
-        sendPacketsByOrder(false)
     }
 
     @Suppress("unused")
-    val worldChangeHandler = handler<WorldChangeEvent> {
-        if (it.world == null) {
-            synchronized(packetQueue) {
-                packetQueue.clear()
+    val worldChangeHandler = handler<WorldChangeEvent>(ignoreCondition = true) {
+        cancel()
+        queue.clear()
+        scope = CoroutineScope(Dispatchers.Default + Job())
+    }
+
+    private fun schedulePacketSending(packet: Packet<*>) {
+        scope!!.launch {
+            val subtrahend = if (dynamic) {
+                val ping = player.ping
+
+                // the ping might vary
+                // over 15 ms variation is probably not really to expect
+                roundDownToIncrement(ping, 15)
+            } else {
+                0
+            }
+
+            delay(delay.toLong() - subtrahend)
+
+            // removed the packet from the queue
+            // but only execute if the queue contained the packet
+            if (queue.remove(packet)) {
+                sendPacketSilently(packet)
             }
         }
     }
 
-    private fun sendPacketsByOrder(all: Boolean) {
-        synchronized(packetQueue) {
-            packetQueue.removeIf {
-                if (all || it.delay <= System.currentTimeMillis() - delay) {
-                    handlePacket(it.packet)
-                    return@removeIf true
-                }
-
-                false
-            }
+    private fun cancel() {
+        try {
+            scope!!.cancel()
+        } catch (_: Exception) {
+            /* ignored */
         }
     }
 
-    private fun reset() {
-        sendPacketsByOrder(true)
+    /**
+     * Rounds the [number] down to the nearest multiple of the given [increment].
+     */
+    @Suppress("SameParameterValue")
+    private fun roundDownToIncrement(number: Int, increment: Int): Int {
+        return (number / increment) * increment
     }
-
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -107,10 +107,6 @@ object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
                     starting = false
                 }
 
-                // If the ping wasn't spoofed before, there is no need to correct it.
-                // (Actually, it needs some seconds before reaching the level,
-                // so the spoofed milliseconds will be wrong when joining a server
-                // or enabling this module for some seconds).
                 if (!starting) {
                     // the player.ping variable is spoofed, so it needs to be corrected
                     ping -= delay


### PR DESCRIPTION
- the delay should now be accurate (the sending isn't done on tick anymore)
- added a dynamic option that subtracts your ping from the delay (closes #3228)
- the packet queue is now cleared when leaving a server
- duplicate packets are sent correctly
- the packet handler runs at a lower priority to ensure better compatibility with other modules
- made pause while being dead an option