### PR TITLE
feat: menu modal shadows

### DIFF
--- a/src-theme/src/routes/menu/common/modal/Modal.svelte
+++ b/src-theme/src/routes/menu/common/modal/Modal.svelte
@@ -53,6 +53,7 @@
     display: flex;
     flex-direction: column;
     border-radius: 5px;
+    box-shadow: 0 0 10px rgba($menu-base-color, 0.5);
   }
 
   .title {


### PR DESCRIPTION
This pull requests adds the same shadow used in ClickGUI panels to modals in LiquidBounce's main menu. This is also more consistent with the way LiquidLauncher is implemented.

![image](https://github.com/user-attachments/assets/a22515ec-1866-45f7-9a09-36c77bbafb99)
