### PR TITLE
fix: changing SearchBarAutoFocus value has no immediate effect

### DIFF
--- a/src-theme/src/routes/clickgui/Search.svelte
+++ b/src-theme/src/routes/clickgui/Search.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import type {Module} from "../../integration/types";
+    import type {ConfigurableSetting, Module} from "../../integration/types";
     import {getModuleSettings, setModuleEnabled} from "../../integration/rest";
     import {listen} from "../../integration/ws";
-    import type {KeyboardKeyEvent, ToggleModuleEvent} from "../../integration/events";
+    import type {ClickGuiValueChangeEvent, KeyboardKeyEvent, ToggleModuleEvent} from "../../integration/events";
     import {highlightModuleName} from "./clickgui_store";
     import {onMount} from "svelte";
     import {convertToSpacedString, spaceSeperatedNames} from "../../theme/theme_config";
@@ -96,9 +96,13 @@
         }
     }
 
+    function applyValues(configurable: ConfigurableSetting) {
+        autoFocus = configurable.value.find(v => v.name === "SearchBarAutoFocus")?.value as boolean ?? true;
+    }
+
     onMount(async () => {
         const clickGuiSettings = await getModuleSettings("ClickGUI");
-        autoFocus = clickGuiSettings.value.find(v => v.name === "SearchBarAutoFocus")?.value as boolean ?? true
+        applyValues(clickGuiSettings);
         if (autoFocus) {
             searchInputElement.focus();
         }
@@ -114,6 +118,10 @@
     });
 
     listen("keyboardKey", handleKeyDown);
+
+    listen("clickGuiValueChange", (e: ClickGuiValueChangeEvent) => {
+        applyValues(e.configurable);
+    });
 </script>
 
 <svelte:window on:click={handleWindowClick} on:keydown={handleWindowKeyDown} on:contextmenu={handleWindowClick}/>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -70,7 +70,9 @@ object ModuleClickGui :
     }
 
     @Suppress("UnusedPrivateProperty")
-    private val searchBarAutoFocus by boolean("SearchBarAutoFocus", true)
+    private val searchBarAutoFocus by boolean("SearchBarAutoFocus", true).onChanged {
+        EventManager.callEvent(ClickGuiValueChangeEvent(this))
+    }
 
     object Snapping : ToggleableConfigurable(this, "Snapping", true) {
 


### PR DESCRIPTION
The new value is not applied until the ClickGUI is reloaded. This has been fixed in this pull request.