### PR TITLE
fix: no bob on tracers (not-ideal fix)

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
@@ -157,7 +157,7 @@ public abstract class MixinGameRenderer {
 
     @Inject(method = "bobView", at = @At("HEAD"), cancellable = true)
     private void injectBobView(MatrixStack matrixStack, float f, CallbackInfo callbackInfo) {
-        if (ModuleNoBob.INSTANCE.getEnabled()) {
+        if (ModuleNoBob.INSTANCE.getEnabled() || ModuleTracers.INSTANCE.getEnabled()) {
             callbackInfo.cancel();
             return;
         }


### PR DESCRIPTION
We could simply transform the line drawing to adapt to the view bobbing, but it always looked off in my attempts, so I fix it like this for now. Hopefully @superblaubeere27 will implement a proper fix soon.