### PR TITLE
feat: protocol version in window title

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     // Recommended mods (on IDE)
     modRuntimeOnly "com.terraformersmc:modmenu:${project.mod_menu_version}"
     modImplementation "maven.modrinth:sodium:${project.sodium_version}"
-    modCompileOnly "de.florianmichael:ViaFabricPlus:${project.viafabricplus_version}"
+    modImplementation "de.florianmichael:ViaFabricPlus:${project.viafabricplus_version}"
 
     // Tests
 //    modImplementation 'com.github.superblaubeere27:tenacc:e3a7ada99a'

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,4 +43,4 @@ mc_authlib_version=1.4.1
 # Recommended mods
 mod_menu_version=11.0.1
 sodium_version=mc1.21-0.5.11
-viafabricplus_version=3.4.8
+viafabricplus_version=3.4.9

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -29,10 +29,11 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKi
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.AutoBlock;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleXRay;
-import net.ccbluex.liquidbounce.render.engine.RenderingFlags;
-import net.ccbluex.liquidbounce.utils.combat.CombatManager;
 import net.ccbluex.liquidbounce.integration.BrowserScreen;
 import net.ccbluex.liquidbounce.integration.VrScreen;
+import net.ccbluex.liquidbounce.render.engine.RenderingFlags;
+import net.ccbluex.liquidbounce.utils.client.vfp.VfpCompatibility;
+import net.ccbluex.liquidbounce.utils.combat.CombatManager;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.AccessibilityOnboardingScreen;
@@ -53,11 +54,16 @@ import net.minecraft.util.hit.HitResult;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import javax.annotation.Nullable;
+
+import static net.ccbluex.liquidbounce.utils.client.ProtocolUtilKt.getHasProtocolTranslator;
 
 @Mixin(MinecraftClient.class)
 public abstract class MixinMinecraftClient {
@@ -173,7 +179,19 @@ public abstract class MixinMinecraftClient {
         titleBuilder.append(LiquidBounce.INSTANCE.getClientCommit());
 
         titleBuilder.append(" | ");
-        titleBuilder.append(SharedConstants.getGameVersion().getName());
+
+        // ViaFabricPlus compatibility
+        if (getHasProtocolTranslator()) {
+            var protocolVersion = VfpCompatibility.INSTANCE.unsafeGetProtocolVersion();
+
+            if (protocolVersion != null) {
+                titleBuilder.append(protocolVersion.getName());
+            } else {
+                titleBuilder.append(SharedConstants.getGameVersion().getName());
+            }
+        } else {
+            titleBuilder.append(SharedConstants.getGameVersion().getName());
+        }
 
         ClientPlayNetworkHandler clientPlayNetworkHandler = this.getNetworkHandler();
         if (clientPlayNetworkHandler != null && clientPlayNetworkHandler.getConnection().isOpen()) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
@@ -109,6 +109,9 @@ fun selectProtocolVersion(protocolId: Int) {
     // Check if the ViaFabricPlus mod is loaded - prevents from causing too many exceptions
     if (hasProtocolTranslator) {
         VfpCompatibility.INSTANCE.unsafeSelectProtocolVersion(protocolId)
+
+        // Update the window title
+        mc.updateWindowTitle()
     } else {
         error("ViaFabricPlus is not loaded")
     }


### PR DESCRIPTION
This makes it easier for users to understand what version they are playing on, as LiquidBounce is pretty much version independent except for the requirement to run on 1.21.1. Unfortunately I still get way too many questions about how to run LiquidBounce on e.g. 1.8.x, 1.16 etc. for some bizarre reason.