### PR TITLE
feat(legacy): make verusfly disabler worked on uncp/ncp

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
@@ -17,19 +17,17 @@ import net.minecraft.init.Blocks
 */
 
 object VerusFly : DisablerMode("VerusFly") {
-    private var dontPlaceOnAttack = true
+    var dontPlaceOnAttack = true
 
     override fun onUpdate() {
-        if (dontPlaceOnAttack) {
-            val pos = mc.thePlayer.position.add(0.0, mc.thePlayer.eyeHeight.toDouble(), 0.0)
-            var blockPos = mc.theWorld.rayTraceBlocks(pos.toVec(), pos.add(pos.x.toDouble(), pos.y * 3.0, pos.z.toDouble()).toVec(), false,false,false).blockPos
-            if(mc.theWorld.getBlockState(blockPos) != Blocks.air)
-            {
-               blockPos = blockPos.add(0.0, 1.0, 0.0)
-            }
+        val player = mc.thePlayer ?: return
+        if (dontPlaceOnAttack && !player.isDead) {
+            val pos = player.position.add(0, if(player.posY > 0) -100 else 100 , 0) ?: return
+
+
             sendPacket(
                 C08PacketPlayerBlockPlacement(
-                    blockPos,
+                    pos,
                     1,
                     ItemStack(Items.water_bucket),
                     0F,
@@ -37,9 +35,9 @@ object VerusFly : DisablerMode("VerusFly") {
                     0F
                 )
             )
-
+        } else {
+            dontPlaceOnAttack = true
         }
-        dontPlaceOnAttack = true
     }
 
     override fun onAttack() {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/disablermodes/verus/VerusFly.kt
@@ -2,13 +2,15 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.v
 
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.DisablerMode
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
+import net.ccbluex.liquidbounce.utils.extensions.toVec
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
+import net.minecraft.init.Blocks
 
 /*
 * Working on Verus: b3898
-* Tested on: anticheat-test.com, eu.loysia.cn
+* Tested on: anticheat-test.com, eu.losiya.cn
 *
 * Disables most Fly checks on the Verus Anticheat
 * Allowing for slow Vanilla fly and fast onGround speeds
@@ -16,12 +18,18 @@ import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
 
 object VerusFly : DisablerMode("VerusFly") {
     private var dontPlaceOnAttack = true
+
     override fun onUpdate() {
         if (dontPlaceOnAttack) {
-            val pos = mc.thePlayer.position.add(0.0, -1.5, 0.0)
+            val pos = mc.thePlayer.position.add(0.0, mc.thePlayer.eyeHeight.toDouble(), 0.0)
+            var blockPos = mc.theWorld.rayTraceBlocks(pos.toVec(), pos.add(pos.x.toDouble(), pos.y * 3.0, pos.z.toDouble()).toVec(), false,false,false).blockPos
+            if(mc.theWorld.getBlockState(blockPos) != Blocks.air)
+            {
+               blockPos = blockPos.add(0.0, 1.0, 0.0)
+            }
             sendPacket(
                 C08PacketPlayerBlockPlacement(
-                    pos,
+                    blockPos,
                     1,
                     ItemStack(Items.water_bucket),
                     0F,

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/FlagCheck.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/FlagCheck.kt
@@ -9,6 +9,8 @@ import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.modules.combat.KillAura
+import net.ccbluex.liquidbounce.features.module.modules.exploit.Disabler
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disablermodes.verus.VerusFly.dontPlaceOnAttack
 import net.ccbluex.liquidbounce.script.api.global.Chat
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
@@ -129,20 +131,23 @@ object FlagCheck : Module("FlagCheck", Category.MISC, gameDetecting = true, hide
 
         val currentTime = System.currentTimeMillis()
 
-        // GhostBlock Checks
-        blockPlacementAttempts.filter { (_, timestamp) ->
-            currentTime - timestamp > 500
-        }.forEach { (blockPos, _) ->
-            val block = world.getBlockState(blockPos).block
-            val isNotUsing = !player.isUsingItem && !player.isBlocking && (!KillAura.renderBlocking || !KillAura.blockStatus)
+        // GhostBlock Checks | Checks is disabled when using VerusFly Disabler, to prevent false flag.
+        if (!Disabler.handleEvents() || (Disabler.handleEvents() && Disabler.mode.contains("VerusFly") && !dontPlaceOnAttack)) {
+            blockPlacementAttempts.filter { (_, timestamp) ->
+                currentTime - timestamp > 500
+            }.forEach { (blockPos, _) ->
+                val block = world.getBlockState(blockPos).block
+                val isNotUsing =
+                    !player.isUsingItem && !player.isBlocking && (!KillAura.renderBlocking || !KillAura.blockStatus)
 
-            if (block == Blocks.air && player.swingProgressInt > 2 && successfulPlacements != blockPos && isNotUsing) {
-                successfulPlacements.remove(blockPos)
-                flagCount++
-                Chat.print("§dDetected §3GhostBlock §b(§c${flagCount}x§b)")
+                if (block == Blocks.air && player.swingProgressInt > 2 && successfulPlacements != blockPos && isNotUsing) {
+                    successfulPlacements.remove(blockPos)
+                    flagCount++
+                    Chat.print("§dDetected §3GhostBlock §b(§c${flagCount}x§b)")
+                }
+
+                blockPlacementAttempts.remove(blockPos)
             }
-
-            blockPlacementAttempts.remove(blockPos)
         }
 
         // Invalid Health/Hunger bar Checks (This is a known lagback by Intave AC)


### PR DESCRIPTION
It now interacts with the water bucket in an extremely high height. This makes it not flag on NCP anymore making it suitable for Blocks MC.