### PR TITLE
fix: StorageESP crashes at joining InsanityCraft (#4353)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -256,7 +256,8 @@ object ModuleStorageESP : Module("StorageESP", Category.RENDER, aliases = arrayO
 
     private object StorageScanner : AbstractBlockLocationTracker<ChestType>() {
         override fun getStateFor(pos: BlockPos, state: BlockState): ChestType? {
-            return world.getBlockEntity(pos)?.categorize()
+            val chunk = mc.world?.getChunk(pos) ?: return null
+            return chunk.getBlockEntity(pos)?.categorize()
         }
     }
 


### PR DESCRIPTION
`World.getBlockEntity` and `Chunk.getBlockEntity` have different behaviors. `World.getBlockEntity` seems to be non thread-safe.

Closes: #4353 