### PR TITLE
fix: Minimap thread-safe

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/types/minimap/ChunkRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/types/minimap/ChunkRenderer.kt
@@ -174,7 +174,7 @@ object ChunkRenderer {
                         for (offZ in from.y..to.y) {
                             val (texX, texY) = atlasPosition.getPosOnAtlas(offX, offZ)
 
-                            val color = getColor(offX + otherPos.startX, offZ + otherPos.startZ)
+                            val color = getColor(offX or otherPos.startX, offZ or otherPos.startZ)
 
                             texture.image!!.setColor(texX, texY, color)
                         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/types/minimap/MinimapHeightmapManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/types/minimap/MinimapHeightmapManager.kt
@@ -70,12 +70,12 @@ class MinimapHeightmapManager {
         val chunkPos = ChunkPos(pos)
         val heightmap = getHeightmap(chunkPos)
 
-        val currentHeight = heightmap.getHeight(pos.x - chunkPos.startX, pos.z - chunkPos.startZ)
+        val currentHeight = heightmap.getHeight(pos.x and 15, pos.z and 15)
 
         val newHeight = calculateHeightIfNeeded(currentHeight, pos, newState)
 
         return if (newHeight != null) {
-            heightmap.setHeight(pos.x - chunkPos.startX, pos.z - chunkPos.startZ, newHeight)
+            heightmap.setHeight(pos.x and 15, pos.z and 15, newHeight)
 
             true
         } else {


### PR DESCRIPTION
- add the read lock on MinimapTextureAtlasManager::get
- MinimapTextureAtlasManager::getOrAllocate doesn't need the read lock, because it is called with the write lock acquired

closes #2508 