### PR TITLE
feat: vomit module

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -133,7 +133,6 @@
     <ID>MaxLineLength:ModuleTracers.kt$ModuleTracers$(if (DistanceColor.useViewDistance) mc.options.viewDistance.value.toFloat() else DistanceColor.customViewDistance) * 16</ID>
     <ID>MaxLineLength:NettyServer.kt$NettyServer$.</ID>
     <ID>MemberNameEqualsClassName:ServerListRest.kt$ServerListRest$internal fun RestNode.serverListRest()</ID>
-    <ID>NestedBlockDepth:ChunkScanner.kt$ChunkScanner.ChunkScannerThread$private fun scanChunk(request: UpdateRequest.ChunkUpdateRequest)</ID>
     <ID>NestedBlockDepth:CombatExtensions.kt$fun Entity.attack(swing: Boolean, keepSprint: Boolean = false)</ID>
     <ID>NestedBlockDepth:CommandManager.kt$CommandManager$fun autoComplete(origCmd: String, start: Int): CompletableFuture&lt;Suggestions></ID>
     <ID>NestedBlockDepth:EntityExtensions.kt$fun LivingEntity.getActualHealth(fromScoreboard: Boolean = true): Float</ID>
@@ -146,6 +145,7 @@
     <ID>SpreadOperator:JsReflectionUtil.kt$JsReflectionUtil$( Remapper.remapField(obj::class.java, name, true), *args.map { it!!::class.java }.toTypedArray() )</ID>
     <ID>SpreadOperator:JsReflectionUtil.kt$JsReflectionUtil$(*args.map { it!!::class.java }.toTypedArray())</ID>
     <ID>SpreadOperator:ModuleScaffold.kt$ModuleScaffold$(blockInMainHand, blockInOffHand, *blocksInHotbar.map { it.second }.toTypedArray())</ID>
+    <ID>SpreadOperator:ModuleVomit.kt$ModuleVomit$( *emptySlots.map { slot -> CreativeInventoryAction.performFillSlot(randomStack, slot) } .toTypedArray(), *emptySlots.map { slot -> ClickInventoryAction.performThrow(null, slot) } .toTypedArray() )</ID>
     <ID>StringLiteralDuplication:AutoQueueGommeDuels.kt$AutoQueueGommeDuels$"AutoPlay"</ID>
     <ID>StringLiteralDuplication:JsSetting.kt$JsSetting$"default"</ID>
     <ID>SwallowedException:ChunkScanner.kt$ChunkScanner.ChunkScannerThread$e: CancellationException</ID>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -35,10 +35,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.ModuleVe
 import net.ccbluex.liquidbounce.features.module.modules.exploit.*
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
-import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleDankBobbing
-import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleDerp
-import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleHandDerp
-import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleSkinDerp
+import net.ccbluex.liquidbounce.features.module.modules.`fun`.*
 import net.ccbluex.liquidbounce.features.module.modules.misc.*
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.ccbluex.liquidbounce.features.module.modules.misc.betterchat.ModuleBetterChat
@@ -182,6 +179,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
             ModuleDerp,
             ModuleSkinDerp,
             ModuleHandDerp,
+            ModuleVomit,
 
             // Misc
             ModuleAntiBot,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleVomit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleVomit.kt
