### PR TITLE
fix: color format mismatch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,12 +21,12 @@ org.gradle.jvmargs=-Xms1024m -Xmx4096m
 # Fabric Properties
 # Check these on https://fabricmc.net/versions.html
 minecraft_version=1.21
-yarn_mappings=1.21+build.2
+yarn_mappings=1.21+build.9
 loader_version=0.15.11
 min_loader_version=0.15.10
 
 # Fabric API
-fabric_version=0.100.3+1.21
+fabric_version=0.100.8+1.21
 # Loom
 loom_version=1.7-SNAPSHOT
 # Mod Properties
@@ -41,6 +41,6 @@ fabric_kotlin_version=1.11.0+kotlin.2.0.0
 # mc-authlib
 mc_authlib_version=1.4.1
 # Recommended mods
-mod_menu_version=11.0.0
-sodium_version=mc1.21-0.5.9
-viafabricplus_version=3.4.1
+mod_menu_version=11.0.1
+sodium_version=mc1.21-0.5.11
+viafabricplus_version=3.4.3

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
@@ -217,20 +217,20 @@ public abstract class MixinWorldRenderer {
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getTeamColorValue()I"))
     private int injectTeamColor(Entity instance) {
         if (ModuleItemESP.INSTANCE.getEnabled() && ModuleItemESP.GlowMode.INSTANCE.isActive() && ModuleItemESP.INSTANCE.shouldRender(instance)) {
-            return ModuleItemESP.INSTANCE.getColor().toABGR();
+            return ModuleItemESP.INSTANCE.getColor().toARGB();
         }
         if (ModuleStorageESP.INSTANCE.getEnabled() && ModuleStorageESP.INSTANCE.handleEvents()
                 && ModuleStorageESP.Glow.INSTANCE.isActive()) {
             var categorizedEntity = ModuleStorageESP.INSTANCE.categorizeEntity(instance);
             if (categorizedEntity != null) {
-                return categorizedEntity.getColor().invoke().toABGR();
+                return categorizedEntity.getColor().invoke().toARGB();
             }
         }
 
         if (instance instanceof LivingEntity && ModuleESP.INSTANCE.getEnabled()
                 && ModuleESP.GlowMode.INSTANCE.isActive()) {
             final Color4b color = ModuleESP.INSTANCE.getColor((LivingEntity) instance);
-            return color.toABGR();
+            return color.toARGB();
         }
 
         return instance.getTeamColorValue();

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/RenderTasks.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/RenderTasks.kt
@@ -169,10 +169,7 @@ data class Color4b(val r: Int, val g: Int, val b: Int, val a: Int) {
 
     fun toRGBA() = Color(this.r, this.g, this.b, this.a).rgb
 
-    /**
-     * Returns the color in ABGR format.
-     */
-    fun toABGR() = ColorHelper.Argb.getArgb(this.a, this.b, this.g, this.r)
+    fun toARGB() = ColorHelper.Argb.getArgb(this.a, this.r, this.g, this.b)
 
     fun fade(fade: Float) = if (fade == 1f) {
             this


### PR DESCRIPTION
I have incorrectly identified a Sodium bug (https://github.com/CaffeineMC/sodium-fabric/commit/19a25aace8929a3c6bc2221fb1117bf8abbabe44) as a yarn mapping issue. The issue has been resolved in Sodium and can now be reverted to the correct use.