### PR TITLE
refactor: proxy validator

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/authlib/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/authlib/MixinMinecraftClient.java
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.injection.mixins.authlib;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mojang.authlib.minecraft.client.MinecraftClient;
-import net.ccbluex.liquidbounce.features.misc.ProxyManager;
+import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager;
 import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/custom/MixinConnectScreen.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/custom/MixinConnectScreen.java
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.api.IpInfoApi;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent;
 import net.ccbluex.liquidbounce.features.misc.HideAppearance;
-import net.ccbluex.liquidbounce.features.misc.ProxyManager;
+import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager;
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.gui.MixinScreen;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
@@ -105,7 +105,7 @@ public abstract class MixinConnectScreen extends MixinScreen {
                 hideSensitiveAddress(serverAddress.getAddress()),
                 serverAddress.getPort()
         );
-        var ipInfo = IpInfoApi.INSTANCE.getLocalIpInfo();
+        var ipInfo = IpInfoApi.INSTANCE.getCurrent();
 
         var client = Text.literal("Client").formatted(Formatting.BLUE);
         if (ipInfo != null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -39,7 +39,7 @@ import net.ccbluex.liquidbounce.features.itemgroup.ClientItemGroups
 import net.ccbluex.liquidbounce.features.itemgroup.groups.headsCollection
 import net.ccbluex.liquidbounce.features.misc.AccountManager
 import net.ccbluex.liquidbounce.features.misc.FriendManager
-import net.ccbluex.liquidbounce.features.misc.ProxyManager
+import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.modules.client.ipcConfiguration
 import net.ccbluex.liquidbounce.integration.IntegrationHandler
@@ -234,7 +234,7 @@ object LiquidBounce : Listenable {
 
             // Refresh local IP info
             logger.info("Refreshing local IP info...")
-            IpInfoApi.refreshLocalIpInfo()
+            IpInfoApi
 
             // Check if client account is available
             if (ClientAccountManager.clientAccount != ClientAccount.EMPTY_ACCOUNT) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/IpInfoApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/IpInfoApi.kt
@@ -18,154 +18,55 @@
  */
 package net.ccbluex.liquidbounce.api
 
-import io.netty.bootstrap.Bootstrap
-import io.netty.buffer.Unpooled
-import io.netty.channel.*
-import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.channel.socket.SocketChannel
-import io.netty.channel.socket.nio.NioSocketChannel
-import io.netty.handler.codec.http.*
-import io.netty.handler.ssl.SslContextBuilder
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory
-import net.ccbluex.liquidbounce.LiquidBounce
-import net.ccbluex.liquidbounce.LiquidBounce.logger
 import net.ccbluex.liquidbounce.config.util.decode
-import net.ccbluex.liquidbounce.features.misc.ProxyManager
-import java.net.URI
+import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager
+import net.ccbluex.liquidbounce.utils.client.logger
+import net.ccbluex.liquidbounce.utils.io.HttpClient
 
+/**
+ * An implementation for the ipinfo.io API including
+ * keeping track of the current IP address.
+ */
 object IpInfoApi {
 
     private const val API_URL = "https://ipinfo.io/json"
-
-    var localIpInfo: IpInfo? = null
-        private set
+    private const val API_URL_OTHER_IP = "https://ipinfo.io/%s/json"
 
     /**
-     * Refresh local IP info
+     * Information about the current IP address of the user. This can change depending on if the
+     * user is using a proxy through the Proxy Manager.
      */
-    fun refreshLocalIpInfo() {
-        requestIpInfo(success = { ipInfo ->
-            logger.info("IP Info [${ipInfo.country}, ${ipInfo.org}]")
-            this.localIpInfo = ipInfo
-        }, failure = {
-            logger.error("Failed to refresh local IP info", it)
-        })
-    }
+    val current: IpData?
+        get() = ProxyManager.currentProxy?.ipInfo ?: original
 
     /**
-     * Request IP info from API
+     * Information about the current IP address of the user. This does not change during use.
+     *
+     * We are only interested in the [IpData.country] for displaying the country in the GUI,
+     * which is unlikely to change, even when changing the IP address. This could happen when using a VPN,
+     * but it's not that important to keep this updated all the time.
      */
-    fun requestIpInfo(proxy: ProxyManager.Proxy? = ProxyManager.currentProxy,
-                      success: (IpInfo) -> Unit,
-                      failure: (Throwable) -> Unit
-    ) = makeAsyncEndpointRequest(proxy = proxy, endpoint = API_URL, success = {
-        success(decode<IpInfo>(it))
-    }, failure = failure)
+    private val original: IpData? = runCatching(this::own).onFailure {
+        logger.error("Failed to get own IP address", it)
+    }.getOrNull()
+
+    fun own() = decode<IpData>(HttpClient.get(API_URL))
+    fun someoneElse(ip: String) = decode<IpData>(HttpClient.get(API_URL_OTHER_IP.format(ip)))
 
     /**
-     * Request to endpoint async and with proxy
+     * Represents information about an IP address
      */
-    private fun makeAsyncEndpointRequest(proxy: ProxyManager.Proxy?, endpoint: String,
-                                         success: (String) -> Unit, failure: (Throwable) -> Unit) = runCatching {
-        val uri = URI(endpoint)
-        val group = NioEventLoopGroup()
+    data class IpData(
+        val ip: String?,
+        val hostname: String?,
+        val city: String?,
+        val region: String?,
+        val country: String?,
+        val loc: String?,
+        val org: String?,
+        val postal: String?,
+        val timezone: String?
+    )
 
-        val ssl = uri.scheme == "https"
-        val sslContext = if (ssl) {
-            SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .build()
-        } else {
-            null
-        }
-
-        try {
-            val bootstrap = Bootstrap()
-                .group(group)
-                .channel(NioSocketChannel::class.java)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 5 seconds timeout
-                .handler(object : ChannelInitializer<SocketChannel>() {
-                    override fun initChannel(p0: SocketChannel) {
-                        val pipeline = p0.pipeline()
-
-                        ProxyManager.insertProxyHandler(proxy, pipeline)
-                        if (sslContext != null) {
-                            pipeline.addLast(sslContext.newHandler(p0.alloc()))
-                        }
-                        pipeline.addLast(HttpClientCodec())
-                        pipeline.addLast(HttpContentDecompressor())
-                        pipeline.addLast(object : SimpleChannelInboundHandler<HttpObject>() {
-
-                            val buffer = StringBuilder()
-
-                            override fun channelRead0(ctx: ChannelHandlerContext, msg: HttpObject) {
-                                if (msg is HttpResponse) {
-                                    // Throw error if status code is not 200
-                                    if (msg.status().code() != 200) {
-                                        error("Invalid status code: ${msg.status().code()}")
-                                    }
-                                }
-
-                                if (msg is HttpContent) {
-                                    val content = msg.content().toString(Charsets.UTF_8)
-                                    buffer.append(content)
-
-                                    if (msg is LastHttpContent) {
-                                        success(buffer.toString())
-                                        ctx.close()
-                                    }
-                                }
-
-                                ctx.channel().writeAndFlush(Unpooled.EMPTY_BUFFER)
-                                    .addListener(ChannelFutureListener.CLOSE)
-                            }
-
-                            @Deprecated("Deprecated in Java")
-                            override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-                                failure(cause)
-                                ctx.close()
-                            }
-
-                        })
-                    }
-                })
-
-            val port = if (uri.port == -1) {
-                if (ssl) 443 else 80
-            } else {
-                uri.port
-            }
-            val channel = bootstrap.connect(uri.host, port).sync().channel()
-
-            val httpRequest = DefaultFullHttpRequest(
-                HttpVersion.HTTP_1_1,
-                HttpMethod.GET,
-                uri.rawPath
-            )
-
-            httpRequest.headers().set(HttpHeaderNames.HOST, uri.host)
-            httpRequest.headers().set(HttpHeaderNames.USER_AGENT, "LiquidBounce ${LiquidBounce.clientVersion}")
-            httpRequest.headers().set(HttpHeaderNames.CONNECTION, HttpHeaders.Values.CLOSE)
-            httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaders.Values.GZIP)
-
-            channel.writeAndFlush(httpRequest).sync()
-            channel.closeFuture().sync()
-        } catch(it: Throwable) {
-            failure(it)
-        } finally {
-            group.shutdownGracefully()
-        }
-    }.onFailure(failure)
 }
 
