### PR TITLE
feat(legacy): add MinRotationDiffFromEnemyToIgnore to SuperKnockback

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
@@ -13,8 +13,7 @@ import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.RotationUtils.getRotationDifference
 import net.ccbluex.liquidbounce.utils.RotationUtils.toRotation
-import net.ccbluex.liquidbounce.utils.extensions.getDistanceToEntityBox
-import net.ccbluex.liquidbounce.utils.extensions.stopXZ
+import net.ccbluex.liquidbounce.utils.extensions.*
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils
 import net.ccbluex.liquidbounce.utils.timing.MSTimer
 import net.ccbluex.liquidbounce.utils.timing.TimeUtils.randomDelay
@@ -105,7 +104,7 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
         val player = mc.thePlayer ?: return
         val target = event.targetEntity as? EntityLivingBase ?: return
         val distance = player.getDistanceToEntityBox(target)
-        val rotationToPlayer = toRotation(mc.thePlayer.hitBox.center, true, target!!)
+        val rotationToPlayer = toRotation(player.hitBox.center, true, target)
 
         if (event.targetEntity.hurtTime > hurtTime || !timer.hasTimePassed(delay) || onlyGround && !player.onGround || RandomUtils.nextInt(
                 endExclusive = 100
@@ -113,7 +112,7 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
 
         if (onlyMove && (!isMoving || onlyMoveForward && player.movementInput.moveStrafe != 0f)) return
 
-        if (getRotationDifference(rotationToPlayer, target!!.rotation) > maxDirectionDiff) return
+        if (getRotationDifference(rotationToPlayer, target.rotation) > maxDirectionDiff) return
 
         when (mode) {
             "Old" -> {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
@@ -11,15 +11,15 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.PacketUtils.sendPackets
-import net.ccbluex.liquidbounce.utils.RotationUtils.getRotationDifference
+import net.ccbluex.liquidbounce.utils.RotationUtils.getAngleDifference
 import net.ccbluex.liquidbounce.utils.RotationUtils.toRotation
 import net.ccbluex.liquidbounce.utils.extensions.*
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils
 import net.ccbluex.liquidbounce.utils.timing.MSTimer
 import net.ccbluex.liquidbounce.utils.timing.TimeUtils.randomDelay
 import net.ccbluex.liquidbounce.value.BoolValue
-import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.FloatValue
+import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.network.play.client.C03PacketPlayer
@@ -33,7 +33,10 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
     private val delay by IntegerValue("Delay", 0, 0..500)
     private val hurtTime by IntegerValue("HurtTime", 10, 0..10)
 
-    private val mode by ListValue("Mode", arrayOf("WTap", "SprintTap", "SprintTap2", "Old", "Silent", "Packet", "SneakPacket"), "Old")
+    private val mode by ListValue("Mode",
+        arrayOf("WTap", "SprintTap", "SprintTap2", "Old", "Silent", "Packet", "SneakPacket"),
+        "Old"
+    )
     private val maxTicksUntilBlock: IntegerValue = object : IntegerValue("MaxTicksUntilBlock", 2, 0..5) {
         override fun isSupported() = mode == "WTap"
 
@@ -69,7 +72,7 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
         override fun onChange(oldValue: Int, newValue: Int) = newValue.coerceAtLeast(stopTicks.get())
     }
 
-    private val maxDirectionDiff by FloatValue("MaxOpponentDirectionDiff", 180f, 30f..180f)
+    private val minEnemyRotDiffToIgnore by FloatValue("MinRotationDiffFromEnemyToIgnore", 180f, 0f..180f)
 
     private val onlyGround by BoolValue("OnlyGround", false)
     val onlyMove by BoolValue("OnlyMove", true)
@@ -104,7 +107,9 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
         val player = mc.thePlayer ?: return
         val target = event.targetEntity as? EntityLivingBase ?: return
         val distance = player.getDistanceToEntityBox(target)
-        val rotationToPlayer = toRotation(player.hitBox.center, true, target)
+
+        val rotationToPlayer = toRotation(player.hitBox.center, false, target).fixedSensitivity().yaw
+        val angleDifferenceToPlayer = getAngleDifference(rotationToPlayer, target.rotationYaw)
 
         if (event.targetEntity.hurtTime > hurtTime || !timer.hasTimePassed(delay) || onlyGround && !player.onGround || RandomUtils.nextInt(
                 endExclusive = 100
@@ -112,7 +117,8 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
 
         if (onlyMove && (!isMoving || onlyMoveForward && player.movementInput.moveStrafe != 0f)) return
 
-        if (getRotationDifference(rotationToPlayer, target.rotation) > maxDirectionDiff) return
+        // Is the enemy facing his back on us?
+        if (angleDifferenceToPlayer > minEnemyRotDiffToIgnore && !target.hitBox.isVecInside(player.eyes)) return
 
         when (mode) {
             "Old" -> {
@@ -261,7 +267,6 @@ object SuperKnockback : Module("SuperKnockback", Category.COMBAT, hideModule = f
 
     override val tag
         get() = mode
-
 
     fun breakSprint() = handleEvents() && forceSprintState == 2 && mode == "SprintTap"
     fun startSprint() = handleEvents() && forceSprintState == 1 && mode == "SprintTap"


### PR DESCRIPTION
Good against 'runners', that usually turn backwards when getting comboed