### PR TITLE
fix: intave speed

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
@@ -61,7 +61,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         )
 
         companion object {
-            private const val BOOST_CONSTANT = 1.003
+            private const val BOOST_CONSTANT = 0.003
         }
 
         @Suppress("unused")


### PR DESCRIPTION
i forgot to push this commit, currently the speed's boost adds +1.003 to the player's velocity :skull: