### PR TITLE
feat: Add grid snapping to clickgui with visual overlay

### DIFF
--- a/src-theme/src/colors.scss
+++ b/src-theme/src/colors.scss
@@ -3,6 +3,7 @@ $accent-color: #4677ff;
 $clickgui-base-color: black;
 $clickgui-text-color: white;
 $clickgui-text-dimmed-color: rgba(211, 211, 211, 255);
+$clickgui-grid-color: rgba(128, 128, 128, 0.25);
 
 $tabgui-base-color: black;
 $tabgui-text-color: white;

--- a/src-theme/src/integration/events.ts
+++ b/src-theme/src/integration/events.ts
@@ -1,4 +1,8 @@
-import type {Component, PlayerData, Proxy, Server, TextComponent} from "./types";
+import type {Component, ConfigurableSetting, PlayerData, Proxy, Server, TextComponent} from "./types";
+
+export interface ClickGuiValueChangeEvent {
+    configurable: ConfigurableSetting;
+}
 
 export interface ToggleModuleEvent {
     moduleName: string;

--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -2,7 +2,7 @@
     import {onMount} from "svelte";
     import {getGameWindow, getModules, getModuleSettings} from "../../integration/rest";
     import {groupByCategory} from "../../integration/util";
-    import type {ConfigurableSetting, GroupedModules, Module} from "../../integration/types";
+    import type {ConfigurableSetting, GroupedModules, Module, TogglableSetting} from "../../integration/types";
     import Panel from "./Panel.svelte";
     import Search from "./Search.svelte";
     import Description from "./Description.svelte";
@@ -13,7 +13,7 @@
         ClickGuiValueChangeEvent,
         ScaleFactorChangeEvent
     } from "../../integration/events";
-    import {scaleFactor, showGrid, snappingEnabled} from "./clickgui_store";
+    import {gridSize, scaleFactor, showGrid, snappingEnabled} from "./clickgui_store";
 
     let categories: GroupedModules = {};
     let modules: Module[] = [];
@@ -25,7 +25,11 @@
 
     function applyValues(configurable: ConfigurableSetting) {
         clickGuiScaleFactor = configurable.value.find(v => v.name === "Scale")?.value as number ?? 1;
-        $snappingEnabled = configurable.value.find(v => v.name === "Snapping")?.value as boolean ?? true;
+
+        const snappingValue = configurable.value.find(v => v.name === "Snapping") as TogglableSetting;
+
+        $snappingEnabled = snappingValue?.value.find(v => v.name === "Enabled")?.value as boolean ?? true;
+        $gridSize = snappingValue?.value.find(v => v.name === "GridSize")?.value as number ?? 10;
     }
 
     onMount(async () => {
@@ -49,7 +53,8 @@
 </script>
 
 <div class="clickgui" class:grid={$showGrid} transition:fade|global={{duration: 200}}
-     style="transform: scale({$scaleFactor * 50}%); width: {2 / $scaleFactor * 100}vw; height: {2 / $scaleFactor * 100}vh;">
+     style="transform: scale({$scaleFactor * 50}%); width: {2 / $scaleFactor * 100}vw; height: {2 / $scaleFactor * 100}vh;
+     background-size: {$gridSize}px {$gridSize}px;">
     <Description/>
     <Search modules={structuredClone(modules)}/>
 
@@ -75,7 +80,6 @@
     &.grid {
       background-image: linear-gradient(to right, $clickgui-grid-color 1px, transparent 1px),
       linear-gradient(to bottom, $clickgui-grid-color 1px, transparent 1px);
-      background-size: $GRID_SIZE $GRID_SIZE;
     }
   }
 </style>

--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -9,7 +9,7 @@
     import {fade} from "svelte/transition";
     import {listen} from "../../integration/ws";
     import type {ClickGuiScaleChangeEvent, ScaleFactorChangeEvent} from "../../integration/events";
-    import {scaleFactor} from "./clickgui_store";
+    import {scaleFactor, showGrid} from "./clickgui_store";
 
     let categories: GroupedModules = {};
     let modules: Module[] = [];
@@ -39,7 +39,7 @@
     });
 </script>
 
-<div class="clickgui" transition:fade|global={{duration: 200}}
+<div class="clickgui" class:grid={$showGrid} transition:fade|global={{duration: 200}}
      style="transform: scale({$scaleFactor * 50}%); width: {2 / $scaleFactor * 100}vw; height: {2 / $scaleFactor * 100}vh;">
     <Description/>
     <Search modules={structuredClone(modules)}/>