@@ -1,0 +1,94 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.`fun`
+
+import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.utils.inventory.*
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
+import net.minecraft.item.ItemStack
+import net.minecraft.registry.Registries
+import net.minecraft.util.math.random.Random
+
+/**
+ * Vomit module
+ *
+ * Drops items from the inventory in a random order to make it look like the player is vomiting.
+ * If the player is in creative mode, the player will drop random block items.
+ */
+object ModuleVomit : Module("Vomit", Category.FUN) {
+
+    private val inventoryConstraints = tree(PlayerInventoryConstraints())
+    private val random = Random.create()
+
+    @Suppress("unused")
+    private val vomitHandler = handler<ScheduleInventoryActionEvent> { event ->
+        if (player.isCreative) {
+            val blockItem = Registries.BLOCK.getRandom(random).get().value()
+            val randomStack = ItemStack(blockItem, 64)
+            val emptySlots = findEmptyStorageSlotsInInventory()
+
+            if (emptySlots.isEmpty()) {
+                // Throw only - this will rate limit after a few stacks
+                event.schedule(inventoryConstraints, CreativeInventoryAction.performThrow(randomStack))
+                return@handler
+            }
+
+            // Fill and throw - this bypasses the creative drop limit
+            event.schedule(inventoryConstraints, if (inventoryConstraints.clickDelay.last <= 0) {
+                // Depending on how many empty slots we have, this might kick in the packet rate limit
+                // of ViaVersion or Minecraft/Paper itself
+                listOf(
+                    *emptySlots.map { slot -> CreativeInventoryAction.performFillSlot(randomStack, slot) }
+                        .toTypedArray(),
+                    *emptySlots.map { slot -> ClickInventoryAction.performThrow(null, slot) }
+                        .toTypedArray()
+                )
+            } else {
+                val slot = emptySlots.random()
+
+                listOf(
+                    CreativeInventoryAction.performFillSlot(randomStack, slot),
+                    ClickInventoryAction.performThrow(null, slot)
+                )
+            })
+        } else {
+            // We specifically only want to choose slots that we can store items in, as
+            // e.g. the offhand slot is not a storage slot on 1.8 servers and therefore can cause issues
+            val playerSlot = findNonEmptyStorageSlotsInInventory()
+            val container = mc.currentScreen as? GenericContainerScreen
+
+            val randomSlot = if (playerSlot.isEmpty()) {
+                // Attempt to drop from the container
+                val slots = findItemsInContainer(container ?: return@handler)
+                if (slots.isEmpty()) return@handler
+
+                slots.random()
+            } else {
+                playerSlot.random()
+            }
+
+            event.schedule(inventoryConstraints, ClickInventoryAction.performThrow(container, randomSlot))
+        }
+    }
+
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
@@ -135,6 +135,10 @@ fun findEmptyStorageSlotsInInventory(): List<ItemSlot> {
     return (INVENTORY_SLOTS + HOTBAR_SLOTS).filter { it.itemStack.isEmpty }
 }
 
+fun findNonEmptyStorageSlotsInInventory(): List<ItemSlot> {
+    return (INVENTORY_SLOTS + HOTBAR_SLOTS).filter { !it.itemStack.isEmpty }
+}
+
 fun findNonEmptySlotsInInventory(): List<ItemSlot> {
     return ALL_SLOTS_IN_INVENTORY.filter { !it.itemStack.isEmpty }
 }

--- a/src/main/resources/assets/liquidbounce/lang/en_us.json
+++ b/src/main/resources/assets/liquidbounce/lang/en_us.json
@@ -414,6 +414,7 @@
   "liquidbounce.module.debugRecorder.description": "Only of interest to developers.",
   "liquidbounce.module.smartEat.description": "Automatically eats food when your hunger is low.",
   "liquidbounce.module.derp.description": "Makes it look as if you were derping around. to other players",
+  "liquidbounce.module.vomit.description": "Vomit items out of your inventory.",
   "liquidbounce.module.disabler.description": "Attempts to disable the AntiCheat of the server.",
   "liquidbounce.module.disabler.messages.info": "Check your configuration in the Disabler module to make sure it is correct for the server or anti-cheat. If not, not only will this module not work, it may even flag you.",
   "liquidbounce.module.disabler.messages.vulcanRiptideMessage": "You need to have a trident enchanted with Riptide in your offhand in order to bypass Vulcan movement checks.",


### PR DESCRIPTION
Drops items from the inventory in a random order to make it look like you are vomiting. If you are in creative mode, the module will drop random block items as quick as possible. Can also take out items from containers if no slots are available to drop in inventory.