### PR TITLE
feat: Added priority to inventory actions

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -25,21 +25,22 @@ import net.ccbluex.liquidbounce.config.Value
 import net.ccbluex.liquidbounce.event.Event
 import net.ccbluex.liquidbounce.features.chat.packet.User
 import net.ccbluex.liquidbounce.features.misc.proxy.Proxy
+import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
+import net.ccbluex.liquidbounce.integration.interop.protocol.event.WebSocketEvent
+import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.PlayerData
+import net.ccbluex.liquidbounce.integration.theme.component.Component
 import net.ccbluex.liquidbounce.utils.client.Nameable
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
 import net.ccbluex.liquidbounce.utils.inventory.InventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.InventoryActionChain
 import net.ccbluex.liquidbounce.utils.inventory.InventoryConstraints
-import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
-import net.ccbluex.liquidbounce.integration.interop.protocol.event.WebSocketEvent
-import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.PlayerData
-import net.ccbluex.liquidbounce.integration.theme.component.Component
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.client.network.ServerInfo
 import net.minecraft.world.GameMode
 
 @Nameable("clickGuiScaleChange")
 @WebSocketEvent
-class ClickGuiScaleChangeEvent(val value: Float): Event()
+class ClickGuiScaleChangeEvent(val value: Float) : Event()
 
 @Nameable("spaceSeperatedNamesChange")
 @WebSocketEvent
@@ -80,7 +81,7 @@ class TargetChangeEvent(val target: PlayerData?) : Event()
 
 @Nameable("blockCountChange")
 @WebSocketEvent
-class BlockCountChangeEvent(val count: Int?): Event()
+class BlockCountChangeEvent(val count: Int?) : Event()
 
 @Nameable("clientChatStateChange")
 @WebSocketEvent
@@ -88,14 +89,19 @@ class ClientChatStateChange(val state: State) : Event() {
     enum class State {
         @SerializedName("connecting")
         CONNECTING,
+
         @SerializedName("connected")
         CONNECTED,
+
         @SerializedName("logon")
         LOGGING_IN,
+
         @SerializedName("loggedIn")
         LOGGED_IN,
+
         @SerializedName("disconnected")
         DISCONNECTED,
+
         @SerializedName("authenticationFailed")
         AUTHENTICATION_FAILED,
     }
@@ -107,6 +113,7 @@ class ClientChatMessageEvent(val user: User, val message: String, val chatGroup:
     enum class ChatGroup {
         @SerializedName("public")
         PUBLIC_CHAT,
+
         @SerializedName("private")
         PRIVATE_CHAT
     }
@@ -154,6 +161,7 @@ class VirtualScreenEvent(val screenName: String, val action: Action) : Event() {
     enum class Action {
         @SerializedName("open")
         OPEN,
+
         @SerializedName("close")
         CLOSE
     }
@@ -189,13 +197,29 @@ class ScheduleInventoryActionEvent(
     val schedule: MutableList<InventoryActionChain> = mutableListOf()
 ) : Event() {
 
-    fun schedule(constrains: InventoryConstraints, action: InventoryAction) =
-        schedule.add(InventoryActionChain(constrains, arrayOf(action)))
-    fun schedule(constrains: InventoryConstraints, vararg actions: InventoryAction) =
-        this.schedule.add(InventoryActionChain(constrains, actions))
-    fun schedule(constrains: InventoryConstraints, actions: List<InventoryAction>) =
-        this.schedule.add(InventoryActionChain(constrains, actions.toTypedArray()))
+    fun schedule(
+        constrains: InventoryConstraints,
+        action: InventoryAction,
+        priority: Priority = Priority.NORMAL
+    ) {
+        schedule.add(InventoryActionChain(constrains, arrayOf(action), priority))
+    }
 
+    fun schedule(
+        constrains: InventoryConstraints,
+        vararg actions: InventoryAction,
+        priority: Priority = Priority.NORMAL
+    ) {
+        this.schedule.add(InventoryActionChain(constrains, actions, priority))
+    }
+
+    fun schedule(
+        constrains: InventoryConstraints,
+        actions: List<InventoryAction>,
+        priority: Priority = Priority.NORMAL
+    ) {
+        this.schedule.add(InventoryActionChain(constrains, actions.toTypedArray(), priority))
+    }
 }
 
 @Nameable("browserUrlChange")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemSl
 import net.ccbluex.liquidbounce.utils.inventory.*
 import net.ccbluex.liquidbounce.utils.item.ArmorPiece
 import net.ccbluex.liquidbounce.utils.item.isNothing
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.item.Items
 
 /**
@@ -52,7 +53,11 @@ object ModuleAutoArmor : Module("AutoArmor", Category.COMBAT) {
         }
 
         for (armorPiece in armorToEquip) {
-            event.schedule(inventoryConstraints, equipArmorPiece(armorPiece) ?: continue)
+            event.schedule(
+                inventoryConstraints,
+                equipArmorPiece(armorPiece) ?: continue,
+                Priority.IMPORTANT_FOR_PLAYER_LIFE
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Refill.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Refill.kt
@@ -31,6 +31,7 @@ import net.ccbluex.liquidbounce.utils.inventory.ClickInventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.INVENTORY_SLOTS
 import net.ccbluex.liquidbounce.utils.inventory.PlayerInventoryConstraints
 import net.ccbluex.liquidbounce.utils.item.isNothing
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 
 object Refill : ToggleableConfigurable(ModuleAutoBuff, "Refill", true) {
 
@@ -44,9 +45,9 @@ object Refill : ToggleableConfigurable(ModuleAutoBuff, "Refill", true) {
 
         // Find valid items in the inventory
         val validItems = INVENTORY_SLOTS.filter {
-            it.itemStack.let {
-                itemStack -> features.any {
-                    f -> f.isValidItem(itemStack, false)
+            it.itemStack.let { itemStack ->
+                features.any { f ->
+                    f.isValidItem(itemStack, false)
                 }
             }
         }
@@ -58,7 +59,10 @@ object Refill : ToggleableConfigurable(ModuleAutoBuff, "Refill", true) {
 
         // Sort the items by the order of the features
         for (slot in validItems) {
-            event.schedule(inventoryConstraints, ClickInventoryAction.performQuickMove(slot = slot))
+            event.schedule(
+                inventoryConstraints, ClickInventoryAction.performQuickMove(slot = slot),
+                Priority.IMPORTANT_FOR_USAGE_1
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
@@ -86,7 +86,13 @@ object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
                     ClickInventoryAction.performPickup(screen, slot),
                     ClickInventoryAction.performPickup(screen, emptySlot),
                 )
-            })
+            },
+                /**
+                 * we prioritize item based on how important it is
+                 * for example we should prioritize armor over apples
+                 */
+                ItemCategorization(listOf()).getItemFacets(slot).maxOf { it.category.type.allocationPriority }
+            )
         }
 
         // Check if stealing the chest was completed
@@ -133,8 +139,10 @@ object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
     private fun isScreenTitleChest(screen: GenericContainerScreen): Boolean {
         val titleString = screen.title.string
 
-        return sequenceOf("container.chest", "container.chestDouble", "container.enderchest", "container.shulkerBox",
-            "container.barrel")
+        return sequenceOf(
+            "container.chest", "container.chestDouble", "container.enderchest", "container.shulkerBox",
+            "container.barrel"
+        )
             .map { Text.translatable(it) }
             .any { it.string == titleString }
     }
@@ -160,8 +168,16 @@ object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
                 continue
             }
 
