### PR TITLE
fix(nextgen): fucker

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
@@ -198,14 +198,20 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
         }
 
         val destroyerTarget = currentTarget ?: return@repeatable
-        val currentRotation = RotationManager.serverRotation
+        val destroyerTargetState = destroyerTarget.pos.getState() ?: return@repeatable
+
+        // Check if the block has updated to a non target
+        if (!targets.contains(destroyerTargetState.block)) {
+            currentTarget = null
+        }
 
         // Check if we are already looking at the block
+        val currentRotation = RotationManager.serverRotation
         val rayTraceResult = raytraceBlock(
             max(range, wallRange).toDouble(),
             currentRotation,
             destroyerTarget.pos,
-            destroyerTarget.pos.getState() ?: return@repeatable
+            destroyerTargetState
         ) ?: return@repeatable
 
         val raytracePos = rayTraceResult.blockPos
@@ -257,7 +263,7 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
         val possibleBlocks = searchBlocksInCuboid(range + 1, eyesPos) { pos, state ->
             targets.contains(state.block)
                 && !((state.block as? BedBlock)?.let { block -> isSelfBedMode.activeChoice.isSelfBed(block, pos) } ?:
-                        false)
+            false)
                 && getNearestPoint(eyesPos, Box.enclosing(pos, pos.add(1, 1, 1))).distanceTo(eyesPos) <= range
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
@@ -198,9 +198,9 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
         }
 
         val destroyerTarget = currentTarget ?: return@repeatable
+        val currentRotation = RotationManager.serverRotation
 
         // Check if we are already looking at the block
-        val currentRotation = RotationManager.serverRotation
         val rayTraceResult = raytraceBlock(
             max(range, wallRange).toDouble(),
             currentRotation,
@@ -256,8 +256,9 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
 
         val possibleBlocks = searchBlocksInCuboid(range + 1, eyesPos) { pos, state ->
             targets.contains(state.block)
-                && !((state.block as? BedBlock)?.let { block -> isSelfBedMode.activeChoice.isSelfBed(block, pos) } ?:
-            false)
+                && !((state.block as? BedBlock)?.let { block ->
+                    isSelfBedMode.activeChoice.isSelfBed(block, pos)
+                } ?: false)
                 && getNearestPoint(eyesPos, Box.enclosing(pos, pos.add(1, 1, 1))).distanceTo(eyesPos) <= range
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFucker.kt
@@ -198,12 +198,6 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
         }
 
         val destroyerTarget = currentTarget ?: return@repeatable
-        val destroyerTargetState = destroyerTarget.pos.getState() ?: return@repeatable
-
-        // Check if the block has updated to a non target
-        if (!targets.contains(destroyerTargetState.block)) {
-            currentTarget = null
-        }
 
         // Check if we are already looking at the block
         val currentRotation = RotationManager.serverRotation
@@ -211,7 +205,7 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
             max(range, wallRange).toDouble(),
             currentRotation,
             destroyerTarget.pos,
-            destroyerTargetState
+            destroyerTarget.pos.getState() ?: return@repeatable
         ) ?: return@repeatable
 
         val raytracePos = rayTraceResult.blockPos
@@ -324,7 +318,7 @@ object ModuleFucker : Module("Fucker", Category.WORLD, aliases = arrayOf("BedBre
         val currentTarget = this.currentTarget
 
         if (currentTarget != null) {
-            if (possibleBlocks.any { (pos, _) -> pos == currentTarget.pos }) {
+            if (possibleBlocks.none { (pos, _) -> pos == currentTarget.pos }) {
                 this.currentTarget = null
             }
             if (currentTarget.isTarget && currentTarget.action != action) {


### PR DESCRIPTION
Allows Fucker to change target if the current block is updated to a non target.   
Makes Fucker usable on servers with custom mining mechanics such as Hypixel SkyBlock.