### PR TITLE
new grim lowhop speed

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -81,7 +81,8 @@ object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
 
         SpeedNCP(configurable),
 
-        SpeedIntave14(configurable)
+        SpeedIntave14(configurable),
+        SpeedGrimLowHop(configurable)
     )
 
     val modes = choices<Choice>("Mode", { it.choices[0] }, this::initializeSpeeds).apply { tagBy(this) }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.Spe
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedLegitHop
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedSpeedYPort
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.grim.SpeedGrimCollide
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.grim.SpeedGrimLowHop
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.intave.SpeedIntave14
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.ncp.SpeedNCP
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.sentinel.SpeedSentinelDamage

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
@@ -31,7 +31,7 @@ class SpeedGrimLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBas
     @Suppress("unused")
     private val jumpHandler = handler<PlayerJumpEvent> { event ->
         if (lowHop) {
-            event.motion = 0.41901ff
+            event.motion = 0.41901f
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
@@ -31,7 +31,7 @@ class SpeedGrimLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBas
     @Suppress("unused")
     private val jumpHandler = handler<PlayerJumpEvent> { event ->
         if (lowHop) {
-            event.motion = 0.42f - 99E-5f
+            event.motion = 0.4101f
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
@@ -1,0 +1,18 @@
+package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.grim
+
+import net.ccbluex.liquidbounce.config.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
+
+class SpeedGrimLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("Grim LowHop", parent) {
+
+    private val lowHop by boolean("LowHop", true)
+
+    @Suppress("unused")
+    private val jumpHandler = handler<PlayerJumpEvent> { event ->
+        if (lowHop) {
+            event.motion = 0.42f - 99E-5f
+        }
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
@@ -1,3 +1,22 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.grim
 
 import net.ccbluex.liquidbounce.config.ChoiceConfigurable

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimLowHop.kt
@@ -31,7 +31,7 @@ class SpeedGrimLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBas
     @Suppress("unused")
     private val jumpHandler = handler<PlayerJumpEvent> { event ->
         if (lowHop) {
-            event.motion = 0.4101f
+            event.motion = 0.41901ff
         }
     }
 }


### PR DESCRIPTION
i made this because the old grim collide is patched
it works only on 1.8.x protocol

- [x] work on a lowhop
- [ ] find out a method to make the speed more fast (optional)