### PR TITLE
feat: lunar spoof version (very outdated)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
@@ -42,7 +42,7 @@ object ModuleSpoofer : Module("ClientSpoofer", Category.EXPLOIT) {
     }
 
     private object Lunar : SpoofMode("Lunar") {
-        override fun getBrand(): String = "lunarclient:v2.12.3-2351"
+        override fun getBrand(): String = "lunarclient:v2.16.8-2433"
     }
 
     private object Cheatbreaker : SpoofMode("Cheatbreaker") {


### PR DESCRIPTION
2.12.3-2351 to v2.16.8-2433 
This is necessary because some servers that have a lunar API already involve this