### PR TITLE
fix(legacy): tower not on move option

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/scaffolds/Tower.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/scaffolds/Tower.kt
@@ -127,6 +127,8 @@ object Tower : MinecraftInstance(), Listenable {
                 return
             if (towerModeValues.get() == "None" || towerModeValues.get() == "Jump")
                 return
+            if (notOnMoveValues.get() && isMoving)
+                return
             if (Speed.state || Fly.state)
                 return
 


### PR DESCRIPTION
should now allow user to jump normally while having TowerNotOnMove option toggled.