### PR TITLE
fix: ESP glow true-sight on entities

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLivingEntityRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLivingEntityRenderer.java
@@ -24,6 +24,7 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import it.unimi.dsi.fastutil.floats.FloatFloatPair;
 import net.ccbluex.liquidbounce.features.cosmetic.CosmeticCategory;
 import net.ccbluex.liquidbounce.features.cosmetic.CosmeticService;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleESP;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleRotations;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleTrueSight;
 import net.minecraft.client.MinecraftClient;
@@ -77,11 +78,13 @@ public class MixinLivingEntityRenderer<T extends LivingEntity> {
 
     @ModifyExpressionValue(method = "render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isInvisibleTo(Lnet/minecraft/entity/player/PlayerEntity;)Z"))
     private boolean injectTrueSight(boolean original) {
-        if (!ModuleTrueSight.INSTANCE.getEnabled() || !ModuleTrueSight.INSTANCE.getEntities()) {
-            return original;
+        // Check if TrueSight is enabled and entities are enabled or ESP is enabled and in glow mode
+        if (ModuleTrueSight.INSTANCE.getEnabled() && ModuleTrueSight.INSTANCE.getEntities() ||
+                ModuleESP.INSTANCE.getEnabled() && ModuleESP.GlowMode.INSTANCE.isActive()) {
+            return false;
         }
 
-        return false;
+        return original;
     }
 
     @ModifyReturnValue(method = "shouldFlipUpsideDown", at = @At("RETURN"))


### PR DESCRIPTION
Invisible entities were not previously rendered by Glow ESP - now they will, without True Sight being enabled.