### PR TITLE
chore: do not label nextgen issues/PRs as dev build

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,3 @@
 
 '🌑 nextgen':
   - 'Nextgen'
-
-'👷 development build':
-  - 'Nextgen'


### PR DESCRIPTION
Since Nextgen has its own official releases, it shouldn't always label GitHub issues or pull requests with the development build label.