### PR TITLE
fix(legacy): scaffold earlyswitch

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -1465,7 +1465,7 @@ object Scaffold : Module("Scaffold", Category.WORLD, Keyboard.KEY_I, hideModule 
         if (stack.stackSize > switchAmount) return
 
         val switchSlot = if (earlySwitch) {
-            InventoryUtils.findBlockStackInHotbarGreaterThan(amountBeforeSwitch)
+            InventoryUtils.findBlockStackInHotbarGreaterThan(amountBeforeSwitch) ?: InventoryUtils.findBlockInHotbar()
         } else {
             InventoryUtils.findBlockInHotbar()
         } ?: return


### PR DESCRIPTION
no longer stuck on a slot when blocks are lower than / equal SlotAmountBeforeSwitch