### PR TITLE
fix: AutoShop purchase logic

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/AutoShopConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/AutoShopConfig.kt
@@ -24,6 +24,8 @@ import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.ModuleAu
 import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.*
 import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.conditions.ConditionNode
 import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.conditions.ConditionNodeDeserializer
+import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.conditions.ItemConditionNode
+import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.conditions.ItemConditionNodeDeserializer
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.client.notification
 
@@ -34,6 +36,7 @@ object AutoShopConfig {
         .registerTypeAdapter(ShopElement::class.javaObjectType, ShopElementDeserializer())
         .registerTypeAdapter(ItemInfo::class.javaObjectType, ItemInfoDeserializer())
         .registerTypeAdapter(ConditionNode::class.javaObjectType, ConditionNodeDeserializer())
+        .registerTypeAdapter(ItemConditionNode::class.javaObjectType, ItemConditionNodeDeserializer())
         .create()
 
     /**
@@ -82,6 +85,7 @@ enum class ShopConfigPreset(override val choiceName: String, val localFileName: 
     BLOCKSMC("BlocksMC", "blocksmc"),
     CUBECRAFT("CubeCraft", "cubecraft"),
     TEAMHOLY("TeamHoly", "teamholy"),
+    FUNNYMC("FunnyMC", "funnymc"),
     DEXLAND("Dexland", "dexland");
 
     val internalPath = "/assets/liquidbounce/data/shops/${localFileName}.json"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopItemUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopItemUtils.kt
@@ -68,12 +68,11 @@ fun String.isArmorItem() : Boolean {
     return this.split(":")[0] in ARMOR_ITEMS
 }
 
-fun GenericContainerScreen.uniqueStacks(): Set<String> {
+fun GenericContainerScreen.stacks(): List<String> {
     return this.screenHandler.slots
         .filter { !it.stack.isNothing() &&
             it.inventory === this.screenHandler.inventory }
         .mapNotNull { Registries.ITEM.getId(it.stack.item).path }
-        .toSet()
 }
 
 private val WOOL_BLOCKS = setOf(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/serializable/conditions/ItemConditionNode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/serializable/conditions/ItemConditionNode.kt
@@ -31,7 +31,11 @@ data class ItemConditionNode(
 ) : ConditionNode
 
 class ItemConditionNodeDeserializer : JsonDeserializer<ItemConditionNode> {
-    override fun deserialize(json: JsonElement?, typeOfT: Type, context: JsonDeserializationContext): ItemConditionNode {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type,
+        context: JsonDeserializationContext): ItemConditionNode {
+
         if (json == null || !json.isJsonObject) {
             throw JsonParseException("Invalid JSON: Expected a JsonObject")
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/serializable/conditions/ItemConditionNode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/serializable/conditions/ItemConditionNode.kt
@@ -18,8 +18,33 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player.autoshop.serializable.conditions
 
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+
 data class ItemConditionNode(
     val id: String,
     val min: Int = 1,
     val max: Int = Int.MAX_VALUE
 ) : ConditionNode
+
+class ItemConditionNodeDeserializer : JsonDeserializer<ItemConditionNode> {
+    override fun deserialize(json: JsonElement?, typeOfT: Type, context: JsonDeserializationContext): ItemConditionNode {
+        if (json == null || !json.isJsonObject) {
+            throw JsonParseException("Invalid JSON: Expected a JsonObject")
+        }
+
+        val jsonObject = json.asJsonObject
+
+        if (!jsonObject.has("id")) {
+            throw JsonParseException("Invalid JSON: Missing 'id' property")
+        }
+        val id = jsonObject["id"].asString
+        val min = jsonObject["min"]?.asInt ?: 1
+        val max = jsonObject["max"]?.asInt ?: Int.MAX_VALUE
+
+        return ItemConditionNode(id, min, max)
+    }
+}

--- a/src/main/resources/assets/liquidbounce/data/shops/funnymc.json
+++ b/src/main/resources/assets/liquidbounce/data/shops/funnymc.json
@@ -1,0 +1,159 @@
+{
+	"traderTitles": ["магазин"],
+	"initialCategorySlot": -1,
+	"itemsWithTiers": {
+		"sword": 		["stone_sword", "iron_sword", "diamond_sword"],
+		"helmet": 		["leather_helmet", "chainmail_helmet", "iron_helmet", "diamond_helmet"],
+		"chestplate": 	["leather_chestplate", "chainmail_chestplate", "iron_chestplate", "diamond_chestplate"],
+		"leggings": 	["leather_leggings", "chainmail_leggings", "iron_leggings", "diamond_leggings"],
+		"boots": 		["leather_boots", "chainmail_boots", "iron_boots", "diamond_boots"]
+	},
+	"elements": [
+    {
+		"item": {"id": "chestplate:tier:4"},
+		"categorySlot": 2, "itemSlot": 34,
+		"price": {"id": "emerald", "minAmount": 2}
+    },
+    {
+		"item": {"id": "leggings:tier:4"},
+		"categorySlot": 2, "itemSlot": 43,
+		"price": {"id": "emerald", "minAmount": 2}
+    },
+    {
+		"item": {"id": "boots:tier:4"},
+		"categorySlot": 2, "itemSlot": 52,
+		"price": {"id": "emerald", "minAmount": 2}
+    },
+    {
+		"item": {"id": "diamond_sword:tier:3"},
+		"categorySlot": 1, "itemSlot": 20,
+		"price": {"id": "emerald", "minAmount": 4}
+    },
+    {
+		"item": {"id": "helmet:tier:4"},
+		"categorySlot": 2, "itemSlot": 25,
+		"price": {"id": "emerald", "minAmount": 2}
+    },
+	{
+		"item": {"id": "sword:tier:2"},
+		"categorySlot": 1, "itemSlot": 19,
+		"price": {"id": "gold_ingot", "minAmount": 7},
+		"purchaseConditions": {"any": [
+			{"id": "gold_ingot", "min": 16},
+					
+			{"all": [
+				{"any": [{"id": "gold_ingot", "min": 10}, {"id": "golden_apple"}]},
+				{"id": "leggings:tier:3"},
+				{"id": "chestplate:tier:3"}
+			]}
+		]}
+    },
+    {
+		"item": {"id": "sword:tier:1"},
+		"categorySlot": 1, "itemSlot": 18,
+		"price": {"id": "iron_ingot", "minAmount": 10}
+    },
+    {
+		"item": {"id": "wool", "minAmount": 64}, 
+		"amountPerClick": 16,
+		"categorySlot": 0, "itemSlot": 18,
+		"price": {"id": "iron_ingot", "minAmount": 4},
+		"purchaseConditions": {"id": "sword:tier:1"}
+    },
+    {
+		"item": {"id": "chestplate:tier:3"},
+		"categorySlot": 2, "itemSlot": 32,
+		"price": {"id": "gold_ingot", "minAmount": 3}
+    },
+    {
+		"item": {"id": "leggings:tier:3"},
+		"categorySlot": 2, "itemSlot": 41,
+		"price": {"id": "gold_ingot", "minAmount": 3}
+    },
+    {
+		"item": {"id": "boots:tier:3"},
+		"categorySlot": 2, "itemSlot": 50,
+		"price": {"id": "gold_ingot", "minAmount": 3},
+		"purchaseConditions": {"any": [
+			{"id": "gold_ingot", "min": 6}, {"id": "golden_apple"}
+		]}
+    },
+    {
+		"item": {"id": "helmet:tier:2"},
+		"categorySlot": 2, "itemSlot": 21,
+		"price": {"id": "iron_ingot", "minAmount": 5},
+		"purchaseConditions": {"id": "sword:tier:1"}
+    },
+    {
+		"item": {"id": "boots:tier:2"},
+		"categorySlot": 2, "itemSlot": 48,
+		"price": {"id": "iron_ingot", "minAmount": 5},
+		"purchaseConditions": {"all": [{"id": "wool", "min": 64}, {"id": "sword:tier:1"}]}
+    },
+    {
+		"item": {"id": "boots:tier:1"},
+		"categorySlot": 2, "itemSlot": 46,
+		"price": {"id": "iron_ingot", "minAmount": 1},
+		"purchaseConditions": {"id": "sword:tier:1"}
+    },
+    {
+		"item": {"id": "helmet:tier:1"},
+		"categorySlot": 2, "itemSlot": 19,
+		"price": {"id": "iron_ingot", "minAmount": 1},
+		"purchaseConditions": {"id": "sword:tier:1"}
+    },
+    {
+		"comment": "golden apple (x1)",
+		"item": {"id": "golden_apple"},
+		"categorySlot": 6, "itemSlot": 18,
+		"price": {"id": "gold_ingot", "minAmount": 3}
+    },
+    {
+		"comment": "golden apple (x2)",
+		"item": {"id": "golden_apple", "minAmount": 2},
+		"categorySlot": 6, "itemSlot": 18,
+		"price": {"id": "gold_ingot", "minAmount": 3},
+		"purchaseConditions": {"id": "boots:tier:3"}
+    },
+    {
+		"comment": "golden apple (x5)",
+		"item": {"id": "golden_apple", "minAmount": 5},
+		"categorySlot": 6, "itemSlot": 18,
+		"price": {"id": "gold_ingot", "minAmount": 3},
+		"purchaseConditions": {"all": [{"id": "boots:tier:3"}, {"id": "sword:tier:2"}]}
+    },
+    {
+		"comment": "golden apple (x12)",
+		"comment2": "it doesn't buy apples when their amount is between 6 and 11 because it already enough (>5)",
+		"comment3": "but as soon as it goes down to 5, it will get replenished up to 12",
+		"comment4": "It might seem a weird optimization but I like it :)",
+		"item": {"id": "golden_apple", "minAmount": 12},
+		"categorySlot": 6, "itemSlot": 18,
+		"price": {"id": "gold_ingot", "minAmount": 3},
+		"purchaseConditions": {"all": [
+			{"id": "golden_apple", "min": 0, "max": 5},
+			{"id": "boots:tier:3"},
+			{"id": "sword:tier:2"}
+		]}
+    },
+    {
+		"comment": "fireball (x10)",
+		"item": {"id": "fire_charge", "minAmount": 10},
+		"categorySlot": 6, "itemSlot": 22,
+		"price": {"id": "iron_ingot", "minAmount": 40}
+    },
+    {
+		"comment": "potion of swiftness (x2)",
+		"item": {"id": "potion:speed", "minAmount": 2},
+		"categorySlot": 5, "itemSlot": 18,
+		"price": {"id": "emerald", "minAmount": 1},
+		"purchaseConditions": {"all": [
+			{"id": "sword:tier:3"}, 
+			{"id": "helmet:tier:4"}, 
+			{"id": "chestplate:tier:4"}, 
+			{"id": "leggings:tier:4"},
+			{"id": "boots:tier:4"}
+		]}
+    }
+  ]
+}

--- a/src/main/resources/assets/liquidbounce/data/shops/pika-network.json
+++ b/src/main/resources/assets/liquidbounce/data/shops/pika-network.json
@@ -2,40 +2,56 @@
   "comment": "An example config for PіkаNеtwоrk",
   "traderTitles": ["shop"],
   "initialCategorySlot": 0,
+  "itemsWithTiers": {
+    "sword": 		["stone_sword", "iron_sword", "diamond_sword"],
+    "armor": 		["chainmail_boots", "iron_boots", "diamond_boots"]
+  },
   "elements": [
     {
-      "item": {"id": "wool", "minAmount": 96},
+      "item": {"id": "wool", "minAmount": 64},
       "amountPerClick": 16,
       "categorySlot": 2, "itemSlot": 19,
       "price": {"id": "iron_ingot", "minAmount": 4}
     },
     {
-      "item": {"id": "diamond_boots"},
+      "item": {"id": "armor:tier:3"},
       "categorySlot": 1, "itemSlot": 21,
       "price": {"id": "emerald", "minAmount": 6}
     },
     {
-      "item": {"id": "iron_boots"},
+      "item": {"id": "armor:tier:2"},
       "categorySlot": 1, "itemSlot": 20,
-      "price": {"id": "gold_ingot", "minAmount": 12},
-      "purchaseConditions": {"all": [{"id": "golden_apple", "min": 2}, {"id": "diamond_boots", "max": 0}]}
+      "price": {"id": "gold_ingot", "minAmount": 12}
     },
     {
-      "item": {"id": "chainmail_boots"},
+      "item": {"id": "armor:tier:1"},
       "categorySlot": 1, "itemSlot": 19,
-      "price": {"id": "iron_ingot", "minAmount": 24},
-      "purchaseConditions": {"all": [{"id": "iron_boots", "max": 0}, {"id": "diamond_boots", "max": 0}]}
+      "price": {"id": "iron_ingot", "minAmount": 24}
     },
     {
-      "item": {"id": "iron_sword"},
+      "item": {"id": "sword:tier:3"},
+      "categorySlot": 3, "itemSlot": 21,
+      "price": {"id": "emerald", "minAmount": 4},
+      "purchaseConditions": {"id": "armor:tier:3"}
+    },
+    {
+      "item": {"id": "sword:tier:2"},
       "categorySlot": 3, "itemSlot": 20,
-      "price": {"id": "gold_ingot", "minAmount": 8}
+      "price": {"id": "gold_ingot", "minAmount": 8},
+      "purchaseConditions": {"id": "armor:tier:2"}
     },
     {
-      "item": {"id": "stone_sword"},
+      "item": {"id": "sword:tier:1"},
       "categorySlot": 3, "itemSlot": 19,
-      "price": {"id": "iron_ingot", "minAmount": 12},
-      "purchaseConditions": {"id": "iron_sword", "max": 0}
+      "price": {"id": "iron_ingot", "minAmount": 12}
+    },
+    {
+      "comment": "extra 32 blocks after getting a sword",
+      "item": {"id": "wool", "minAmount": 96},
+      "amountPerClick": 16,
+      "categorySlot": 2, "itemSlot": 19,
+      "price": {"id": "iron_ingot", "minAmount": 4},
+      "purchaseConditions": {"id": "sword:tier:1"}
     },
     {
       "item": {"id": "wooden_pickaxe"},
@@ -48,7 +64,12 @@
       "price": {"id": "iron_ingot", "minAmount": 10}
     },
     {
-      "item": {"id": "golden_apple", "minAmount": 2},
+      "item": {"id": "shears"},
+      "categorySlot": 5, "itemSlot": 23,
+      "price": {"id": "iron_ingot", "minAmount": 20}
+    },
+    {
+      "item": {"id": "golden_apple", "minAmount": 1},
       "categorySlot": 6, "itemSlot": 19,
       "price": {"id": "gold_ingot", "minAmount": 3}
     },
@@ -56,7 +77,7 @@
       "item": {"id": "golden_apple", "minAmount": 5},
       "categorySlot": 6, "itemSlot": 19,
       "price": {"id": "gold_ingot", "minAmount": 3},
-      "purchaseConditions": {"id": "iron_boots"}
+      "purchaseConditions": {"id": "armor:tier:2"}
     },
     {
       "item": {"id": "fire_charge", "minAmount": 5},

--- a/src/main/resources/assets/liquidbounce/data/shops/teamholy.json
+++ b/src/main/resources/assets/liquidbounce/data/shops/teamholy.json
@@ -44,6 +44,7 @@
     },
     {
       "item": {"id": "sandstone", "minAmount": 64},
+      "amountPerClick": 2,
       "categorySlot": 0, "itemSlot": 10,
       "price": {"id": "brick"}
     },


### PR DESCRIPTION
- fixed conditions not working because of the absence of required default values
- fixed item category updates not being detected
- fixed Quick mode not buying all possible items due to wrong calculations
- fixed debug messages spam if nothing has been bought
- updated the config for Pіka Netwоrk (now it buys 64 blocks only giving priority to the stone sword and armor. Buys the rest of the blocks after there is a weapon)
- added a new config for FunnyMC (not sure if it's really needed and if somebody even plays here but AutoShop here works ridiculously well, with no delays because of their low-quality anti-cheat)

As for custom configs in the future, I'd like to make a UI for a custom config builder containing a list of draggable items and their amounts, prices, slots, etc. However, I'm not sure how much time it will take :)