### PR TITLE
fix: 'online only' toggle switch in multiplayer menu

### DIFF
--- a/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
+++ b/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
@@ -46,7 +46,7 @@
     $: {
         let filteredServers = servers;
         if (onlineOnly) {
-            filteredServers = filteredServers.filter(s => s.ping >= 0);
+            filteredServers = filteredServers.filter(s => s.ping > 0);
         }
         if (searchQuery) {
             filteredServers = filteredServers.filter(s => s.name.toLowerCase().includes(searchQuery.toLowerCase()));


### PR DESCRIPTION
Apparently, offline servers are no longer reported with a ping `< 0` but one of exactly zero. This pull request fixes the switch.