### PR TITLE
feat: improved clarity of authenication forwarding in proxy manager

### DIFF
--- a/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
+++ b/src-theme/src/routes/menu/proxymanager/AddProxyModal.svelte
@@ -65,6 +65,6 @@
         <IconTextInput title="Username" icon="user" bind:value={username}/>
         <IconTextInput title="Password" icon="lock" type="password" bind:value={password}/>
     {/if}
-    <SwitchSetting title="Forward Authentication" bind:value={forwardAuthentication}/>
+    <SwitchSetting title="Forward Microsoft Authentication" bind:value={forwardAuthentication}/>
     <ButtonSetting title="Add Proxy" {disabled} on:click={addProxy} listenForEnter={true} {loading}/>
 </Modal>

--- a/src-theme/src/routes/menu/proxymanager/EditProxyModal.svelte
+++ b/src-theme/src/routes/menu/proxymanager/EditProxyModal.svelte
@@ -65,6 +65,6 @@
         <IconTextInput title="Username" icon="user" bind:value={username}/>
         <IconTextInput title="Password" icon="lock" type="password" bind:value={password}/>
     {/if}
-    <SwitchSetting title="Forward Authentication" bind:value={forwardAuthentication}/>
+    <SwitchSetting title="Forward Microsoft Authentication" bind:value={forwardAuthentication}/>
     <ButtonSetting title="Edit Proxy" {disabled} on:click={editProxy} listenForEnter={true} {loading}/>
 </Modal>


### PR DESCRIPTION
This pull request renames the "Forward Authentication" setting of the proxy manager addition and editing modals to "Forward Microsoft Authentication" to make the distinction between proxy authentication and game server authentication clearer.