### PR TITLE
feat: default value for server name in 'add server' modal

### DIFF
--- a/src-theme/src/routes/menu/multiplayer/AddServerModal.svelte
+++ b/src-theme/src/routes/menu/multiplayer/AddServerModal.svelte
@@ -10,7 +10,7 @@
 
     const dispatch = createEventDispatcher();
 
-    let name = "";
+    let name = "Minecraft Server";
     let address = "";
     let resourcePackPolicy = "Prompt";
 
@@ -31,7 +31,7 @@
     }
 
     function cleanUp() {
-        name = "";
+        name = "Minecraft Server";
         address = "";
         resourcePackPolicy = "";
     }


### PR DESCRIPTION
Like the vanilla menu, LiquidBounce will now use 'Minecraft Server' as the default server name.

![image](https://github.com/CCBlueX/LiquidBounce/assets/18741573/6ae2a699-69cc-4356-a4f9-c4d4f4b4bd59)
