### PR TITLE
fix: spellchecker being enabled for some inputs

### DIFF
--- a/src-theme/src/routes/clickgui/setting/TextArraySetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/TextArraySetting.svelte
@@ -33,9 +33,8 @@
         <div class="inputs">
             {#each cSetting.value as _, index}
                 <div class="input-wrapper">
-                    <input type="text" class="value" placeholder={setting.name} bind:value={cSetting.value[index]}
-                           on:input={handleChange}
-                           spellcheck="false">
+                    <input type="text" class="value" spellcheck="false" placeholder={setting.name} bind:value={cSetting.value[index]}
+                           on:input={handleChange}>
                     <button class="button-remove" title="Remove" on:click={() => removeValueIndex(index)}>
                         <img src="img/clickgui/icon-cross.svg" alt="remove">
                     </button>

--- a/src-theme/src/routes/clickgui/setting/TextSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/TextSetting.svelte
@@ -17,9 +17,9 @@
 
 <div class="setting">
     <div class="name">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}</div>
-    <input type="text" class="value"
+    <input type="text" class="value" spellcheck="false"
            placeholder={$spaceSeperatedNames ? convertToSpacedString(setting.name) : setting.name}
-           bind:value={cSetting.value} on:input={handleChange} spellcheck="false">
+           bind:value={cSetting.value} on:input={handleChange}>
 </div>
 
 <style lang="scss">

--- a/src-theme/src/routes/clickgui/setting/blocks/BlocksSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/blocks/BlocksSetting.svelte
@@ -51,7 +51,7 @@
 
 <div class="setting">
     <div class="name">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}</div>
-    <input type="text" placeholder="Search" class="search-input" bind:value={searchQuery}>
+    <input type="text" placeholder="Search" class="search-input" bind:value={searchQuery} spellcheck="false">
     <div class="results">
         <VirtualList items={renderedBlocks} let:item>
             <Block identifier={item.identifier} name={item.name} enabled={cSetting.value.includes(item.identifier)} on:toggle={handleBlockToggle}/>

--- a/src-theme/src/routes/menu/common/Search.svelte
+++ b/src-theme/src/routes/menu/common/Search.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <input class="search" type="text" placeholder="Search..." bind:value={value}
-       on:input={() => dispatch("search", {query: value})}>
+       on:input={() => dispatch("search", {query: value})} spellcheck="false">
 
 <style lang="scss">
   @import "../../../colors.scss";

--- a/src-theme/src/routes/menu/common/setting/IconTextInput.svelte
+++ b/src-theme/src/routes/menu/common/setting/IconTextInput.svelte
@@ -12,7 +12,7 @@
         <img src="img/menu/icon-{icon}.svg" alt={icon}>
     </div>
     {#if type === "text"}
-        <input {pattern} maxlength={maxLength} class="input" type="text" placeholder={title} bind:value={value} autocomplete="off">
+        <input {pattern} maxlength={maxLength} class="input" spellcheck="false" type="text" placeholder={title} bind:value={value} autocomplete="off">
     {:else if type === "password"}
         <input {pattern} maxlength={maxLength} class="input" type="password" placeholder={title} bind:value={value} autocomplete="off">
     {/if}


### PR DESCRIPTION
Currently, the spellchecker might underline spelling mistakes in inputs for tokens, etc. This doesn't make any sense.