### PR TITLE
fix: edit account button being clickable in account manager

### DIFF
--- a/src-theme/src/routes/menu/common/header/Account.svelte
+++ b/src-theme/src/routes/menu/common/header/Account.svelte
@@ -10,9 +10,7 @@
     let premium = true;
 
     const inAccountManager = $location === "/altmanager";
-
-    console.log(inAccountManager);
-
+    
     async function refreshSession() {
         const session = await getSession();
         username = session.username;

--- a/src-theme/src/routes/menu/common/header/Account.svelte
+++ b/src-theme/src/routes/menu/common/header/Account.svelte
@@ -3,10 +3,15 @@
     import {getSession, openScreen} from "../../../../integration/rest";
     import {onMount} from "svelte";
     import {listen} from "../../../../integration/ws";
+    import {location} from "svelte-spa-router";
 
     let username = "";
     let avatar = "";
     let premium = true;
+
+    const inAccountManager = $location === "/altmanager";
+
+    console.log(inAccountManager);
 
     async function refreshSession() {
         const session = await getSession();
@@ -36,7 +41,7 @@
             <span class="offline">Offline</span>
         {/if}
     </div>
-    <button class="button-change-account" type="button" on:click={() => openScreen("altmanager")}>
+    <button class="button-change-account" disabled={inAccountManager} type="button" on:click={() => openScreen("altmanager")}>
         <ToolTip text="Change account"/>
 
         <img class="icon" src="img/menu/icon-pen.svg" alt="change account">
@@ -97,5 +102,10 @@
     position: relative;
     height: max-content;
     cursor: pointer;
+
+    &:disabled {
+      pointer-events: none;
+      opacity: .5;
+    }
   }
 </style>


### PR DESCRIPTION
The edit account button will now be disabled and faded out slightly when the account manager is opened.

![image](https://github.com/user-attachments/assets/63a91302-d6bb-411b-8795-e2e15b2a8672)
