### PR TITLE
feat(CrystalAura): id predict and set dead

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
@@ -1,0 +1,58 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015-2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
+
+import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
+import java.util.concurrent.ConcurrentLinkedDeque
+
+/**
+ * Counts how many crystals the crystal aura places.
+ * Cps stands for crystals per second.
+ */
+object CrystalAuraSpeedDebugger : CrystalPostAttackTracker() {
+
+    private var cps = ConcurrentLinkedDeque<Long>()
+
+    @Suppress("unused")
+    val repeatable1 = repeatable {
+        val currentTime = System.currentTimeMillis()
+        val cpsTime = currentTime - 1000L
+        while (cps.isNotEmpty()) {
+            if (cps.first >= cpsTime) {
+                break
+            }
+
+            cps.removeFirst()
+        }
+
+        ModuleDebug.debugParameter(ModuleCrystalAura, "CPS", cps.size)
+    }
+
+    override fun confirmed(id: Int) {
+        cps.add(System.currentTimeMillis())
+    }
+
+    override fun cleared() {
+        attackedIds.clear()
+    }
+
+    override fun handleEvents() = ModuleCrystalAura.handleEvents() && ModuleDebug.enabled
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentLinkedDeque
 
 /**
  * Counts how many crystals the crystal aura places.
- * Cps stands for crystals per second.
+ * "CPS" stands for crystals per second.
  */
 object CrystalAuraSpeedDebugger : CrystalPostAttackTracker() {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
@@ -1,0 +1,125 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015-2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
+
+import it.unimi.dsi.fastutil.ints.Int2LongLinkedOpenHashMap
+import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.events.PacketEvent
+import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.repeatable
+import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket
+import net.minecraft.network.packet.s2c.play.PlaySoundFromEntityS2CPacket
+import net.minecraft.sound.SoundEvents
+import java.util.*
+
+/**
+ * Can be implemented to handle actions after crystals got attacked.
+ */
+abstract class CrystalPostAttackTracker : Listenable {
+
+    protected val attackedIds: MutableMap<Int, Long> = Collections.synchronizedMap(Int2LongLinkedOpenHashMap())
+
+    val repeatable = repeatable {
+        val currentTime = System.currentTimeMillis()
+        val attackTime = currentTime - timeOutAfter() // 5 seconds
+        attackedIds.entries.iterator().apply {
+            while (hasNext()) {
+                val entry = next()
+                if (entry.value < attackTime) {
+                    remove()
+                    timedOut(entry.key)
+                }
+            }
+        }
+    }
+
+    @Suppress("unused")
+    val worldChangeHandler = handler<WorldChangeEvent> {
+        attackedIds.clear()
+        cleared()
+    }
+
+    @Suppress("unused")
+    val explodeListener = handler<PacketEvent> { event ->
+        when (val packet = event.packet) {
+            is PlaySoundFromEntityS2CPacket -> {
+                if (packet.sound != SoundEvents.ENTITY_GENERIC_EXPLODE) {
+                    return@handler
+                }
+
+                val id = packet.entityId
+                attackedIds.remove(id)?.let {
+                    confirmed(id)
+                }
+            }
+
+            is EntitiesDestroyS2CPacket -> {
+                packet.entityIds.forEach { id ->
+                    attackedIds.remove(id)?.let {
+                        confirmed(id)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onToggle() {
+        attackedIds.clear()
+        cleared()
+    }
+
+    /**
+     * Gets called when we are sure the crystal got destroyed.
+     *
+     * @param id The id of the attacked entity.
+     */
+    open fun confirmed(id: Int) {}
+
+    /**
+     * Gets called when the crystal was not confirmed in the time defined by [timeOutAfter] in ms.
+     *
+     * @param id The id of the attacked entity.
+     */
+    open fun timedOut(id: Int) {}
+
+    /**
+     * Gets called when the attacked id list gets cleared.
+     */
+    open fun cleared() {}
+
+    /**
+     * Show be called when the crystal aura attacks.
+     *
+     * @param id The id of the attacked entity.
+     */
+    open fun attacked(id: Int) {
+        if (!handleEvents()) {
+            return
+        }
+
+        attackedIds[id] = System.currentTimeMillis()
+    }
+
+    /**
+     * After how many ms attacks are not tracked anymore.
+     */
+    open fun timeOutAfter(): Long = 5000L // 5 seconds
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
@@ -38,7 +38,7 @@ abstract class CrystalPostAttackTracker : Listenable {
 
     val repeatable = repeatable {
         val currentTime = System.currentTimeMillis()
-        val attackTime = currentTime - timeOutAfter() // 5 seconds
+        val attackTime = currentTime - timeOutAfter()
         attackedIds.entries.iterator().apply {
             while (hasNext()) {
                 val entry = next()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalDestroyer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalDestroyer.kt
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
- *
- *
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
@@ -34,12 +32,13 @@ import kotlin.math.max
 
 object SubmoduleCrystalDestroyer : ToggleableConfigurable(ModuleCrystalAura, "Destroy", true) {
 
-    private val swing by boolean("Swing", true)
+    val swing by boolean("Swing", true)
     private val delay by int("Delay", 0, 0..1000, "ms")
-    private val range by float("Range", 4.5F, 1.0F..5.0F)
-    private val wallsRange by float("WallsRange", 4.5F, 1.0F..5.0F)
+    val range by float("Range", 4.5F, 1.0F..5.0F)
+    val wallsRange by float("WallsRange", 4.5F, 1.0F..5.0F)
 
-    private val chronometer = Chronometer()
+    var postAttackHandlers = arrayOf(CrystalAuraSpeedDebugger, SubmoduleSetDead.CrystalTracker)
+    val chronometer = Chronometer()
     private var currentTarget: EndCrystalEntity? = null
 
     fun tick() {
@@ -78,6 +77,7 @@ object SubmoduleCrystalDestroyer : ToggleableConfigurable(ModuleCrystalAura, "De
             val target1 = currentTarget ?: return@rotate
 
             target1.attack(swing)
+            postAttackHandlers.forEach { it.attacked(target1.id) }
             chronometer.reset()
         })
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalPlacer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalPlacer.kt
@@ -164,7 +164,7 @@ object SubmoduleCrystalPlacer : ToggleableConfigurable(ModuleCrystalAura, "Place
         val wallsRange = wallsRange.toDouble()
 
         val target = ModuleCrystalAura.currentTarget ?: return
-        val maxX = target.boundingBox.maxX
+        val maxY = target.boundingBox.maxY
 
         val positions = mutableListOf<ObjectObjectImmutablePair<BlockPos, Boolean>>()
 
@@ -177,7 +177,7 @@ object SubmoduleCrystalPlacer : ToggleableConfigurable(ModuleCrystalAura, "Place
             if ((state.block == Blocks.OBSIDIAN || state.block == Blocks.BEDROCK) &&
                 pos.up().getState()!!.isAir &&
                 canSeeUpperBlockSide &&
-                pos.x.toDouble() + 1.0 < maxX
+                pos.y.toDouble() + 1.0 < maxY
             ) {
                 val blocked = pos.up().isBlockedByEntitiesReturnCrystal()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalPlacer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleCrystalPlacer.kt
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
- *
- *
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
@@ -140,6 +138,8 @@ object SubmoduleCrystalPlacer : ToggleableConfigurable(ModuleCrystalAura, "Place
                 getSlot() ?: return@rotate,
                 swingMode
             )
+
+            SubmoduleIdPredict.run(targetPos)
 
             chronometer.reset()
         })

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
@@ -85,13 +85,12 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 return
             }
 
-            val rotation = oldRotation!!.normalize()
             network.sendPacket(PlayerMoveC2SPacket.Full(
                 player.x,
                 player.y,
                 player.z,
-                rotation.yaw,
-                rotation.pitch,
+                oldRotation!!.yaw,
+                oldRotation!!.pitch,
                 player.isOnGround
             ))
         }
@@ -125,7 +124,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 wallsRange = SubmoduleCrystalDestroyer.wallsRange.toDouble(),
             ) ?: return
 
-        Rotate.sendRotation(rotation)
+        Rotate.sendRotation(rotation.normalize())
 
         val swing = SubmoduleCrystalDestroyer.swing
         if (swing && !swingAlways) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
@@ -1,0 +1,166 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015-2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
+
+import net.ccbluex.liquidbounce.config.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.PacketEvent
+import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
+import net.ccbluex.liquidbounce.utils.aiming.Rotation
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.raytraceBox
+import net.minecraft.entity.decoration.EndCrystalEntity
+import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
+import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket
+import net.minecraft.network.packet.s2c.play.ExperienceOrbSpawnS2CPacket
+import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket
+import net.minecraft.util.Hand
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Box
+import kotlin.math.max
+
+/**
+ * Allows the crystal aura to send a break packet right when a crystal is placed by predicting the
+ * expected entity id.
+ */
+object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict", true) {
+
+    /**
+     * Sends a packet for all included offsets.
+     */
+    private val offsetRange by intRange("OffsetRange", 1..2, 1..100)
+
+    /**
+     * Swings before every attack. Otherwise, it will only swing once.
+     *
+     * Only works when [SubmoduleCrystalDestroyer.swing] is enabled.
+     */
+    private val swingAlways by boolean("SwingAlways", false)
+
+    /**
+     * Sends an additional rotation packet.
+     */
+    private object Rotate : ToggleableConfigurable(this, "Rotate", true) {
+
+        val back by boolean("Back", false)
+
+        var yaw = 0f
+        var pitch = 0f
+
+        fun rotate(rotation: Rotation) {
+            if (!enabled) {
+                return
+            }
+
+            val serverRot = RotationManager.serverRotation
+            yaw = serverRot.yaw
+            pitch = serverRot.pitch
+            network.sendPacket(PlayerMoveC2SPacket.LookAndOnGround(rotation.yaw, rotation.pitch, player.isOnGround))
+        }
+
+        fun rotateBack() {
+            if (!enabled || !back) {
+                return
+            }
+
+            network.sendPacket(PlayerMoveC2SPacket.LookAndOnGround(yaw, pitch, player.isOnGround))
+        }
+
+    }
+
+    init {
+        tree(Rotate)
+    }
+
+    private var highestId = 0
+        set(value) {
+            field = value
+            ModuleDebug.debugParameter(ModuleCrystalAura, "Highest ID", highestId)
+        }
+
+    override fun enable() {
+        reset()
+    }
+
+    fun run(placePos: BlockPos) {
+        if (!enabled) {
+            return
+        }
+
+        val (rotation, _) =
+            raytraceBox(
+                player.eyePos,
+                Box(placePos).expand(0.5, 0.0, 0.5).withMaxY(placePos.y + 2.0),
+                range = SubmoduleCrystalDestroyer.range.toDouble(),
+                wallsRange = SubmoduleCrystalDestroyer.wallsRange.toDouble(),
+            ) ?: return
+
+        Rotate.rotate(rotation)
+
+        val swing = SubmoduleCrystalDestroyer.swing
+        if (swing && !swingAlways) {
+            player.swingHand(Hand.MAIN_HAND)
+        }
+
+        offsetRange.forEach { idOffset ->
+            val id = highestId + idOffset
+
+            // don't attack other entities in case the highest ID is wrong
+            val entity = world.getEntityById(id)
+            if (entity != null && entity !is EndCrystalEntity) {
+                return@forEach
+            }
+
+            if (swing && swingAlways) {
+                player.swingHand(Hand.MAIN_HAND)
+            }
+
+            val packet = PlayerInteractEntityC2SPacket(id, player.isSneaking, PlayerInteractEntityC2SPacket.ATTACK)
+            network.sendPacket(packet)
+            SubmoduleCrystalDestroyer.postAttackHandlers.forEach { it.attacked(id) }
+        }
+
+        SubmoduleCrystalDestroyer.chronometer.reset()
+        Rotate.rotateBack()
+    }
+
+    private fun reset() {
+        highestId = 0
+        world.entities.forEach {
+            highestId = max(it.id, highestId)
+        }
+    }
+
+    @Suppress("unused")
+    val entitySpawnHandler = handler<PacketEvent> {
+        when(val packet = it.packet) {
+            is ExperienceOrbSpawnS2CPacket -> highestId = max(packet.entityId, highestId)
+            is EntitySpawnS2CPacket -> highestId = max(packet.entityId, highestId)
+            is GameJoinS2CPacket -> highestId = max(packet.playerEntityId, highestId)
+        }
+    }
+
+    @Suppress("unused")
+    val worldChangeHandler = handler<WorldChangeEvent> {
+        reset()
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
@@ -65,7 +65,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
         var yaw = 0f
         var pitch = 0f
 
-        fun rotate(rotation: Rotation) {
+        fun sendRotation(rotation: Rotation) {
             if (!enabled) {
                 return
             }
@@ -113,7 +113,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 wallsRange = SubmoduleCrystalDestroyer.wallsRange.toDouble(),
             ) ?: return
 
-        Rotate.rotate(rotation)
+        Rotate.sendRotation(rotation)
 
         val swing = SubmoduleCrystalDestroyer.swing
         if (swing && !swingAlways) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
@@ -62,26 +62,38 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
 
         val back by boolean("Back", false)
 
-        var yaw = 0f
-        var pitch = 0f
+        var oldRotation: Rotation? = null
 
         fun sendRotation(rotation: Rotation) {
             if (!enabled) {
                 return
             }
 
-            val serverRot = RotationManager.serverRotation
-            yaw = serverRot.yaw
-            pitch = serverRot.pitch
-            network.sendPacket(PlayerMoveC2SPacket.LookAndOnGround(rotation.yaw, rotation.pitch, player.isOnGround))
+            oldRotation = RotationManager.serverRotation
+            network.sendPacket(PlayerMoveC2SPacket.Full(
+                player.x,
+                player.y,
+                player.z,
+                rotation.yaw,
+                rotation.pitch,
+                player.isOnGround
+            ))
         }
 
         fun rotateBack() {
-            if (!enabled || !back) {
+            if (!enabled || !back || oldRotation == null) {
                 return
             }
 
-            network.sendPacket(PlayerMoveC2SPacket.LookAndOnGround(yaw, pitch, player.isOnGround))
+            val rotation = oldRotation!!.normalize()
+            network.sendPacket(PlayerMoveC2SPacket.Full(
+                player.x,
+                player.y,
+                player.z,
+                rotation.yaw,
+                rotation.pitch,
+                player.isOnGround
+            ))
         }
 
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleSetDead.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleSetDead.kt
@@ -1,0 +1,73 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015-2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
+import net.ccbluex.liquidbounce.config.ToggleableConfigurable
+import net.minecraft.entity.Entity
+import net.minecraft.entity.decoration.EndCrystalEntity
+import java.util.*
+
+/**
+ * Removes hit crystals instantly from the world instead of waiting for the actual remove packet
+ * what might allow faster placement.
+ */
+object SubmoduleSetDead : ToggleableConfigurable(ModuleCrystalAura, "SetDead", true) {
+
+    /**
+     * If the crystal was removed but no entity remove packet was sent after the confirmation time, the
+     * crystal is added back to the world.
+     */
+    val confirmTime by int("ConfirmTime", 150, 10..2000, "ms")
+
+    object CrystalTracker : CrystalPostAttackTracker() {
+
+        val entities: MutableMap<Int, EndCrystalEntity> = Collections.synchronizedMap(Int2ObjectOpenHashMap())
+
+        override fun attacked(id: Int) {
+            if (!handleEvents()) {
+                return
+            }
+
+            val entity = world.getEntityById(id)
+            if (entity is EndCrystalEntity) {
+                super.attacked(id)
+                world.removeEntity(id, Entity.RemovalReason.DISCARDED)
+            }
+        }
+
+        override fun confirmed(id: Int) {
+            entities.remove(id)
+        }
+
+        override fun timedOut(id: Int) {
+            world.addEntity(entities.remove(id) ?: return)
+        }
+
+        override fun cleared() {
+            entities.clear()
+        }
+
+        override fun timeOutAfter() = confirmTime.toLong()
+
+        override fun parent() = SubmoduleSetDead
+
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/TargetTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/TargetTracker.kt
@@ -39,7 +39,7 @@ import net.minecraft.entity.player.PlayerEntity
  */
 open class TargetTracker(
     defaultPriority: PriorityEnum = PriorityEnum.HEALTH,
-    rangeOption: Boolean = false
+    maxRange: Float? = null
 ) : Configurable("Target") {
 
     var range = Double.MAX_VALUE
@@ -52,8 +52,8 @@ open class TargetTracker(
     private val priority by enumChoice("Priority", defaultPriority)
 
     init {
-        if (rangeOption) {
-            float("Range", 4.5f, 1f..12f).onChanged { range = it.toDouble() }
+        if (maxRange != null) {
+            float("Range", 4.5f, 1f..maxRange).onChanged { range = it.toDouble() }
             range = 4.5
         }
     }

--- a/src/main/resources/liquidbounce.accesswidener
+++ b/src/main/resources/liquidbounce.accesswidener
@@ -158,6 +158,9 @@ mutable field net/minecraft/network/packet/s2c/common/CommonPingS2CPacket parame
 accessible field net/minecraft/entity/LimbAnimator pos F
 
 accessible field net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket entityId I
+accessible method net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket <init> (IZLnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler;)V
+accessible class net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler
+accessible field net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket ATTACK Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler;
 
 accessible field net/minecraft/network/packet/s2c/play/ChunkDeltaUpdateS2CPacket sectionPos Lnet/minecraft/util/math/ChunkSectionPos;
 


### PR DESCRIPTION
- Adds id predict
- Adds set dead
- Adds an "AutoCrystal" alias 
- Adds the crystal speed to the debug module display
- Fixes wrong placement criteria (used X instead of Y)

Set dead will let the crystal aura run at stable 10 crystals/second and id predict at 20 crystals/second.