@@ -52,6 +52,8 @@
 <style lang="scss">
   @import "../../colors.scss";
 
+  $GRID_SIZE: 10px;
+
   .clickgui {
     background-color: rgba($clickgui-base-color, 0.6);
     overflow: hidden;
@@ -60,5 +62,11 @@
     transform-origin: top left;
     left: 0;
     top: 0;
+
+    &.grid {
+      background-image: linear-gradient(to right, rgba(128, 128, 128, 0.25) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(128, 128, 128, 0.25) 1px, transparent 1px);
+      background-size: $GRID_SIZE $GRID_SIZE;
+    }
   }
 </style>

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -230,8 +230,8 @@
 
   :global(.moving-panel) {
     background-image: 
-      linear-gradient(to right, rgba(128, 128, 128, 0.1) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(128, 128, 128, 0.1) 1px, transparent 1px);
+      linear-gradient(to right, rgba(128, 128, 128, 0.25) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(128, 128, 128, 0.25) 1px, transparent 1px);
     background-size: $GRID_SIZE $GRID_SIZE;
   }
 

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -27,6 +27,8 @@
     const GRID_SIZE = 25;
     const panelConfig = loadPanelConfig();
 
+    let ignoreGrid = false;
+
     interface PanelConfig {
         top: number;
         left: number;
@@ -169,12 +171,25 @@
         }, 500);
     });
 
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === 'Shift') {
+            ignoreGrid = true;
+        }
+    }
+
+    function handleKeyup(e: KeyboardEvent) {
+        if (e.key === 'Shift') {
+            ignoreGrid = false;
+        }
+    }
+
     function snapToGrid(value: number): number {
+        if (ignoreGrid) return value;
         return Math.round(value / GRID_SIZE) * GRID_SIZE;
     }
 </script>
 
-<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove}/>
+<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove} on:keydown={handleKeydown} on:keyup={handleKeyup}/>
 
 <div
         class="panel"

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -24,7 +24,7 @@
     let prevY = 0;
     let offsetX = 0;
     let offsetY = 0;
