### PR TITLE
fix: block counter being stuck after disabling scaffold

### DIFF
--- a/src-theme/src/integration/events.ts
+++ b/src-theme/src/integration/events.ts
@@ -50,7 +50,7 @@ export interface TargetChangeEvent {
 }
 
 export interface BlockCountChangeEvent {
-    count: number | null;
+    count?: number;
 }
 
 export interface AccountManagerAdditionEvent {

--- a/src-theme/src/routes/hud/elements/BlockCounter.svelte
+++ b/src-theme/src/routes/hud/elements/BlockCounter.svelte
@@ -3,7 +3,7 @@
     import {fly} from "svelte/transition";
     import type {BlockCountChangeEvent} from "../../../integration/events";
 
-    let count: number | null = null;
+    let count: number | undefined;
 
     function mapToColor(value: number): string {
         if (value <= 0) {
@@ -23,8 +23,9 @@
 
 </script>
 
-{#if count !== null}
-    <div class="counter" style="color: {mapToColor(count)}" transition:fly={{ y: -5, duration: 200 }}>
+{#if count !== undefined}
+    <div class="counter" style="color: {mapToColor(count)}" in:fly={{ y: -5, duration: 200 }}
+         out:fly={{ y: -5, duration: 200 }}>
         {count}
     </div>
 {/if}


### PR DESCRIPTION
Fixes block counter not disappearing after disabling Scaffold. Also fixes glitching animation when the width of the counter changed between showing and hiding.

![image](https://github.com/user-attachments/assets/658a2cc7-9e94-4a47-8647-6ec3e99ee537)
