### PR TITLE
feat: command auto account

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.commands.client.*
 import net.ccbluex.liquidbounce.features.command.commands.client.fakeplayer.CommandFakePlayer
 import net.ccbluex.liquidbounce.features.command.commands.creative.*
+import net.ccbluex.liquidbounce.features.command.commands.utility.CommandAutoAccount
 import net.ccbluex.liquidbounce.features.command.commands.utility.CommandPosition
 import net.ccbluex.liquidbounce.features.command.commands.utility.CommandUsername
 import net.ccbluex.liquidbounce.features.misc.HideAppearance
@@ -145,6 +146,7 @@ object CommandManager : Iterable<Command> {
         addCommand(CommandContainers.createCommand())
         addCommand(CommandSay.createCommand())
         addCommand(CommandFakePlayer.createCommand())
+        addCommand(CommandAutoAccount.createCommand())
 
         // creative commands
         addCommand(CommandItemRename.createCommand())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/utility/CommandAutoAccount.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/utility/CommandAutoAccount.kt
@@ -1,0 +1,38 @@
+package net.ccbluex.liquidbounce.features.command.commands.utility
+
+import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
+import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleAutoAccount
+
+/**
+ * AutoAccount Command
+ *
+ * Allows you to manually trigger the actions of [ModuleAutoAccount].
+ */
+object CommandAutoAccount {
+
+    @Suppress("SpellCheckingInspection")
+    fun createCommand(): Command {
+        return CommandBuilder
+            .begin("autoaccount")
+            .hub()
+            .subcommand(
+                CommandBuilder
+                    .begin("register")
+                    .handler {_, _ ->
+                        ModuleAutoAccount.register()
+                    }
+                    .build()
+            )
+            .subcommand(
+                CommandBuilder
+                    .begin("login")
+                    .handler {_, _ ->
+                        ModuleAutoAccount.login()
+                    }
+                    .build()
+            )
+            .build()
+    }
+
+}


### PR DESCRIPTION
This PR adds a command to trigger the actions of the AutoAccount module, 
as it's really annoying when it doesn't get triggered and you have to look up
the password and then type the command sometimes even without auto-completion.