### PR TITLE
Revert feat: improve ping spoof (#3230)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -18,134 +18,86 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import kotlinx.coroutines.*
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.fakelag.DelayData
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.handlePacket
 import net.ccbluex.liquidbounce.utils.client.markAsError
-import net.ccbluex.liquidbounce.utils.client.sendPacketSilently
-import net.ccbluex.liquidbounce.utils.entity.ping
-import net.minecraft.network.packet.Packet
-import net.minecraft.network.packet.c2s.common.CommonPongC2SPacket
-import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket
-import java.util.concurrent.ConcurrentLinkedQueue
+import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket
+import net.minecraft.network.packet.s2c.common.KeepAliveS2CPacket
 
 /**
  * PingSpoof module
  *
  * Spoofs your ping to a specified value.
  */
+
 object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
 
     private val delay by int("Delay", 500, 0..25000, "ms")
-    private val dynamic by boolean("Dynamic", false)
-    private val pauseDeath by boolean("PauseWhileBeingDead", true)
 
-    // stores all packets that have to be sent
-    val queue = ConcurrentLinkedQueue<Packet<*>>()
-
-    // handles each packet and its delay
-    var scope: CoroutineScope? = null
-
-    var starting = true
-
-    override fun enable() {
-        scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-        starting = true
-    }
+    private val packetQueue = LinkedHashSet<DelayData>()
 
     override fun disable() {
-        cancel()
-        while (queue.isNotEmpty()) {
-            sendPacketSilently(queue.poll())
-        }
+        reset()
     }
 
-    // the packet handler should have a really low priority,
-    // so from other modules canceled events won't be sent
-    val packetHandler = handler<PacketEvent>(priority = -1000) { event ->
+    val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
 
-        val pause = player.isDead && pauseDeath
-        if (pause || event.isCancelled) {
+        if (player.isDead || event.isCancelled) {
             return@handler
         }
 
-        if (packet is KeepAliveC2SPacket || packet is CommonPongC2SPacket) {
+        if (packet is KeepAliveS2CPacket || packet is CommonPingS2CPacket) {
             event.cancelEvent()
-            queue.add(packet)
-            schedulePacketSending(packet)
+
+            synchronized(packetQueue) {
+                packetQueue.add(DelayData(packet, System.currentTimeMillis()))
+            }
         }
     }
 
-    @Suppress("SpellCheckingInspection")
     val tickHandler = handler<GameTickEvent> {
         if (mc.isIntegratedServerRunning) {
             chat(markAsError(message("cantEnableInSingleplayer")))
             enabled = false
+            return@handler
         }
+
+        sendPacketsByOrder(false)
     }
 
     @Suppress("unused")
-    val worldChangeHandler = handler<WorldChangeEvent>(ignoreCondition = true) {
-        cancel()
-        queue.clear()
-        scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-        starting = true
-    }
-
-    private fun schedulePacketSending(packet: Packet<*>) {
-        scope!!.launch {
-            val subtrahend = if (dynamic) {
-                var ping = player.ping
-
-                if (starting && ping > delay) {
-                    starting = false
-                }
-
-                if (!starting) {
-                    // the player.ping variable is spoofed, so it needs to be corrected
-                    ping -= delay
-                } else {
-                    ping = 0
-                }
-
-                // The ping might vary,
-                // so it should rather keep it above the set ping
-                // over 10 ms variation is probably not really to expect.
-                roundDownToIncrement(ping, 10).coerceAtLeast(0)
-            } else {
-                0
-            }
-
-            delay(delay.toLong() - subtrahend)
-
-            // Removes the packet from the queue,
-            // but only execute if the queue contained the packet.
-            if (queue.remove(packet)) {
-                sendPacketSilently(packet)
+    val worldChangeHandler = handler<WorldChangeEvent> {
+        if (it.world == null) {
+            synchronized(packetQueue) {
+                packetQueue.clear()
             }
         }
     }
 
-    private fun cancel() {
-        try {
-            scope!!.cancel()
-        } catch (_: Exception) {
-            /* ignored */
+    private fun sendPacketsByOrder(all: Boolean) {
+        synchronized(packetQueue) {
+            packetQueue.removeIf {
+                if (all || it.delay <= System.currentTimeMillis() - delay) {
+                    handlePacket(it.packet)
+                    return@removeIf true
+                }
+
+                false
+            }
         }
     }
 
-    /**
-     * Rounds the [number] down to the nearest multiple of the given [increment].
-     */
-    @Suppress("SameParameterValue")
-    private fun roundDownToIncrement(number: Int, increment: Int): Int {
-        return (number / increment) * increment
+    private fun reset() {
+        sendPacketsByOrder(true)
     }
+
 
 }


### PR DESCRIPTION
This reverts commit 9f95fcdb7d6580e2d0d5c20c9a8b6c1e6510f7c2 as it flags verus. (https://github.com/b0LBwZ7r5HOeh6CBMuQIhVu3/VerusAC0/blob/49bf8789e88561189cc20d24b6d9ddf9f0510cf8/src/main/java/me/levansj01/verus/check/checks/badpackets/BadPacketsG3.java)
Reopens #3228.

Not delaying the Serverbound-CommonPong packet leads to less flags but it still flags.

Thoughts:  It would probably work if the Serverbound-Pong packet was ignored and the module would only remove the first element that meets the condition on send.