### PR TITLE
add logs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /build/
 /run/
 /mcef/
+/logs/


### PR DESCRIPTION
Sometimes while building a log is generated in the /logs directory. With this PR the logs in this directory will be ignored.