-            event.schedule(inventoryConstrains,
-                ClickInventoryAction.performSwap(screen, hotbarSwap.from, hotbarSwap.to))
+            event.schedule(
+                inventoryConstrains,
+                ClickInventoryAction.performSwap(screen, hotbarSwap.from, hotbarSwap.to),
+                /**
+                 * we prioritize item based on how important it is
+                 * for example we should prioritize armor over apples
+                 */
+                ItemCategorization(listOf()).getItemFacets(hotbarSwap.from)
+                    .maxOf { it.category.type.allocationPriority }
+            )
 
             // todo: hook to schedule and check if swap was successful
             cleanupPlan.remapSlots(
@@ -210,7 +226,7 @@ object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
             }
         }),
         INDEX("Index", { list -> list.sortedBy { it.slotInContainer } }),
-        RANDOM("Random", List<ContainerItemSlot>::shuffled ),
+        RANDOM("Random", List<ContainerItemSlot>::shuffled),
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ItemCategorization.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ItemCategorization.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor.ArmorEv
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.*
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ScaffoldBlockItemSelection
 import net.ccbluex.liquidbounce.utils.item.*
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.sorting.compareValueByCondition
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.fluid.LavaFluid
@@ -49,7 +50,7 @@ enum class ItemType(
      * ## Used values
      * - Specialization (see above): 10 per level
      */
-    val allocationPriority: Int = 0,
+    val allocationPriority: Priority = Priority.NORMAL,
     /**
      * The user maybe wants to filter the items by a specific type. But the we don't need all versions of the item.
      * To stop the invcleaner from keeping items of every type, we can specify what function a specific item serves.
@@ -57,20 +58,20 @@ enum class ItemType(
      */
     val providedFunction: ItemFunction? = null
 ) {
-    ARMOR(true, allocationPriority = 20),
-    SWORD(true, allocationPriority = 10, providedFunction = ItemFunction.WEAPON_LIKE),
-    WEAPON(true, allocationPriority = -1, providedFunction = ItemFunction.WEAPON_LIKE),
+    ARMOR(true, allocationPriority = Priority.IMPORTANT_FOR_PLAYER_LIFE),
+    SWORD(true, allocationPriority = Priority.IMPORTANT_FOR_USAGE_2, providedFunction = ItemFunction.WEAPON_LIKE),
+    WEAPON(true, allocationPriority = Priority.NOT_IMPORTANT, providedFunction = ItemFunction.WEAPON_LIKE),
     BOW(true),
     CROSSBOW(true),
     ARROW(true),
-    TOOL(true, allocationPriority = 10),
+    TOOL(true, allocationPriority = Priority.IMPORTANT_FOR_USAGE_1),
     ROD(true),
     THROWABLE(false),
     SHIELD(true),
     FOOD(false),
     BUCKET(false),
-    PEARL(false),
-    GAPPLE(false),
+    PEARL(false, allocationPriority = Priority.IMPORTANT_FOR_USAGE_1),
+    GAPPLE(false, allocationPriority = Priority.IMPORTANT_FOR_USAGE_1),
     POTION(false),
     BLOCK(false),
     NONE(false),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.features.module.modules.player.offhand.ModuleOff
 import net.ccbluex.liquidbounce.utils.inventory.ClickInventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.PlayerInventoryConstraints
 import net.ccbluex.liquidbounce.utils.inventory.findNonEmptySlotsInInventory
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.screen.slot.SlotActionType
 
 /**
@@ -92,12 +93,12 @@ object ModuleInventoryCleaner : Module("InventoryCleaner", Category.PLAYER) {
             )
 
             val constraintProvider = AmountConstraintProvider(
-                maxItemsPerCategory = hashMapOf(
+                desiredItemsPerCategory = hashMapOf(
                     Pair(ItemSortChoice.BLOCK.category!!, maxBlocks),
                     Pair(ItemSortChoice.THROWABLES.category!!, maxThrowables),
                     Pair(ItemCategory(ItemType.ARROW, 0), maxArrows),
                 ),
-                maxValuePerFunction = hashMapOf(
+                desiredValuePerFunction = hashMapOf(
                     Pair(ItemFunction.FOOD, maxFoods),
                     Pair(ItemFunction.WEAPON_LIKE, 1),
                 )
@@ -150,7 +151,11 @@ object ModuleInventoryCleaner : Module("InventoryCleaner", Category.PLAYER) {
         val itemsToThrowOut = findItemsToThrowOut(cleanupPlan, findNonEmptySlotsInInventory())
 
         for (slot in itemsToThrowOut) {
-            event.schedule(inventoryConstraints, ClickInventoryAction.performThrow(screen = null, slot))
+            event.schedule(
+                inventoryConstraints,
+                ClickInventoryAction.performThrow(screen = null, slot),
+                Priority.NOT_IMPORTANT
+            )
         }
     }
 
@@ -160,19 +165,19 @@ object ModuleInventoryCleaner : Module("InventoryCleaner", Category.PLAYER) {
     ) = itemsInInv.filter { it !in cleanupPlan.usefulItems }
 
     private class AmountConstraintProvider(
-        val maxItemsPerCategory: HashMap<ItemCategory, Int>,
-        val maxValuePerFunction: HashMap<ItemFunction, Int>,
+        val desiredItemsPerCategory: HashMap<ItemCategory, Int>,
+        val desiredValuePerFunction: HashMap<ItemFunction, Int>,
     ) {
         fun getConstraints(facet: ItemFacet): ArrayList<ItemConstraintInfo> {
             val constraints = ArrayList<ItemConstraintInfo>()
 
             if (facet.providedItemFunctions.isEmpty()) {
-                val defaultMin = if (facet.category.type.oneIsSufficient) 1 else Integer.MAX_VALUE
-                val minValue = this.maxItemsPerCategory[facet.category] ?: defaultMin
+                val defaultDesiredAmount = if (facet.category.type.oneIsSufficient) 1 else Integer.MAX_VALUE
+                val desiredAmount = this.desiredItemsPerCategory[facet.category] ?: defaultDesiredAmount
 
                 val info = ItemConstraintInfo(
                     group = ItemCategoryConstraintGroup(
-                        minValue..Integer.MAX_VALUE,
+                        desiredAmount..Integer.MAX_VALUE,
                         10,
                         facet.category
                     ),
@@ -184,7 +189,7 @@ object ModuleInventoryCleaner : Module("InventoryCleaner", Category.PLAYER) {
                 for ((function, amountAdded) in facet.providedItemFunctions) {
                     val info = ItemConstraintInfo(
                         group = ItemFunctionCategoryConstraintGroup(
-                            maxValuePerFunction.getOrDefault(function, 1)..Integer.MAX_VALUE,
+                            desiredValuePerFunction.getOrDefault(function, 1)..Integer.MAX_VALUE,
                             10,
                             function
                         ),


### PR DESCRIPTION
Now items have their own priorities in InventoryManager (for example armor will be equipped before sorting throwables | blocks | etc.)

new behavior

https://github.com/user-attachments/assets/e5a96582-02f3-49ef-aba9-5abe6a3aaa84

old behavior


https://github.com/user-attachments/assets/3b8d8eff-ef2e-4b77-ba79-a611f1326a2b

