### PR TITLE
feat: 'get token' button in altening modal

### DIFF
--- a/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
@@ -2,7 +2,7 @@
     import Tab from "../../common/modal/Tab.svelte";
     import IconTextInput from "../../common/setting/IconTextInput.svelte";
     import ButtonSetting from "../../common/setting/ButtonSetting.svelte";
-    import {addAlteningAccount} from "../../../../integration/rest";
+    import {addAlteningAccount, browse} from "../../../../integration/rest";
 
     let token = "";
     $: disabled = validateToken(token);
@@ -22,4 +22,5 @@
 <Tab>
     <IconTextInput icon="user" title="Token" bind:value={token}/>
     <ButtonSetting {disabled} title="Add Account" on:click={addAccount} listenForEnter={true} inset={true} />
+    <ButtonSetting title="Get Account Token" on:click={() => browse("ALTENING_FREE")} secondary={true}/>
 </Tab>

--- a/src/main/resources/assets/liquidbounce/client_urls.properties
+++ b/src/main/resources/assets/liquidbounce/client_urls.properties
@@ -7,3 +7,4 @@ MAINTAINER_YOUTUBE=https://youtube.com/CCBlueX
 CLIENT_WEBSITE=https://liquidbounce.net
 VIAFABRICPLUS=https://modrinth.com/mod/viafabricplus
 EASYMC=https://easymc.io/get
+ALTENING_FREE=https://thealtening.com/free/free-minecraft-alts


### PR DESCRIPTION
The Altening login modal now has a 'Get Token' button like the EasyMC modal.

![image](https://github.com/CCBlueX/LiquidBounce/assets/18741573/b47faa97-1045-49af-acb8-ecfbd466d73d)

