### PR TITLE
fix: words not separated

### DIFF
--- a/src-theme/src/routes/menu/title/Title.svelte
+++ b/src-theme/src/routes/menu/title/Title.svelte
@@ -66,7 +66,7 @@
             {:else if clientButtonsShown}
                 <MainButton title="Proxy Manager" icon="proxymanager" on:click={() => openScreen("proxymanager")}
                             index={0}/>
-                <MainButton title="ClickGUI" icon="clickgui" on:click={() => openScreen("clickgui")} index={1}/>
+                <MainButton title="Click GUI" icon="clickgui" on:click={() => openScreen("clickgui")} index={1}/>
                 <!-- <MainButton title="Scripts" icon="scripts" index={2}/> -->
                 <MainButton title="Back" icon="back-large" on:click={toggleButtons} index={2}/>
             {/if}


### PR DESCRIPTION
Following the logic of e.g. "Proxy Manager", words should be separated by spaces.