### PR TITLE
Update ru_ru.json

### DIFF
--- a/src/main/resources/assets/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/assets/liquidbounce/lang/ru_ru.json
@@ -55,7 +55,7 @@
   "liquidbounce.command.client.subcommand.info.result.clientAuthor": "Автор клиента: %s",
   "liquidbounce.command.client.subcommand.reload.description": "Перезагружает Ваш клиент",
   "liquidbounce.command.config.subcommand.load.description": "Загружает конфигурационный файл.",
-  "liquidbounce.command.config.subcommand.load.parameter.name.description": "Имя конфигурационного файлы.",
+  "liquidbounce.command.config.subcommand.load.parameter.name.description": "Имя конфигурационного файла.",
   "liquidbounce.command.config.subcommand.create.parameter.name.description": "Название конфигурационного файла.",
   "liquidbounce.command.config.subcommand.create.parameter.overwrite.description": "Перезаписать существующий конфигурационного файл.",
   "liquidbounce.command.config.subcommand.create.result.failedToCreate": "Не удалось создать конфигурационный файл с названием %s.",


### PR DESCRIPTION
Improvement.
The word "файл" should be in the genitive case because it specifies the word "имя" (meaning "name"). In Russian, when specifying words like this, the genitive case is used. Thus, "файл" in the genitive case is "файла". Furthermore, the English translation uses "file" in the singular form, not "files" in the plural. In the Russian translation, "файлы" (plural) is used, but the correct word should be "файл" (singular).