### PR TITLE
feat: freecam disable on quit

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeCam.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeCam.kt
@@ -40,8 +40,7 @@ import net.minecraft.util.math.Vec3i
  *
  * Allows you to move out of your body.
  */
-
-object ModuleFreeCam : Module("FreeCam", Category.RENDER) {
+object ModuleFreeCam : Module("FreeCam", Category.RENDER, disableOnQuit = true) {
 
     private val speed by float("Speed", 1f, 0.1f..2f)
 


### PR DESCRIPTION
Makes the freecam disable on quitting, as it is very confusing when you join back and forget that it was enabled.