### PR TITLE
fix: apply CORS restrictions

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpConductor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpConductor.kt
@@ -73,19 +73,25 @@ class HttpConductor {
 
     private fun middleware(context: RequestContext, response: FullHttpResponse): FullHttpResponse {
         val httpHeaders = response.headers()
-
         val requestOrigin = context.headers["origin"]
-        if (requestOrigin == "http://localhost" || requestOrigin == "http://127.0.0.1") {
-            httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = requestOrigin
-        } else {
-            httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "null"
-        }
 
-        httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS] = "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"
-        httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS] =
-            "Content-Type, Content-Length, Authorization, Accept, X-Requested-With"
+        if (requestOrigin != null) {
+            // If the origin is either localhost or 127.0.0.1, allow it
+            if (requestOrigin == "http://localhost" || requestOrigin == "http://127.0.0.1") {
+                httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = requestOrigin
+            } else {
+                // Block cross-origin requests by not allowing other origins
+                httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "null"
+            }
+
+            // Allow specific methods and headers for cross-origin requests
+            httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS] = "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"
+            httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS] =
+                "Content-Type, Content-Length, Authorization, Accept, X-Requested-With"
+        }
 
         return response
     }
+
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpConductor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpConductor.kt
@@ -49,7 +49,12 @@ class HttpConductor {
             val httpHeaders = response.headers()
             httpHeaders[HttpHeaderNames.CONTENT_TYPE] = "text/plain"
             httpHeaders[HttpHeaderNames.CONTENT_LENGTH] = response.content().readableBytes()
-            httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
+
+            val requestOrigin = context.headers["origin"]
+            if (requestOrigin == "http://localhost" || requestOrigin == "http://127.0.0.1") {
+                httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = requestOrigin
+            }
+
             httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS] = "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"
             httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS] = "Content-Type, Content-Length, Authorization, Accept, X-Requested-With"
             return@runCatching response

--- a/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpResponseUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/web/socket/netty/HttpResponseUtil.kt
@@ -39,9 +39,6 @@ private fun httpResponse(status: HttpResponseStatus, contentType: String = "text
     val httpHeaders = response.headers()
     httpHeaders[HttpHeaderNames.CONTENT_TYPE] = contentType
     httpHeaders[HttpHeaderNames.CONTENT_LENGTH] = response.content().readableBytes()
-    httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
-    httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS] = "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"
-    httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS] = "Content-Type, Content-Length, Authorization, Accept, X-Requested-With"
     return response
 }
 
@@ -88,7 +85,6 @@ fun httpFile(file: File): FullHttpResponse {
     val httpHeaders = response.headers()
     httpHeaders[HttpHeaderNames.CONTENT_TYPE] = tika.detect(file)
     httpHeaders[HttpHeaderNames.CONTENT_LENGTH] = response.content().readableBytes()
-    httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
     return response
 }
 
@@ -104,7 +100,6 @@ fun httpFileStream(stream: InputStream): FullHttpResponse {
     val httpHeaders = response.headers()
     httpHeaders[HttpHeaderNames.CONTENT_TYPE] = tika.detect(bytes)
     httpHeaders[HttpHeaderNames.CONTENT_LENGTH] = response.content().readableBytes()
-    httpHeaders[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
 
     return response
 }


### PR DESCRIPTION
Restrict CORS to allow only localhost and 127.0.0.1 for development purposes.

CORS is not strictly required for our use case, as the REST API, WebSocket, and Static File Server are all hosted on the same host and port. However, to support development workflows—such as working on themes—we allow access to the Client REST API from `localhost` or `127.0.0.1`.

This change restricts access from third-party websites, ensuring that only local development environments can make cross-origin requests. Note that this does not affect the `External Client Menu` feature, as long as the host URL is accessed directly.