-    const GRID_SIZE = 20;
+    const GRID_SIZE = 25;
     const panelConfig = loadPanelConfig();
 
     interface PanelConfig {
@@ -211,7 +211,7 @@
 <style lang="scss">
   @import "../../colors.scss";
 
-  $GRID_SIZE: 20px;
+  $GRID_SIZE: 25px;
 
   :global(.moving-panel) {
     background-image: 

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -6,7 +6,7 @@
     import type {ToggleModuleEvent} from "../../integration/events";
     import {fly} from "svelte/transition";
     import {quintOut} from "svelte/easing";
-    import {highlightModuleName, maxPanelZIndex, showGrid, snappingEnabled} from "./clickgui_store";
+    import {gridSize, highlightModuleName, maxPanelZIndex, showGrid, snappingEnabled} from "./clickgui_store";
     import {setItem} from "../../integration/persistent_storage";
     import {scaleFactor} from "./clickgui_store";
 
@@ -22,7 +22,7 @@
     let moving = false;
     let offsetX = 0;
     let offsetY = 0;
-    const GRID_SIZE = 10;
+
     const panelConfig = loadPanelConfig();
 
     let ignoreGrid = false;
@@ -184,7 +184,7 @@
     function snapToGrid(value: number): number {
         if (ignoreGrid || !$snappingEnabled) return value;
 
-        return Math.round(value / GRID_SIZE) * GRID_SIZE;
+        return Math.round(value / $gridSize) * $gridSize;
     }
 </script>
 

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -6,7 +6,7 @@
     import type {ToggleModuleEvent} from "../../integration/events";
     import {fly} from "svelte/transition";
     import {quintOut} from "svelte/easing";
-    import {highlightModuleName, maxPanelZIndex} from "./clickgui_store";
+    import {highlightModuleName, maxPanelZIndex, showGrid} from "./clickgui_store";
     import {setItem} from "../../integration/persistent_storage";
     import {scaleFactor} from "./clickgui_store";
 
@@ -20,11 +20,9 @@
     let renderedModules: TModule[] = [];
 
     let moving = false;
-    let prevX = 0;
-    let prevY = 0;
     let offsetX = 0;
     let offsetY = 0;
-    const GRID_SIZE = 25;
+    const GRID_SIZE = 10;
     const panelConfig = loadPanelConfig();
 
     let ignoreGrid = false;
@@ -91,17 +89,17 @@
         offsetX = e.clientX - panelConfig.left;
         offsetY = e.clientY - panelConfig.top;
         panelConfig.zIndex = ++$maxPanelZIndex;
-        document.body.classList.add('moving-panel');
+        $showGrid = true;
     }
 
     function onMouseMove(e: MouseEvent) {
         if (moving) {
             const newLeft = (e.clientX - offsetX) * (2 / $scaleFactor);
             const newTop = (e.clientY - offsetY) * (2 / $scaleFactor);
-            
+
             panelConfig.left = snapToGrid(newLeft);
             panelConfig.top = snapToGrid(newTop);
-            
+
             fixPosition();
             savePanelConfig();
         }
@@ -109,7 +107,7 @@
 
     function onMouseUp() {
         moving = false;
-        document.body.classList.remove('moving-panel');
+        $showGrid = false;
     }
 
     function toggleExpanded() {
@@ -172,19 +170,20 @@
     });
 
     function handleKeydown(e: KeyboardEvent) {
-        if (e.key === 'Shift') {
+        if (e.key === "Shift") {
             ignoreGrid = true;
         }
     }
 
     function handleKeyup(e: KeyboardEvent) {
-        if (e.key === 'Shift') {
+        if (e.key === "Shift") {
             ignoreGrid = false;
         }
     }
 
     function snapToGrid(value: number): number {
         if (ignoreGrid) return value;
+
         return Math.round(value / GRID_SIZE) * GRID_SIZE;
     }
 </script>
@@ -225,15 +224,6 @@
 
 <style lang="scss">
   @import "../../colors.scss";
-
-  $GRID_SIZE: 25px;
-
-  :global(.moving-panel) {
-    background-image: 
-      linear-gradient(to right, rgba(128, 128, 128, 0.25) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(128, 128, 128, 0.25) 1px, transparent 1px);
-    background-size: $GRID_SIZE $GRID_SIZE;
-  }
 
   .panel {
     border-radius: 5px;

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -6,7 +6,7 @@
     import type {ToggleModuleEvent} from "../../integration/events";
     import {fly} from "svelte/transition";
     import {quintOut} from "svelte/easing";
-    import {highlightModuleName, maxPanelZIndex, showGrid} from "./clickgui_store";
+    import {highlightModuleName, maxPanelZIndex, showGrid, snappingEnabled} from "./clickgui_store";
     import {setItem} from "../../integration/persistent_storage";
     import {scaleFactor} from "./clickgui_store";
 
@@ -89,7 +89,7 @@
         offsetX = e.clientX - panelConfig.left;
         offsetY = e.clientY - panelConfig.top;
         panelConfig.zIndex = ++$maxPanelZIndex;
-        $showGrid = true;
+        $showGrid = $snappingEnabled;
     }
 
     function onMouseMove(e: MouseEvent) {
@@ -182,7 +182,7 @@
     }
 
     function snapToGrid(value: number): number {
-        if (ignoreGrid) return value;
+        if (ignoreGrid || !$snappingEnabled) return value;
 
         return Math.round(value / GRID_SIZE) * GRID_SIZE;
     }

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -15,3 +15,5 @@ export const highlightModuleName: Writable<string | null> = writable(null);
 export const scaleFactor: Writable<number> = writable(2);
 
 export const showGrid: Writable<boolean> = writable(false);
+
+export const snappingEnabled: Writable<boolean> = writable(true);

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -13,3 +13,5 @@ export const maxPanelZIndex: Writable<number> = writable(0);
 export const highlightModuleName: Writable<string | null> = writable(null);
 
 export const scaleFactor: Writable<number> = writable(2);
+
+export const showGrid: Writable<boolean> = writable(false);

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -17,3 +17,5 @@ export const scaleFactor: Writable<number> = writable(2);
 export const showGrid: Writable<boolean> = writable(false);
 
 export const snappingEnabled: Writable<boolean> = writable(true);
+
+export const gridSize: Writable<number> = writable(10);

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -128,7 +128,8 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     PlayerSneakMultiplier::class,
     PerspectiveEvent::class,
     ItemLoreQueryEvent::class,
-    PlayerEquipmentChangeEvent::class
+    PlayerEquipmentChangeEvent::class,
+    ClickGuiValueChangeEvent::class
 )
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.event.events
 
 import com.google.gson.annotations.SerializedName
+import net.ccbluex.liquidbounce.config.Configurable
 import net.ccbluex.liquidbounce.config.Value
 import net.ccbluex.liquidbounce.event.Event
 import net.ccbluex.liquidbounce.features.chat.packet.User
@@ -38,9 +39,18 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.client.network.ServerInfo
 import net.minecraft.world.GameMode
 
+@Deprecated(
+    "The `clickGuiScaleChange` event has been deprecated.",
+    ReplaceWith("ClickGuiScaleChangeEvent"),
+    DeprecationLevel.WARNING
+)
 @Nameable("clickGuiScaleChange")
 @WebSocketEvent
 class ClickGuiScaleChangeEvent(val value: Float) : Event()
+
+@Nameable("clickGuiValueChange")
+@WebSocketEvent
+class ClickGuiValueChangeEvent(val configurable: Configurable) : Event()
 
 @Nameable("spaceSeperatedNamesChange")
 @WebSocketEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.mojang.blaze3d.systems.RenderSystem
+import net.ccbluex.liquidbounce.config.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.ClickGuiValueChangeEvent
 import net.ccbluex.liquidbounce.event.events.ClickGuiScaleChangeEvent
@@ -71,12 +72,25 @@ object ModuleClickGui :
     @Suppress("UnusedPrivateProperty")
     private val searchBarAutoFocus by boolean("SearchBarAutoFocus", true)
 
-    @Suppress("UnusedPrivateProperty")
-    private val snapping by boolean("Snapping", true).onChanged {
-        EventManager.callEvent(ClickGuiValueChangeEvent(this))
+    object Snapping : ToggleableConfigurable(this, "Snapping", true) {
+
+        @Suppress("UnusedPrivateProperty")
+        private val gridSize by int("GridSize", 10, 1..100, "px").onChanged {
+            EventManager.callEvent(ClickGuiValueChangeEvent(ModuleClickGui))
+        }
+
+        init {
+            inner.find { it.name == "Enabled" }?.onChanged {
+                EventManager.callEvent(ClickGuiValueChangeEvent(ModuleClickGui))
+            }
+        }
     }
 
     private var clickGuiTab: ITab? = null
+
+    init {
+        tree(Snapping)
+    }
 
     override fun enable() {
         // Pretty sure we are not in a game, so we can't open the clickgui

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.events.ClickGuiValueChangeEvent
 import net.ccbluex.liquidbounce.event.events.ClickGuiScaleChangeEvent
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
@@ -49,8 +50,10 @@ object ModuleClickGui :
     @Suppress("UnusedPrivateProperty")
     private val scale by float("Scale", 1f, 0.5f..2f).onChanged {
         EventManager.callEvent(ClickGuiScaleChangeEvent(it))
+        EventManager.callEvent(ClickGuiValueChangeEvent(this))
     }
 
+    @Suppress("UnusedPrivateProperty")
     private val cache by boolean("Cache", true).onChanged { cache ->
         RenderSystem.recordRenderCall {
             if (cache) {
@@ -68,6 +71,11 @@ object ModuleClickGui :
     @Suppress("UnusedPrivateProperty")
     private val searchBarAutoFocus by boolean("SearchBarAutoFocus", true)
 
+    @Suppress("UnusedPrivateProperty")
+    private val snapping by boolean("Snapping", true).onChanged {
+        EventManager.callEvent(ClickGuiValueChangeEvent(this))
+    }
+
     private var clickGuiTab: ITab? = null
 
     override fun enable() {
@@ -76,11 +84,13 @@ object ModuleClickGui :
             return
         }
 
-        mc.setScreen(if (clickGuiTab == null) {
-            VrScreen(VirtualScreenType.CLICK_GUI)
-        } else {
-            ClickScreen()
-        })
+        mc.setScreen(
+            if (clickGuiTab == null) {
+                VrScreen(VirtualScreenType.CLICK_GUI)
+            } else {
+                ClickScreen()
+            }
+        )
         super.enable()
     }
 


### PR DESCRIPTION
### What does this PR do?
- Adds grid snapping functionality to the `clickgui`.
- Includes a visual overlay that displays the grid while dragging panels.
- Improves the ability to visually organize and align panels.

### Why is this change useful?
- Helps users maintain a clean, visually aligned interface.
- Especially useful for users who prefer perfect alignment.

### Future Plans:
- Option to enable/disable grid snapping.
- Option to customize grid size and toggle the grid display.


![image](https://github.com/user-attachments/assets/45c9a2ec-f19c-4adf-afe4-e3533a8fdaed)


![image](https://github.com/user-attachments/assets/12a3cb7f-ac2e-426f-8e03-a98e3144816c)
