### PR TITLE
feat: client-spoofer custom option

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
@@ -18,24 +18,53 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import net.ccbluex.liquidbounce.config.NamedChoice
+import net.ccbluex.liquidbounce.config.Choice
+import net.ccbluex.liquidbounce.config.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 
 // TODO: add this to configure page, whenever it is finished
+@Suppress("SpellCheckingInspection")
 object ModuleSpoofer : Module("ClientSpoofer", Category.EXPLOIT) {
 
-    val mode = enumChoice("Mode", SpoofMode.LUNAR)
+    private const val CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-    fun clientBrand(brand: String) = if (enabled) mode.inner.clientBrand() else brand
+    val mode = choices(
+        "Mode",
+        Lunar,
+        arrayOf(Vanilla, Lunar, Cheatbreaker, Custom)
+    )
 
-    enum class SpoofMode(override val choiceName: String, val clientBrand: () -> String) : NamedChoice {
-        VANILLA("Vanilla", { "vanilla" }),
-        LUNAR("Lunar", { "lunarclient:v2.12.3-2351" }),
-        CHEATBREAKER("Cheatbreaker", { "CB"})
+    fun clientBrand(brand: String) = if (enabled) mode.activeChoice.getBrand() else brand
+
+    private object Vanilla : SpoofMode("Vanilla") {
+        override fun getBrand(): String = "vanilla"
     }
 
-    private const val CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    private object Lunar : SpoofMode("Lunar") {
+        override fun getBrand(): String = "lunarclient:v2.12.3-2351"
+    }
+
+    private object Cheatbreaker : SpoofMode("Cheatbreaker") {
+        override fun getBrand(): String = "CB"
+    }
+
+    private object Custom : SpoofMode("Custom") {
+
+        val brandName by text("BrandName", "")
+
+        override fun getBrand(): String = brandName
+
+    }
+
+    abstract class SpoofMode(name: String) : Choice(name) {
+
+        override val parent: ChoiceConfigurable<*>
+            get() = mode
+
+        abstract fun getBrand(): String
+
+    }
 
     fun random(length: Int, chars: CharArray = CHARS.toCharArray()): String {
         val stringBuilder = StringBuilder()
@@ -44,4 +73,5 @@ object ModuleSpoofer : Module("ClientSpoofer", Category.EXPLOIT) {
         }
         return stringBuilder.toString()
     }
+
 }


### PR DESCRIPTION
Allows to set a custom string as client brand. 
This allows to set it to more niche stuff that isn't from great interest
to most users but also allows to adapt to new clients without the need
to change the code.
The old options are still there for convenience.