-data class IpInfo(
-    val ip: String?,
-    val hostname: String?,
-    val city: String?,
-    val region: String?,
-    val country: String?,
-    val loc: String?,
-    val org: String?,
-    val postal: String?,
-    val timezone: String?
-)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/Value.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/Value.kt
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.config.util.Exclude
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.ValueChangedEvent
 import net.ccbluex.liquidbounce.features.misc.FriendManager
-import net.ccbluex.liquidbounce.features.misc.ProxyManager
+import net.ccbluex.liquidbounce.features.misc.proxy.Proxy
 import net.ccbluex.liquidbounce.integration.interop.protocol.ProtocolExclude
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
@@ -453,7 +453,7 @@ enum class ListValueType(val type: Class<*>?) {
     Item(net.minecraft.item.Item::class.java),
     String(kotlin.String::class.java),
     Friend(FriendManager.Friend::class.java),
-    Proxy(ProxyManager.Proxy::class.java),
+    Proxy(net.ccbluex.liquidbounce.features.misc.proxy.Proxy::class.java),
     Account(MinecraftAccount::class.java),
     None(null)
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -24,7 +24,7 @@ import com.google.gson.annotations.SerializedName
 import net.ccbluex.liquidbounce.config.Value
 import net.ccbluex.liquidbounce.event.Event
 import net.ccbluex.liquidbounce.features.chat.packet.User
-import net.ccbluex.liquidbounce.features.misc.ProxyManager
+import net.ccbluex.liquidbounce.features.misc.proxy.Proxy
 import net.ccbluex.liquidbounce.utils.client.Nameable
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
 import net.ccbluex.liquidbounce.utils.inventory.InventoryAction
@@ -134,15 +134,15 @@ class AccountManagerAdditionResultEvent(val username: String? = null, val error:
 
 @Nameable("proxyAdditionResult")
 @WebSocketEvent
-class ProxyAdditionResultEvent(val proxy: ProxyManager.Proxy? = null, val error: String? = null) : Event()
+class ProxyAdditionResultEvent(val proxy: Proxy? = null, val error: String? = null) : Event()
 
 @Nameable("proxyCheckResult")
 @WebSocketEvent
-class ProxyCheckResultEvent(val proxy: ProxyManager.Proxy, val error: String? = null) : Event()
+class ProxyCheckResultEvent(val proxy: Proxy, val error: String? = null) : Event()
 
 @Nameable("proxyEditResult")
 @WebSocketEvent
-class ProxyEditResultEvent(val proxy: ProxyManager.Proxy? = null, val error: String? = null) : Event()
+class ProxyEditResultEvent(val proxy: Proxy? = null, val error: String? = null) : Event()
 
 @Nameable("browserReady")
 class BrowserReadyEvent(val browser: IBrowser) : Event()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/Proxy.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/Proxy.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.misc.proxy
+
+import io.netty.handler.proxy.Socks5ProxyHandler
+import net.ccbluex.liquidbounce.api.IpInfoApi
+import java.net.InetSocketAddress
+
+/**
+ * Contains serializable proxy data
+ */
+data class Proxy(
+    val host: String,
+    val port: Int,
+    val credentials: Credentials?,
+    var forwardAuthentication: Boolean = false,
+    var ipInfo: IpInfoApi.IpData? = null,
+    var favorite: Boolean = false
+) {
+
+    val address
+        get() = InetSocketAddress(host, port)
+
+    fun handler() = if (credentials != null) {
+        Socks5ProxyHandler(address, credentials.username, credentials.password)
+    } else {
+        Socks5ProxyHandler(address)
+    }
+
+    data class Credentials(val username: String, val password: String) {
+        companion object {
+            fun credentials(username: String, password: String) = if (username.isNotBlank() && password.isNotBlank()) {
+                Credentials(username, password)
+            } else {
+                null
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
@@ -16,14 +16,10 @@
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
-package net.ccbluex.liquidbounce.features.misc
+package net.ccbluex.liquidbounce.features.misc.proxy
 
-import io.netty.channel.ChannelPipeline
 import io.netty.handler.proxy.Socks5ProxyHandler
 import net.ccbluex.liquidbounce.LiquidBounce
-import net.ccbluex.liquidbounce.api.IpInfo
-import net.ccbluex.liquidbounce.api.IpInfoApi
-import net.ccbluex.liquidbounce.api.IpInfoApi.requestIpInfo
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.Configurable
 import net.ccbluex.liquidbounce.config.ListValueType
@@ -35,9 +31,7 @@ import net.ccbluex.liquidbounce.event.events.ProxyAdditionResultEvent
 import net.ccbluex.liquidbounce.event.events.ProxyCheckResultEvent
 import net.ccbluex.liquidbounce.event.events.ProxyEditResultEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.misc.ProxyManager.Proxy.Companion.NO_PROXY
-import net.ccbluex.liquidbounce.features.misc.ProxyManager.ProxyCredentials.Companion.credentialsFromUserInput
-import java.net.InetSocketAddress
+import net.ccbluex.liquidbounce.features.misc.proxy.Proxy.Credentials.Companion.credentials
 
 /**
  * Proxy Manager
@@ -46,8 +40,10 @@ import java.net.InetSocketAddress
  */
 object ProxyManager : Configurable("proxy"), Listenable {
 
-    var proxy by value("selectedProxy", NO_PROXY, valueType = ValueType.PROXY)
-    val proxies by value(name, mutableListOf<Proxy>(), listType = ListValueType.Proxy)
+    private val NO_PROXY = Proxy("", 0, null)
+
+    private var proxy by value("selectedProxy", NO_PROXY, valueType = ValueType.PROXY)
+    internal val proxies by value(name, mutableListOf<Proxy>(), listType = ListValueType.Proxy)
 
     /**
      * The proxy that is set in the current session and used for all server connections
@@ -61,7 +57,7 @@ object ProxyManager : Configurable("proxy"), Listenable {
 
     fun addProxy(host: String, port: Int, username: String = "", password: String = "",
                  forwardAuthentication: Boolean = false) {
-        Proxy(host, port, credentialsFromUserInput(username, password), forwardAuthentication).checkProxy(
+        Proxy(host, port, credentials(username, password), forwardAuthentication).check(
             success = { proxy ->
                 LiquidBounce.logger.info("Added proxy [${proxy.host}:${proxy.port}]")
                 proxies.add(proxy)
@@ -80,7 +76,7 @@ object ProxyManager : Configurable("proxy"), Listenable {
     @Suppress("LongParameterList")
     fun editProxy(index: Int, host: String, port: Int, username: String = "", password: String = "",
                   forwardAuthentication: Boolean = false) {
-        Proxy(host, port, credentialsFromUserInput(username, password), forwardAuthentication).checkProxy(
+        Proxy(host, port, credentials(username, password), forwardAuthentication).check(
             success = { newProxy ->
                 val isConnected = proxy == proxies[index]
 
@@ -104,7 +100,7 @@ object ProxyManager : Configurable("proxy"), Listenable {
 
     fun checkProxy(index: Int) {
         val proxy = proxies.getOrNull(index) ?: error("Invalid proxy index")
-        proxy.checkProxy(
+        proxy.check(
             success = { proxy ->
                 LiquidBounce.logger.info("Checked proxy [${proxy.host}:${proxy.port}]")
                 ConfigSystem.storeConfigurable(this)
@@ -129,12 +125,12 @@ object ProxyManager : Configurable("proxy"), Listenable {
 
     fun setProxy(index: Int) {
         proxy = proxies[index]
-        sync()
+        ConfigSystem.storeConfigurable(this)
     }
 
     fun unsetProxy() {
         proxy = NO_PROXY
-        sync()
+        ConfigSystem.storeConfigurable(this)
     }
 
     fun favoriteProxy(index: Int) {
@@ -149,78 +145,25 @@ object ProxyManager : Configurable("proxy"), Listenable {
         ConfigSystem.storeConfigurable(this)
     }
 
-    private fun sync() {
-        ConfigSystem.storeConfigurable(this)
-        IpInfoApi.refreshLocalIpInfo()
-    }
-
     /**
      * Adds a SOCKS5 netty proxy handler to the pipeline when a proxy is set
      *
      * @see Socks5ProxyHandler
      * @see PipelineEvent
      */
-    val pipelineHandler = handler<PipelineEvent> {
-        val pipeline = it.channelPipeline
-
-        if (it.local) {
+    @Suppress("unused")
+    private val pipelineHandler = handler<PipelineEvent> { event ->
+        // If we are connecting to a local server, we don't need a proxy, as this would cause a connection error.
+        if (event.local) {
             return@handler
         }
 
-        insertProxyHandler(currentProxy, pipeline)
-    }
+        val pipeline = event.channelPipeline
 
-    fun insertProxyHandler(proxy: Proxy? = currentProxy, pipeline: ChannelPipeline) {
-        proxy?.run {
-            pipeline.addFirst(
-                "proxy",
-                if (credentials != null) {
-                    Socks5ProxyHandler(address, credentials.username, credentials.password)
-                } else {
-                    Socks5ProxyHandler(address)
-                }
-            )
-        }
-    }
-
-    /**
-     * Contains serializable proxy data
-     */
-    data class Proxy(
-        val host: String,
-        val port: Int,
-        val credentials: ProxyCredentials?,
-        var forwardAuthentication: Boolean = false,
-        var ipInfo: IpInfo? = null,
-        var favorite: Boolean = false
-    ) {
-        val address
-            get() = InetSocketAddress(host, port)
-
-        companion object {
-            val NO_PROXY = Proxy("", 0, null)
-        }
-
-        fun checkProxy(success: (Proxy) -> Unit, failure: (Throwable) -> Unit) =
-            requestIpInfo(proxy = this, success = { ipInfo ->
-                LiquidBounce.logger.info("IP Info [${ipInfo.country}, ${ipInfo.org}]")
-                this.ipInfo = ipInfo
-
-                success(this)
-            }, failure = failure)
-
-    }
-
-    /**
-     * Contains serializable proxy credentials
-     */
-    data class ProxyCredentials(val username: String, val password: String) {
-        companion object {
-            fun credentialsFromUserInput(username: String, password: String) =
-                if (username.isNotBlank() && password.isNotBlank())
-                    ProxyCredentials(username, password)
-                else
-                    null
+        // Only add the proxy handler if it's not already in the pipeline. If there is already a proxy handler,
+        // it is likely from [ProxyValidator] and we don't want to override it.
+        if (pipeline.get("proxy") == null) {
+            pipeline.addFirst("proxy", currentProxy?.handler() ?: return@handler)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
@@ -1,0 +1,165 @@
+package net.ccbluex.liquidbounce.features.misc.proxy
+
+import io.netty.bootstrap.Bootstrap
+import io.netty.channel.*
+import io.netty.channel.epoll.Epoll
+import io.netty.channel.epoll.EpollSocketChannel
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.timeout.ReadTimeoutHandler
+import net.ccbluex.liquidbounce.api.IpInfoApi
+import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.utils.client.convertToString
+import net.ccbluex.liquidbounce.utils.client.logger
+import net.minecraft.client.network.*
+import net.minecraft.network.ClientConnection
+import net.minecraft.network.DisconnectionInfo
+import net.minecraft.network.NetworkSide
+import net.minecraft.network.listener.ClientQueryPacketListener
+import net.minecraft.network.packet.c2s.query.QueryPingC2SPacket
+import net.minecraft.network.packet.c2s.query.QueryRequestC2SPacket
+import net.minecraft.network.packet.s2c.query.PingResultS2CPacket
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket
+import net.minecraft.server.ServerMetadata
+import net.minecraft.util.Util
+import java.net.InetSocketAddress
+import kotlin.jvm.optionals.getOrNull
+
+
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * This is a generic Minecraft server that is used to check if a proxy is working. The server also
+ * responds to query requests with the client's IP address.
+ */
+private const val PING_SERVER = "ping.liquidproxy.net"
+
+class ClientConnectionTicker(private val clientConnection: ClientConnection) : Listenable {
+    @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
+        clientConnection.tick()
+    }
+}
+
+/**
+ * Checks if a proxy is valid and can be used for Minecraft. This will use network resources to check the proxy,
+ * as well as update the ip information of the proxy.
+ */
+fun Proxy.check(success: (Proxy) -> Unit, failure: (Throwable) -> Unit) = runCatching {
+    logger.info("Request ping server via proxy... [$host:$port]")
+
+    val serverAddress = ServerAddress.parse(PING_SERVER)
+    val socketAddress: InetSocketAddress = AllowedAddressResolver.DEFAULT.resolve(serverAddress)
+        .map(Address::getInetSocketAddress)
+        .getOrNull()
+        ?: error("Failed to resolve $PING_SERVER")
+    logger.info("Resolved ping server [$PING_SERVER]: $socketAddress")
+
+    val clientConnection = ClientConnection(NetworkSide.CLIENTBOUND)
+    connect(socketAddress, false, clientConnection)
+
+    val ticker = ClientConnectionTicker(clientConnection)
+
+    val clientQueryPacketListener = object : ClientQueryPacketListener {
+
+        private var serverMetadata: ServerMetadata? = null
+        private var startTime = 0L
+
+        override fun onResponse(packet: QueryResponseS2CPacket) {
+            if (serverMetadata != null) {
+                failure(IllegalStateException("Received multiple responses from server"))
+                return
+            }
+
+            val metadata = packet.metadata()
+            serverMetadata = metadata
+            startTime = Util.getMeasuringTimeMs()
+            clientConnection.send(QueryPingC2SPacket(startTime))
+            logger.info("Proxy Metadata [$host:$port]: ${metadata.description.convertToString()}")
+        }
+
+        override fun onPingResult(packet: PingResultS2CPacket) {
+            val serverMetadata = this.serverMetadata ?: error("Received ping result without metadata")
+            val ping = Util.getMeasuringTimeMs() - startTime
+            logger.info("Proxy Ping [$host:$port]: $ping ms")
+
+            runCatching {
+                val ipInfo = IpInfoApi.someoneElse(serverMetadata.description.convertToString())
+                this@check.ipInfo = ipInfo
+                logger.info("Proxy Info [$host:$port]: ${ipInfo.ip} [${ipInfo.country}, ${ipInfo.org}]")
+            }.onFailure { throwable ->
+                logger.error("Failed to update IP info for proxy [$host:$port]", throwable)
+            }
+
+            success(this@check)
+        }
+
+        override fun onDisconnected(info: DisconnectionInfo) {
+            EventManager.unregisterEventHandler(ticker)
+
+            if (this.serverMetadata == null) {
+                failure(IllegalStateException("Disconnected before receiving metadata"))
+            }
+        }
+
+        override fun isConnectionOpen() = clientConnection.isOpen
+    }
+
+    clientConnection.connect(serverAddress.address, serverAddress.port, clientQueryPacketListener)
+    clientConnection.send(QueryRequestC2SPacket.INSTANCE)
+    logger.info("Sent query request via proxy [$host:$port]")
+}.onFailure { throwable -> failure(throwable) }
+
+private fun Proxy.connect(
+    address: InetSocketAddress,
+    useEpoll: Boolean,
+    connection: ClientConnection
+): ChannelFuture {
+    val clazz: Class<out SocketChannel?>
+    val eventLoopGroup: EventLoopGroup
+    if (Epoll.isAvailable() && useEpoll) {
+        clazz = EpollSocketChannel::class.java
+        eventLoopGroup = ClientConnection.EPOLL_CLIENT_IO_GROUP.get() as EventLoopGroup
+    } else {
+        clazz = NioSocketChannel::class.java
+        eventLoopGroup = ClientConnection.CLIENT_IO_GROUP.get() as EventLoopGroup
+    }
+
+    return Bootstrap().group(eventLoopGroup).handler(object : ChannelInitializer<Channel?>() {
+        override fun initChannel(channel: Channel?) {
+            val channel = channel!!
+
+            try {
+                channel.config().setOption(ChannelOption.TCP_NODELAY, true)
+            } catch (_: ChannelException) {
+            }
+
+            val channelPipeline = channel.pipeline().addLast("timeout", ReadTimeoutHandler(30))
+            // Assign proxy before [ClientConnection.addHandlers] to avoid overriding the proxy
+            channelPipeline.addFirst("proxy", handler())
+            ClientConnection.addHandlers(channelPipeline, NetworkSide.CLIENTBOUND, false, null)
+            connection.addFlowControlHandler(channelPipeline)
+        }
+    }).channel(clazz).connect(address.address, address.port)
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ProxyFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ProxyFunctions.kt
@@ -23,7 +23,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
-import net.ccbluex.liquidbounce.features.misc.ProxyManager
+import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager
 import net.ccbluex.liquidbounce.integration.interop.protocol.protocolGson
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.netty.http.model.RequestObject

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/SessionFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/SessionFunctions.kt
@@ -19,6 +19,6 @@ fun getSessionInfo(requestObject: RequestObject): FullHttpResponse {
 // GET /api/v1/client/location
 @Suppress("UNUSED_PARAMETER")
 fun getLocationInfo(requestObject: RequestObject): FullHttpResponse {
-    val locationInfo = IpInfoApi.localIpInfo ?: return httpForbidden("Location is not known (yet)")
+    val locationInfo = IpInfoApi.current ?: return httpForbidden("Location is not known")
     return httpOk(protocolGson.toJsonTree(locationInfo))
 }


### PR DESCRIPTION
To improve accuracy when checking proxy health, we now query a Minecraft server instead. This ensures that the proxy supports Minecraft communication. There are many providers and proxies that only support HTTP/HTTPS communication, so this is the best way to check. This also has the side effect of giving us accurate ping information, which may be useful to implement in the GUI in the future.

![image](https://github.com/user-attachments/assets/6defa8b5-cc86-418d-8b91-51ae93780657)

Logging:
```
(LiquidBounce) Request ping server via proxy... [smart.eu-fra.liquidproxy.net:1080]
(LiquidBounce) Resolved ping server [ping.liquidproxy.net]: ping.liquidproxy.net/178.63.18.138:25565
(LiquidBounce) Sent query request via proxy [smart.eu-fra.liquidproxy.net:1080]
(LiquidBounce) Proxy Metadata [smart.eu-fra.liquidproxy.net:1080]: 45.88.109.232
(LiquidBounce) Proxy Ping [smart.eu-fra.liquidproxy.net:1080]: 16 ms
(LiquidBounce) Proxy Info [smart.eu-fra.liquidproxy.net:1080]: 45.88.109.232 [DE, AS44486 Oliver Horscht is trading as "SYNLINQ"]
(LiquidBounce) Checked proxy [smart.eu-fra.liquidproxy.net:1080]
(LiquidBounce) Successfully saved config 'proxy'.
```