### PR TITLE
feat: prettier log messages

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
@@ -141,7 +141,7 @@ object ModuleLiquidChat : Module("LiquidChat", Category.CLIENT, hide = true, sta
             ClientChatMessageEvent.ChatGroup.PRIVATE_CHAT -> writeChat(
                 "[".asText().styled { it.withFormatting(Formatting.DARK_GRAY) }
                     .append(event.user.name.asText().styled { it.withFormatting(Formatting.BLUE) })
-                    .append("]".asText().styled { it.withFormatting(Formatting.DARK_GRAY) })
+                    .append("] ".asText().styled { it.withFormatting(Formatting.DARK_GRAY) })
                     .append(event.message.asText().styled { it.withFormatting(Formatting.GRAY) })
             )
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
@@ -43,9 +43,9 @@ val inGame: Boolean
 private val clientPrefix = Text.empty()
     .styled { it.withFormatting(Formatting.RESET) }.styled { it.withFormatting(Formatting.GRAY) }
     .append(Text.literal("Liquid")
-        .styled { it.withColor(Formatting.WHITE) }).styled { it.withFormatting(Formatting.BOLD) }
+        .styled { it.withColor(Formatting.WHITE) }.styled { it.withFormatting(Formatting.BOLD) })
     .append(Text.literal("Bounce")
-        .styled { it.withColor(Formatting.BLUE) }).styled { it.withFormatting(Formatting.BOLD) }
+        .styled { it.withColor(Formatting.BLUE) }.styled { it.withFormatting(Formatting.BOLD) })
     .append(Text.literal(" ▸ ")
         .styled { it.withFormatting(Formatting.RESET) }.styled { it.withColor(Formatting.DARK_GRAY) })
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
@@ -25,7 +25,6 @@ import net.ccbluex.liquidbounce.interfaces.ClientTextColorAdditions
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.util.InputUtil
 import net.minecraft.text.MutableText
-import net.minecraft.text.Style
 import net.minecraft.text.Text
 import net.minecraft.text.TextColor
 import net.minecraft.util.Formatting
@@ -41,7 +40,14 @@ val inGame: Boolean
     get() = MinecraftClient.getInstance()?.let { mc -> mc.player != null && mc.world != null } ?: false
 
 // Chat formatting
-private val clientPrefix = "§f§lLiquid§9§lBounce §8▸ §7".asText()
+private val clientPrefix = Text.empty()
+    .styled { it.withFormatting(Formatting.RESET) }.styled { it.withFormatting(Formatting.GRAY) }
+    .append(Text.literal("Liquid")
+        .styled { it.withColor(Formatting.WHITE) }).styled { it.withFormatting(Formatting.BOLD) }
+    .append(Text.literal("Bounce")
+        .styled { it.withColor(Formatting.BLUE) }).styled { it.withFormatting(Formatting.BOLD) }
+    .append(Text.literal(" ▸ ")
+        .styled { it.withFormatting(Formatting.RESET) }.styled { it.withColor(Formatting.DARK_GRAY) })
 
 fun dot() = regular(".")
 
@@ -66,6 +72,7 @@ fun withColor(text: String, color: Formatting) = text.asText().styled { it.withC
 fun bypassNameProtection(text: MutableText) = text.styled {
     val color = it.color ?: TextColor.fromFormatting(Formatting.RESET)
 
+    @Suppress("KotlinConstantConditions")
     val newColor = (color as ClientTextColorAdditions).`liquid_bounce$withNameProtectionBypass`()
 
     it.withColor(newColor)
@@ -159,5 +166,6 @@ fun keyName(keyCode: Int) = when (keyCode) {
  */
 fun browseUrl(url: String) = Util.getOperatingSystem().open(url)
 
+@Suppress("CAST_NEVER_SUCCEEDS")
 val TextColor.bypassesNameProtection: Boolean
     get() = (this as ClientTextColorAdditions).`liquid_bounce$doesBypassingNameProtect`()


### PR DESCRIPTION
Instead of for example 
`[14:58:16] [nioEventLoopGroup-4-1/INFO] (Minecraft) [System] [CHAT] §9§lLiquidChat §8▸ §7user_11 §8▸ §7what server?`
it'd now show
`[14:58:16] [nioEventLoopGroup-4-1/INFO] (Minecraft) [System] [CHAT] LiquidChat ▸ user_11 ▸ what server?`
in the game log.