### PR TITLE
fix: forward authentication value not being reset

### DIFF
--- a/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
+++ b/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
@@ -47,6 +47,7 @@
         hostPort = "";
         username = "";
         password = "";
+        forwardAuthentication = false;
     }
 </script>
 


### PR DESCRIPTION
The `Forward Authentication` setting of the add proxy modal is not being reset after the modal is closed. Instead, it keeps the previous state.