### PR TITLE
ncp lowhop

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -32,6 +32,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.sen
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.spartan.SpeedSpartan524
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.spartan.SpeedSpartan524GroundTimer
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.verus.SpeedVerusB3882
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.ncp.SpeedNoCheatPlusLowHop
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.vulcan.SpeedVulcan286
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.vulcan.SpeedVulcan288
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.vulcan.SpeedVulcanGround286
@@ -64,6 +65,7 @@ object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
         SpeedVerusB3882(configurable),
 
         SpeedHypixelBHop(configurable),
+        SpeedNoCheatPlusLowHop(configurable),
 
         SpeedSpartan524(configurable),
         SpeedSpartan524GroundTimer(configurable),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNoCheatPlusLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNoCheatPlusLowHop.kt
@@ -1,0 +1,51 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015-2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.ncp
+
+import net.ccbluex.liquidbounce.config.Choice
+import net.ccbluex.liquidbounce.config.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.utils.entity.strafe
+
+/**
+ * @anticheat NoCheatPlus
+ * @testedOn anticheat-test.com + eu.loyisa.cn + blocksmc.com
+ */
+ 
+class SpeedNoCheatPlusLowHop(override val parent: ChoiceConfigurable<*>) : Choice("NoCheatPlusLowHop") {
+
+    private var airTicks = 0
+
+    val repeatable = repeatable {
+
+        player.strafe()
+
+        if (player.isOnGround) {
+            player.jump()
+            airTicks = 0
+        } else {
+            if (airTicks == 3) {
+                player.velocity.y = -0.09800000190734863
+            }
+            airTicks++
+        }
+    }
+}


### PR DESCRIPTION
The speed will be very customisable due to there being not many servers using just ncp, features for vulcan and verus to work too is included.

The task list will be completed per option, here is the list of options that will be in the speed.

- [ ] Ticks Until Fall (4..6)
- [ ] Lowhop Speed (0..0.5)
- [ ] Potion Modifier (0..0.1)
- [ ] Faster Fall (true/false)
- [ ] Horizontal Modification (true/false)
- [ ] Damage Strafe (0..3) (0 will disable the damage strafe)
- [ ] YPort (true/false)