### PR TITLE
chore: use gpt-4o-mini on AutoChatGame

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
@@ -40,7 +40,7 @@ object ModuleAutoChatGame : Module("AutoChatGame", Category.MISC) {
         .doNotIncludeAlways() // Keeps API key private
     private val openAiKey by text("OpenAiKey", "")
         .doNotIncludeAlways() // Keeps API key private
-    private val model by text("Model", "gpt-4")
+    private val model by text("Model", "gpt-4o-mini") // GPT 4O Mini should be enough for this
     private val delayResponse by intRange("ReactionTime", 1000..5000, 0..10000,
         "ms")
     private val cooldownMinutes by int("Cooldown", 2, 0..60, "minutes")


### PR DESCRIPTION
[GPT-4o mini](https://platform.openai.com/docs/models/gpt-4o-mini)
> GPT-4o mini (“o” for “omni”) is our most advanced model in the small models category, and our cheapest model yet. It is multimodal (accepting text or image inputs and outputting text), has higher intelligence than gpt-3.5-turbo but is just as fast. It is meant to be used for smaller tasks, including vision tasks.
> 
> We recommend choosing gpt-4o-mini where you would have previously used gpt-3.5-turbo as this model is more capable and cheaper.