### PR TITLE
feat: add OnlyExposure option to XRay (#3964)

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinBlock.java
@@ -38,8 +38,7 @@ public class MixinBlock {
     private static boolean injectXRay(boolean original, BlockState state, BlockView world, BlockPos pos, Direction side, BlockPos otherPos) {
         var xRay = ModuleXRay.INSTANCE;
         if (xRay.getEnabled()) {
-            var blocks = xRay.getBlocks();
-            return blocks.contains(state.getBlock());
+            return xRay.shouldRender(state, pos);
         }
 
         return original;

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinSodiumBlockOcclusionCache.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinSodiumBlockOcclusionCache.java
@@ -44,8 +44,7 @@ public class MixinSodiumBlockOcclusionCache {
             return;
         }
 
-        Set<Block> blocks = module.getBlocks();
-        cir.setReturnValue(blocks.contains(selfState.getBlock()));
+        cir.setReturnValue(module.shouldRender(selfState, pos));
         cir.cancel();
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
@@ -20,7 +20,11 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.utils.block.getState
+import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks.*
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Direction
 
 /**
  * XRay module
@@ -32,6 +36,9 @@ object ModuleXRay : Module("XRay", Category.RENDER) {
 
     // Lighting of blocks through walls
     val fullBright by boolean("FullBright", true)
+
+    // Only render blocks with non-solid blocks around
+    private val onlyExposure by boolean("OnlyExposure", false)
 
     private val deafultBlocks = mutableSetOf(
         // Overworld ores
@@ -167,6 +174,16 @@ object ModuleXRay : Module("XRay", Category.RENDER) {
         "Blocks",
         deafultBlocks
     )
+
+    fun shouldRender(blockState: BlockState, blockPos: BlockPos) = when {
+        blockState.block !in blocks -> false
+
+        onlyExposure -> Direction.entries.any {
+            blockPos.add(it.vector)?.let { pos -> pos.getState()?.isSolidBlock(world, pos) } == false
+        }
+
+        else -> true
+    }
 
     fun resetBlocks() {
         blocks.clear()


### PR DESCRIPTION
If this option is enabled, XRay will only render blocks having non-solid block(s) around it.