### PR TITLE
fix: text-setting not adding spaces

### DIFF
--- a/src-theme/src/routes/clickgui/setting/TextSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/TextSetting.svelte
@@ -17,8 +17,9 @@
 
 <div class="setting">
     <div class="name">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}</div>
-    <input type="text" class="value" placeholder={setting.name} bind:value={cSetting.value} on:input={handleChange}
-           spellcheck="false">
+    <input type="text" class="value"
+           placeholder={$spaceSeperatedNames ? convertToSpacedString(setting.name) : setting.name}
+           bind:value={cSetting.value} on:input={handleChange} spellcheck="false">
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
The text setting now also separates the name in empty text fields.