### PR TITLE
refactor(EventSystem): Running States and Event Handler

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -5,6 +5,8 @@
     <ID>BracesOnIfStatements:AimDebugRecorder.kt$AimDebugRecorder$else</ID>
     <ID>BracesOnIfStatements:AutoFarmAutoWalk.kt$AutoFarmAutoWalk$if</ID>
     <ID>BracesOnIfStatements:AutoFarmBlockHandler.kt$AutoFarmBlockTracker$if</ID>
+    <ID>BracesOnIfStatements:ClientModule.kt$ClientModule$else</ID>
+    <ID>BracesOnIfStatements:ClientModule.kt$ClientModule$if</ID>
     <ID>BracesOnIfStatements:CommandItemEnchant.kt$CommandItemEnchant$else</ID>
     <ID>BracesOnIfStatements:CommandItemEnchant.kt$CommandItemEnchant$if</ID>
     <ID>BracesOnIfStatements:DebugCPSRecorder.kt$DebugCPSRecorder$if</ID>
@@ -17,13 +19,10 @@
     <ID>BracesOnIfStatements:FlyFireballLegitTechnique.kt$FlyFireballLegitTechnique$if</ID>
     <ID>BracesOnIfStatements:FlyGrim2859V.kt$FlyGrim2859V$if</ID>
     <ID>BracesOnIfStatements:ItemImageAtlas.kt$ItemImageAtlas$if</ID>
-    <ID>BracesOnIfStatements:Module.kt$Module$else</ID>
-    <ID>BracesOnIfStatements:Module.kt$Module$if</ID>
     <ID>BracesOnIfStatements:ModuleAntiExploit.kt$ModuleAntiExploit$if</ID>
     <ID>BracesOnIfStatements:ModuleAutoBow.kt$ModuleAutoBow$else</ID>
     <ID>BracesOnIfStatements:ModuleAutoBow.kt$ModuleAutoBow$if</ID>
     <ID>BracesOnIfStatements:ModuleAutoFarm.kt$ModuleAutoFarm$if</ID>
-    <ID>BracesOnIfStatements:ModuleBlink.kt$ModuleBlink$if</ID>
     <ID>BracesOnIfStatements:ModuleBlockESP.kt$ModuleBlockESP.Glow$if</ID>
     <ID>BracesOnIfStatements:ModuleBlockESP.kt$ModuleBlockESP.Outline$if</ID>
     <ID>BracesOnIfStatements:ModuleClickTp.kt$ModuleClickTp$else</ID>
@@ -102,8 +101,8 @@
     <ID>LongParameterList:FontRenderer.kt$FontRenderer$( x0: Float, x: Float, y: Float, z: Float, color: Color4b, through: Boolean )</ID>
     <ID>LongParameterList:Mat4.kt$Mat4.Companion$( left: Float, top: Float, right: Float, bottom: Float, nearPlane: Float, farPlane: Float )</ID>
     <ID>LongParameterList:Region.kt$Region$(minX: Int, minY: Int, minZ: Int, maxX: Int, maxY: Int, maxZ: Int)</ID>
-    <ID>LongParameterList:RotationsUtil.kt$RotationManager$( rotation: Rotation, considerInventory: Boolean = true, configurable: RotationsConfigurable, priority: Priority, provider: Module, whenReached: RestrictedSingleUseAction? = null )</ID>
-    <ID>LongParameterList:RotationsUtil.kt$RotationManager$( vecRotation: VecRotation, entity: Entity? = null, considerInventory: Boolean = true, configurable: RotationsConfigurable, priority: Priority, provider: Module )</ID>
+    <ID>LongParameterList:RotationsUtil.kt$RotationManager$( rotation: Rotation, considerInventory: Boolean = true, configurable: RotationsConfigurable, priority: Priority, provider: ClientModule, whenReached: RestrictedSingleUseAction? = null )</ID>
+    <ID>LongParameterList:RotationsUtil.kt$RotationManager$( vecRotation: VecRotation, entity: Entity? = null, considerInventory: Boolean = true, configurable: RotationsConfigurable, priority: Priority, provider: ClientModule )</ID>
     <ID>LongParameterList:ScriptNetworkUtil.kt$ScriptNetworkUtil$(x: Double, y: Double, z: Double, yaw: Float, pitch: Float, onGround: Boolean)</ID>
     <ID>LongParameterList:TargetFinding.kt$BlockPlacementTargetFindingOptions$( val offsetsToInvestigate: List&lt;Vec3i>, val stackToPlaceWith: ItemStack, val facePositionFactory: FaceTargetPositionFactory, val offsetPriorityGetter: (Vec3i) -> Double, val playerPositionOnPlacement: Vec3d, val playerPoseOnPlacement: EntityPose = EntityPose.STANDING, val allowPointingAway: Boolean = false )</ID>
     <ID>LongParameterList:ThemeManager.kt$ThemeManager$(context: DrawContext, width: Int, height: Int, mouseX: Int, mouseY: Int, delta: Float)</ID>
@@ -114,6 +113,8 @@
     <ID>MatchingDeclarationName:ComparatorUtils.kt$ComparatorChain&lt;T> : Comparator</ID>
     <ID>MatchingDeclarationName:MovementUtils.kt$DirectionalInput</ID>
     <ID>MaxLineLength:HttpClient.kt$HttpClient$"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"</ID>
+    <ID>MaxLineLength:ModuleAutoBuff.kt$ModuleAutoBuff$object</ID>
+    <ID>MaxLineLength:Parameters.kt$fun</ID>
     <ID>NestedBlockDepth:AStarMode.kt$AStarMode$private fun findPath(start: Vec3i, end: Vec3i, maxCost: Int, maxIterations: Int = 500): List&lt;Vec3i></ID>
     <ID>NestedBlockDepth:CombatExtensions.kt$fun Entity.attack(swing: Boolean, keepSprint: Boolean = false)</ID>
     <ID>NestedBlockDepth:CommandManager.kt$CommandManager$fun autoComplete(origCmd: String, start: Int): CompletableFuture&lt;Suggestions></ID>
@@ -122,7 +123,7 @@
     <ID>NestedBlockDepth:ScaffoldGodBridgeTechnique.kt$ScaffoldGodBridgeTechnique$override fun ledge( ledge: Boolean, ledgeSoon: Boolean, target: BlockPlacementTarget?, rotation: Rotation ): LedgeState</ID>
     <ID>PrintStackTrace:CommandManager.kt$CommandManager$e</ID>
     <ID>ReturnCount:AutoFarmBlockHandler.kt$AutoFarmBlockTracker$override fun getStateFor(pos: BlockPos, state: BlockState): AutoFarmTrackedStates?</ID>
-    <ID>ReturnCount:IntegrationHandler.kt$IntegrationHandler$private fun handleScreenSituation(screen: Screen?): Boolean</ID>
+    <ID>ReturnCount:IntegrationListener.kt$IntegrationListener$private fun handleScreenSituation(screen: Screen?): Boolean</ID>
     <ID>ReturnCount:SpeedAntiCornerBump.kt$SpeedAntiCornerBump$fun getSuggestedJumpDelay( simulatedPlayer: SimulatedPlayer, n: Int = 2, ): Int?</ID>
     <ID>SpreadOperator:AStarMode.kt$AStarMode$( Vec3i(-1, 0, 0), // left Vec3i(1, 0, 0), // right *(-9..9).map { Vec3i(0, it, 0) }.toTypedArray(), // up- and down Vec3i(0, 0, -1), // front Vec3i(0, 0, 1) // back )</ID>
     <ID>SpreadOperator:ModuleVomit.kt$ModuleVomit$( *emptySlots.map { slot -> CreativeInventoryAction.performFillSlot(randomStack, slot) } .toTypedArray(), *emptySlots.map { slot -> ClickInventoryAction.performThrow(null, slot) } .toTypedArray() )</ID>
@@ -140,9 +141,9 @@
     <ID>ThrowsCount:CommandManager.kt$CommandManager$@ScriptApiRequired @JvmName("execute") fun execute(cmd: String)</ID>
     <ID>ThrowsCount:CommandXRay.kt$CommandXRay$fun createCommand(): Command</ID>
     <ID>TooManyFunctions:AccountFunctions.kt$net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client.AccountFunctions.kt</ID>
-    <ID>TooManyFunctions:AccountManager.kt$AccountManager : ConfigurableListenable</ID>
+    <ID>TooManyFunctions:AccountManager.kt$AccountManager : ConfigurableEventListener</ID>
     <ID>TooManyFunctions:BlockExtensions.kt$net.ccbluex.liquidbounce.utils.block.BlockExtensions.kt</ID>
-    <ID>TooManyFunctions:BlockPlacer.kt$BlockPlacer : ConfigurableListenable</ID>
+    <ID>TooManyFunctions:BlockPlacer.kt$BlockPlacer : ConfigurableEventListener</ID>
     <ID>TooManyFunctions:ChatClient.kt$ChatClient</ID>
     <ID>TooManyFunctions:ClientUtils.kt$net.ccbluex.liquidbounce.utils.client.ClientUtils.kt</ID>
     <ID>TooManyFunctions:CommandClient.kt$CommandClient</ID>
@@ -150,19 +151,19 @@
     <ID>TooManyFunctions:ConfigSystem.kt$ConfigSystem</ID>
     <ID>TooManyFunctions:Configurable.kt$Configurable : Value</ID>
     <ID>TooManyFunctions:EntityExtensions.kt$net.ccbluex.liquidbounce.utils.entity.EntityExtensions.kt</ID>
-    <ID>TooManyFunctions:FakeLag.kt$FakeLag : Listenable</ID>
+    <ID>TooManyFunctions:FakeLag.kt$FakeLag : EventListener</ID>
     <ID>TooManyFunctions:InventoryUtils.kt$net.ccbluex.liquidbounce.utils.inventory.InventoryUtils.kt</ID>
     <ID>TooManyFunctions:ItemExtensions.kt$net.ccbluex.liquidbounce.utils.item.ItemExtensions.kt</ID>
-    <ID>TooManyFunctions:ModuleManager.kt$ModuleManager : ListenableIterable</ID>
+    <ID>TooManyFunctions:ModuleManager.kt$ModuleManager : EventListenerIterable</ID>
     <ID>TooManyFunctions:PlacementRenderHandler.kt$PlacementRenderHandler</ID>
     <ID>TooManyFunctions:ProxyFunctions.kt$net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client.ProxyFunctions.kt</ID>
     <ID>TooManyFunctions:RenderTasks.kt$Color4b</ID>
-    <ID>TooManyFunctions:RotationsUtil.kt$RotationManager : Listenable</ID>
+    <ID>TooManyFunctions:RotationsUtil.kt$RotationManager : EventListener</ID>
     <ID>TooManyFunctions:ScriptSetting.kt$ScriptSetting</ID>
     <ID>TooManyFunctions:TextExtensions.kt$net.ccbluex.liquidbounce.utils.client.TextExtensions.kt</ID>
     <ID>UnusedParameter:ClientApi.kt$ClientApi$settings: String</ID>
-    <ID>UnusedParameter:CommandConfig.kt$CommandConfig$validator: (Module) -> Boolean = { true }</ID>
-    <ID>UnusedParameter:CommandLocalConfig.kt$CommandLocalConfig$validator: (Module) -> Boolean = { true }</ID>
+    <ID>UnusedParameter:CommandConfig.kt$CommandConfig$validator: (ClientModule) -> Boolean = { true }</ID>
+    <ID>UnusedParameter:CommandLocalConfig.kt$CommandLocalConfig$validator: (ClientModule) -> Boolean = { true }</ID>
     <ID>UnusedParameter:FaceTargetPositionFactory.kt$StabilizedRotationTargetPositionFactory$face: Face</ID>
     <ID>UnusedParameter:ModuleManager.kt$ModuleManager$args: List&lt;String></ID>
     <ID>UnusedPrivateProperty:NoFallBlink.kt$NoFallBlink$i</ID>

--- a/src/main/java/net/ccbluex/liquidbounce/common/TweakedMethods.java
+++ b/src/main/java/net/ccbluex/liquidbounce/common/TweakedMethods.java
@@ -33,7 +33,7 @@ import net.minecraft.world.RaycastContext;
 public class TweakedMethods {
 
     public static BlockHitResult tweakedRaycast(BlockView blockView, RaycastContext context) {
-        if (ModuleGhostHand.INSTANCE.getEnabled()) {
+        if (ModuleGhostHand.INSTANCE.getRunning()) {
             var returned = (BlockHitResult) BlockView.raycast(context.getStart(), context.getEnd(), context, (contextx, pos) -> {
                 BlockState blockState = blockView.getBlockState(pos);
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinBlock.java
@@ -37,7 +37,7 @@ public class MixinBlock {
     @ModifyReturnValue(method = "shouldDrawSide", at = @At("RETURN"))
     private static boolean injectXRay(boolean original, BlockState state, BlockView world, BlockPos pos, Direction side, BlockPos otherPos) {
         var xRay = ModuleXRay.INSTANCE;
-        if (xRay.getEnabled()) {
+        if (xRay.getRunning()) {
             return xRay.shouldRender(state, pos);
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinCobwebBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinCobwebBlock.java
@@ -39,7 +39,7 @@ public class MixinCobwebBlock {
      */
     @Inject(method = "onEntityCollision", at = @At("HEAD"), cancellable = true)
     private void hookEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo callback) {
-        if (ModuleNoWeb.INSTANCE.getEnabled() && entity == MinecraftClient.getInstance().player &&
+        if (ModuleNoWeb.INSTANCE.getRunning() && entity == MinecraftClient.getInstance().player &&
                 ModuleNoWeb.INSTANCE.handleEntityCollision(pos)) {
             callback.cancel();
         }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinPowderSnowBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinPowderSnowBlock.java
@@ -35,7 +35,7 @@ public class MixinPowderSnowBlock {
 
     @Inject(method = "onEntityCollision", at = @At("HEAD"), cancellable = true)
     private void hookEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
-        if (ModuleNoSlow.INSTANCE.getEnabled() && NoSlowPowderSnow.INSTANCE.getEnabled()) {
+        if (ModuleNoSlow.INSTANCE.getRunning() && NoSlowPowderSnow.INSTANCE.getEnabled()) {
             ci.cancel();
 
             var multiplier = NoSlowPowderSnow.INSTANCE.getMultiplier();

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinSlimeBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/block/MixinSlimeBlock.java
@@ -35,7 +35,7 @@ public class MixinSlimeBlock {
 
     @Inject(method = "bounce", at = @At("HEAD"), cancellable = true)
     private void hookBounce(Entity entity, CallbackInfo ci) {
-        if (ModuleNoSlow.INSTANCE.getEnabled() && NoSlowSlime.INSTANCE.getEnabled()) {
+        if (ModuleNoSlow.INSTANCE.getRunning() && NoSlowSlime.INSTANCE.getEnabled()) {
             if (entity.getVelocity().y == -0.0784000015258789 || entity.getVelocity().y == -0.001567998535156222) {
                 ci.cancel();
             }
@@ -44,7 +44,7 @@ public class MixinSlimeBlock {
 
     @Inject(method = "onSteppedOn", at = @At("HEAD"), cancellable = true)
     private void hookStep(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) {
-        if (ModuleNoSlow.INSTANCE.getEnabled() && NoSlowSlime.INSTANCE.getEnabled()) {
+        if (ModuleNoSlow.INSTANCE.getRunning() && NoSlowSlime.INSTANCE.getEnabled()) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinClientWorld.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinClientWorld.java
@@ -37,7 +37,7 @@ public class MixinClientWorld {
 
     @ModifyReturnValue(method = "getBlockParticle", at = @At("RETURN"))
     private Block injectBlockParticle(Block original) {
-        if (ModuleTrueSight.INSTANCE.getEnabled() && ModuleTrueSight.INSTANCE.getBarriers()) {
+        if (ModuleTrueSight.INSTANCE.getRunning() && ModuleTrueSight.INSTANCE.getBarriers()) {
             return Blocks.BARRIER;
         }
         return original;

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -91,7 +91,7 @@ public abstract class MixinMinecraftClient {
     @Inject(method = "isAmbientOcclusionEnabled()Z", at = @At("HEAD"), cancellable = true)
     private static void injectXRayFullBright(CallbackInfoReturnable<Boolean> callback) {
         ModuleXRay module = ModuleXRay.INSTANCE;
-        if (!module.getEnabled() || !module.getFullBright()) {
+        if (!module.getRunning() || !module.getFullBright()) {
             return;
         }
 
@@ -274,7 +274,7 @@ public abstract class MixinMinecraftClient {
     @ModifyExpressionValue(method = "doAttack",
             at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;attackCooldown:I", ordinal = 0))
     private int injectNoMissCooldown(int original) {
-        if (ModuleNoMissCooldown.INSTANCE.getEnabled() && ModuleNoMissCooldown.INSTANCE.getRemoveAttackCooldown()) {
+        if (ModuleNoMissCooldown.INSTANCE.getRunning() && ModuleNoMissCooldown.INSTANCE.getRemoveAttackCooldown()) {
             return 0;
         }
 
@@ -284,13 +284,13 @@ public abstract class MixinMinecraftClient {
     @WrapWithCondition(method = "doAttack", at = @At(value = "FIELD",
             target = "Lnet/minecraft/client/MinecraftClient;attackCooldown:I", ordinal = 1))
     private boolean disableAttackCooldown(MinecraftClient instance, int value) {
-        return !(ModuleNoMissCooldown.INSTANCE.getEnabled() && ModuleNoMissCooldown.INSTANCE.getRemoveAttackCooldown());
+        return !(ModuleNoMissCooldown.INSTANCE.getRunning() && ModuleNoMissCooldown.INSTANCE.getRemoveAttackCooldown());
     }
 
     @Inject(method = "doAttack", at = @At("HEAD"), cancellable = true)
     private void injectCombatPause(CallbackInfoReturnable<Boolean> cir) {
         if (player == null || crosshairTarget == null || crosshairTarget.getType() == HitResult.Type.MISS) {
-            if (ModuleNoMissCooldown.INSTANCE.getEnabled() && ModuleNoMissCooldown.INSTANCE.getCancelAttackOnMiss()) {
+            if (ModuleNoMissCooldown.INSTANCE.getRunning() && ModuleNoMissCooldown.INSTANCE.getCancelAttackOnMiss()) {
                 // Prevent swinging
                 cir.setReturnValue(true);
             }
@@ -328,23 +328,23 @@ public abstract class MixinMinecraftClient {
 
     @ModifyExpressionValue(method = "handleBlockBreaking", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
     private boolean injectMultiActionsBreakingWhileUsing(boolean original) {
-        return original && !(ModuleMultiActions.INSTANCE.isRunning() && ModuleMultiActions.INSTANCE.getBreakingWhileUsing());
+        return original && !(ModuleMultiActions.INSTANCE.getRunning() && ModuleMultiActions.INSTANCE.getBreakingWhileUsing());
     }
 
     @ModifyExpressionValue(method = "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;isBreakingBlock()Z"))
     private boolean injectMultiActionsPlacingWhileBreaking(boolean original) {
-        return original && !(ModuleMultiActions.INSTANCE.isRunning() && ModuleMultiActions.INSTANCE.getPlacingWhileBreaking());
+        return original && !(ModuleMultiActions.INSTANCE.getRunning() && ModuleMultiActions.INSTANCE.getPlacingWhileBreaking());
     }
 
     @ModifyExpressionValue(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z", ordinal = 0))
     private boolean injectMultiActionsAttackingWhileUsingAndEnforcedBlockingState(boolean isUsingItem) {
         if (isUsingItem) {
-            if (!this.options.useKey.isPressed() && !(ModuleKillAura.INSTANCE.getEnabled()
+            if (!this.options.useKey.isPressed() && !(ModuleKillAura.INSTANCE.getRunning()
                     && AutoBlock.INSTANCE.getEnabled() && AutoBlock.INSTANCE.getBlockingStateEnforced())) {
                 this.interactionManager.stopUsingItem(this.player);
             }
 
-            if (!ModuleMultiActions.INSTANCE.isRunning() || !ModuleMultiActions.INSTANCE.getAttackingWhileUsing()) {
+            if (!ModuleMultiActions.INSTANCE.getRunning() || !ModuleMultiActions.INSTANCE.getAttackingWhileUsing()) {
                 this.options.attackKey.timesPressed = 0;
             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouse.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouse.java
@@ -68,12 +68,12 @@ public class MixinMouse {
 
     @ModifyExpressionValue(method = "updateMouse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/Perspective;isFirstPerson()Z"))
     private boolean injectZoomCondition1(boolean original) {
-        return original || ModuleZoom.INSTANCE.getEnabled();
+        return original || ModuleZoom.INSTANCE.getRunning();
     }
 
     @ModifyExpressionValue(method = "updateMouse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingSpyglass()Z"))
     private boolean injectZoomCondition2(boolean original) {
-        return original || ModuleZoom.INSTANCE.getEnabled();
+        return original || ModuleZoom.INSTANCE.getRunning();
     }
 
     @WrapWithCondition(method = "updateMouse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;changeLookDirection(DD)V"), require = 1, allow = 1)

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinTextHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinTextHandler.java
@@ -43,7 +43,7 @@ public class MixinTextHandler {
 
     @Inject(method = "getWidth(Lnet/minecraft/text/StringVisitable;)F", at = @At("HEAD"), cancellable = true)
     private void injectNameProtectWidthB(StringVisitable text, CallbackInfoReturnable<Float> cir) {
-        if (!ModuleNameProtect.INSTANCE.getEnabled()) {
+        if (!ModuleNameProtect.INSTANCE.getRunning()) {
             return;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWorld.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinWorld.java
@@ -56,7 +56,7 @@ public class MixinWorld {
     private void injectOverrideWeather(float delta, CallbackInfoReturnable<Float> cir) {
         var module = ModuleCustomAmbience.INSTANCE;
         var desiredWeather = module.getWeather().get();
-        if (module.getEnabled()) {
+        if (module.getRunning()) {
             switch (desiredWeather) {
                 case SUNNY -> cir.setReturnValue(0.0f);
                 case RAINY, THUNDER -> cir.setReturnValue(1.0f);
@@ -69,7 +69,7 @@ public class MixinWorld {
     private void injectOverrideThunder(float delta, CallbackInfoReturnable<Float> cir) {
         var module = ModuleCustomAmbience.INSTANCE;
         var desiredWeather = module.getWeather().get();
-        if (module.getEnabled()) {
+        if (module.getRunning()) {
             switch (desiredWeather) {
                 case SUNNY, RAINY, SNOWY -> cir.setReturnValue(0.0f);
                 case THUNDER -> cir.setReturnValue(1.0f);

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractClientPlayerEntity.java
@@ -30,7 +30,7 @@ public abstract class MixinAbstractClientPlayerEntity {
 
     @ModifyReturnValue(method = "getFovMultiplier", at = @At("RETURN"))
     private float injectFovMultiplier(float original) {
-        if (ModuleNoFov.INSTANCE.getEnabled()) {
+        if (ModuleNoFov.INSTANCE.getRunning()) {
             return ModuleNoFov.INSTANCE.getFovMultiplier(original);
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractHorseEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinAbstractHorseEntity.java
@@ -34,7 +34,7 @@ public class MixinAbstractHorseEntity {
     private boolean isSaddled(boolean original) {
         // If entity control is enabled and enforce saddled is enabled,
         // return always true and pretend the entity is saddled
-        if (ModuleEntityControl.INSTANCE.getEnabled() && ModuleEntityControl.INSTANCE.getEnforceSaddled()) {
+        if (ModuleEntityControl.INSTANCE.getRunning() && ModuleEntityControl.INSTANCE.getEnforceSaddled()) {
             return true;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinClientPlayerEntity.java
@@ -184,7 +184,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
      */
     @ModifyExpressionValue(method = "tickNausea", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;shouldPause()Z"))
     private boolean hookNetherClosingScreen(boolean original) {
-        if (ModulePortalMenu.INSTANCE.getEnabled()) {
+        if (ModulePortalMenu.INSTANCE.getRunning()) {
             return true;
         }
 
@@ -223,7 +223,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
      */
     @ModifyExpressionValue(method = "canStartSprinting", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z"))
     private boolean hookSprintAffectStart(boolean original) {
-        if (ModuleNoSlow.INSTANCE.getEnabled()) {
+        if (ModuleNoSlow.INSTANCE.getRunning()) {
             return false;
         }
 
@@ -254,7 +254,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @ModifyReturnValue(method = "isAutoJumpEnabled", at = @At("RETURN"))
     private boolean injectLegitStep(boolean original) {
-        if (ModuleStep.INSTANCE.getEnabled() && ModuleStep.Legit.INSTANCE.isActive()) {
+        if (ModuleStep.INSTANCE.getRunning() && ModuleStep.Legit.INSTANCE.isSelected()) {
             return true;
         }
 
@@ -263,7 +263,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @Inject(method = "swingHand", at = @At("HEAD"), cancellable = true)
     private void swingHand(Hand hand, CallbackInfo ci) {
-        if (ModuleNoSwing.INSTANCE.getEnabled()) {
+        if (ModuleNoSwing.INSTANCE.getRunning()) {
             if (!ModuleNoSwing.INSTANCE.shouldHideForServer()) {
                 networkHandler.sendPacket(new HandSwingC2SPacket(hand));
             }
@@ -277,7 +277,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @ModifyReturnValue(method = "getMountJumpStrength", at = @At("RETURN"))
     private float hookMountJumpStrength(float original) {
-        if (ModuleEntityControl.INSTANCE.getEnabled() && ModuleEntityControl.INSTANCE.getEnforceJumpStrength()) {
+        if (ModuleEntityControl.INSTANCE.getRunning() && ModuleEntityControl.INSTANCE.getEnforceJumpStrength()) {
             return 1f;
         }
 
@@ -286,7 +286,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
 
     @ModifyExpressionValue(method = "tickMovement", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerAbilities;allowFlying:Z"))
     private boolean hookFreeCamPreventCreativeFly(boolean original) {
-        return !ModuleFreeCam.INSTANCE.getEnabled() && original;
+        return !ModuleFreeCam.INSTANCE.getRunning() && original;
     }
 
     @ModifyVariable(method = "sendMovementPackets", at = @At("STORE"), ordinal = 2)
@@ -302,7 +302,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
     @ModifyExpressionValue(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;isPressed()Z"))
     private boolean hookAutoSprint(boolean original) {
         return !ModuleSuperKnockback.INSTANCE.shouldBlockSprinting() && !ModuleKillAura.INSTANCE.shouldBlockSprinting()
-                && (ModuleSprint.INSTANCE.getEnabled() || original);
+                && (ModuleSprint.INSTANCE.getRunning() || original);
     }
 
     @ModifyExpressionValue(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isWalking()Z"))
@@ -332,7 +332,7 @@ public abstract class MixinClientPlayerEntity extends MixinPlayerEntity {
             target = "Lnet/minecraft/client/network/ClientPlayerEntity;isSprinting()Z")
     )
     private boolean hookNoHungerSprint(boolean original) {
-        return !(ModuleAntiHunger.INSTANCE.getEnabled() && ModuleAntiHunger.INSTANCE.getNoSprint()) && original;
+        return !(ModuleAntiHunger.INSTANCE.getRunning() && ModuleAntiHunger.INSTANCE.getNoSprint()) && original;
     }
 
     @WrapWithCondition(method = "closeScreen", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V"))

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinEntity.java
@@ -74,7 +74,7 @@ public abstract class MixinEntity {
 
     @ModifyExpressionValue(method = "bypassesLandingEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;isSneaking()Z"))
     private boolean hookAntiBounce(boolean original) {
-        return ModuleAntiBounce.INSTANCE.getEnabled() || original;
+        return ModuleAntiBounce.INSTANCE.getRunning() || original;
     }
 
     /**
@@ -92,7 +92,7 @@ public abstract class MixinEntity {
      */
     @Redirect(method = "changeLookDirection", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(FFF)F"))
     public float hookNoPitchLimit(float value, float min, float max) {
-        boolean noLimit = ModuleNoPitchLimit.INSTANCE.getEnabled();
+        boolean noLimit = ModuleNoPitchLimit.INSTANCE.getRunning();
 
         if (noLimit) return value;
         return MathHelper.clamp(value, min, max);

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLivingEntity.java
@@ -94,7 +94,7 @@ public abstract class MixinLivingEntity extends MixinEntity {
      */
     @Redirect(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/registry/entry/RegistryEntry;)Z"))
     public boolean hookTravelStatusEffect(LivingEntity instance, RegistryEntry<StatusEffect> effect) {
-        if ((effect == StatusEffects.LEVITATION || effect == StatusEffects.SLOW_FALLING) && ModuleAntiLevitation.INSTANCE.getEnabled()) {
+        if ((effect == StatusEffects.LEVITATION || effect == StatusEffects.SLOW_FALLING) && ModuleAntiLevitation.INSTANCE.getRunning()) {
             if (instance.hasStatusEffect(effect)) {
                 instance.fallDistance = 0f;
             }
@@ -107,7 +107,7 @@ public abstract class MixinLivingEntity extends MixinEntity {
 
     @Inject(method = "hasStatusEffect", at = @At("HEAD"), cancellable = true)
     private void hookAntiNausea(RegistryEntry<StatusEffect> effect, CallbackInfoReturnable<Boolean> cir) {
-        if (effect == StatusEffects.NAUSEA && ModuleAntiBlind.INSTANCE.getEnabled() && ModuleAntiBlind.INSTANCE.getAntiNausea()) {
+        if (effect == StatusEffects.NAUSEA && ModuleAntiBlind.INSTANCE.getRunning() && ModuleAntiBlind.INSTANCE.getAntiNausea()) {
             cir.setReturnValue(false);
             cir.cancel();
         }
@@ -158,7 +158,7 @@ public abstract class MixinLivingEntity extends MixinEntity {
 
     @Inject(method = "pushAwayFrom", at = @At("HEAD"), cancellable = true)
     private void hookNoPush(CallbackInfo callbackInfo) {
-        if (ModuleNoPush.INSTANCE.getEnabled()) {
+        if (ModuleNoPush.INSTANCE.getRunning()) {
             callbackInfo.cancel();
         }
     }
@@ -166,12 +166,12 @@ public abstract class MixinLivingEntity extends MixinEntity {
     @Inject(method = "tickMovement", at = @At("HEAD"))
     private void hookTickMovement(CallbackInfo callbackInfo) {
         // We don't want NoJumpDelay to interfere with AirJump which would lead to a Jetpack-like behavior
-        var noJumpDelay = ModuleNoJumpDelay.INSTANCE.getEnabled() && !ModuleAirJump.INSTANCE.getAllowJump();
+        var noJumpDelay = ModuleNoJumpDelay.INSTANCE.getRunning() && !ModuleAirJump.INSTANCE.getAllowJump();
 
         // The jumping cooldown would lead to very slow tower building
-        var towerActive = ModuleScaffold.INSTANCE.getEnabled() && !(ModuleScaffold.INSTANCE.getTowerMode()
+        var towerActive = ModuleScaffold.INSTANCE.getRunning() && !(ModuleScaffold.INSTANCE.getTowerMode()
                 .getActiveChoice() instanceof NoneChoice) && ModuleScaffold.INSTANCE.getTowerMode()
-                .getActiveChoice().isActive();
+                .getActiveChoice().isSelected();
 
         if (noJumpDelay || towerActive) {
             jumpingCooldown = 0;
@@ -196,7 +196,7 @@ public abstract class MixinLivingEntity extends MixinEntity {
         }
 
         var elytra = isFallFlying();
-        if (ModuleElytraRecast.INSTANCE.getEnabled() && previousElytra && !elytra) {
+        if (ModuleElytraRecast.INSTANCE.getRunning() && previousElytra && !elytra) {
             MinecraftClient.getInstance().getSoundManager().stopSounds(SoundEvents.ITEM_ELYTRA_FLYING.getId(),
                     SoundCategory.PLAYERS);
             ModuleElytraRecast.INSTANCE.recastElytra();

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinBossBarHud.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinBossBarHud.java
@@ -30,7 +30,7 @@ public abstract class MixinBossBarHud {
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
     private void hookRenderStatusEffectOverlay(CallbackInfo ci) {
-        if (ModuleAntiBlind.INSTANCE.getEnabled() && ModuleAntiBlind.INSTANCE.getBossBars()) {
+        if (ModuleAntiBlind.INSTANCE.getRunning() && ModuleAntiBlind.INSTANCE.getBossBars()) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatHud.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatHud.java
@@ -63,7 +63,7 @@ public abstract class MixinChatHud {
     @Redirect(method = "addMessage(Lnet/minecraft/client/gui/hud/ChatHudLine;)V", at = @At(value = "INVOKE", target = "Ljava/util/List;size()I", ordinal = 0))
     public int hookGetSize2(List<ChatHudLine.Visible> list) {
         var betterChat = ModuleBetterChat.INSTANCE;
-        if (betterChat.getEnabled() && betterChat.getInfiniteLength()) {
+        if (betterChat.getRunning() && betterChat.getInfiniteLength()) {
             return -1;
         }
 
@@ -76,7 +76,7 @@ public abstract class MixinChatHud {
     @Inject(method = "clear", at = @At(value = "HEAD"), cancellable = true)
     public void hookClear(boolean clearHistory, CallbackInfo ci) {
         var betterChat = ModuleBetterChat.INSTANCE;
-        if (betterChat.getEnabled() && betterChat.getAntiClear() && !betterChat.getAntiChatClearPaused()) {
+        if (betterChat.getRunning() && betterChat.getAntiClear() && !betterChat.getAntiChatClearPaused()) {
             ci.cancel();
         }
     }
@@ -108,7 +108,7 @@ public abstract class MixinChatHud {
         }
 
         var betterChat = ModuleBetterChat.INSTANCE;
-        if (!betterChat.getEnabled() || !betterChat.getInfiniteLength()) {
+        if (!betterChat.getRunning() || !betterChat.getInfiniteLength()) {
             while(visibleMessages.size() > 100) {
                 visibleMessages.removeLast();
             }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinInGameHud.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinInGameHud.java
@@ -89,7 +89,7 @@ public abstract class MixinInGameHud {
     @Inject(method = "renderOverlay", at = @At("HEAD"), cancellable = true)
     private void injectPumpkinBlur(DrawContext context, Identifier texture, float opacity, CallbackInfo callback) {
         ModuleAntiBlind module = ModuleAntiBlind.INSTANCE;
-        if (!module.getEnabled()) {
+        if (!module.getRunning()) {
             return;
         }
 
@@ -105,7 +105,7 @@ public abstract class MixinInGameHud {
 
     @Inject(method = "renderCrosshair", at = @At("HEAD"), cancellable = true)
     private void hookFreeCamRenderCrosshairInThirdPerson(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
-        if ((ModuleFreeCam.INSTANCE.getEnabled() && ModuleFreeCam.INSTANCE.shouldDisableCrosshair())
+        if ((ModuleFreeCam.INSTANCE.getRunning() && ModuleFreeCam.INSTANCE.shouldDisableCrosshair())
                 || ComponentOverlay.isTweakEnabled(FeatureTweak.DISABLE_CROSSHAIR)) {
             ci.cancel();
         }
@@ -114,7 +114,7 @@ public abstract class MixinInGameHud {
     @Inject(method = "renderPortalOverlay", at = @At("HEAD"), cancellable = true)
     private void hookRenderPortalOverlay(CallbackInfo ci) {
         var antiBlind = ModuleAntiBlind.INSTANCE;
-        if (antiBlind.getEnabled() && antiBlind.getPortalOverlay()) {
+        if (antiBlind.getRunning() && antiBlind.getPortalOverlay()) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinHeldItemRenderer.java
@@ -31,7 +31,6 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ShieldItem;
 import net.minecraft.item.SwordItem;
 import net.minecraft.util.Arm;
 import net.minecraft.util.Hand;
@@ -48,7 +47,7 @@ public abstract class MixinHeldItemRenderer {
 
     @Inject(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;push()V", shift = At.Shift.AFTER))
     private void hookRenderFirstPersonItem(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (ModuleAnimations.INSTANCE.getEnabled()) {
+        if (ModuleAnimations.INSTANCE.getRunning()) {
             if (Hand.MAIN_HAND == hand && ModuleAnimations.MainHand.INSTANCE.getEnabled()) {
                 matrices.translate(ModuleAnimations.MainHand.INSTANCE.getMainHandX(), ModuleAnimations.MainHand.INSTANCE.getMainHandY(), ModuleAnimations.MainHand.INSTANCE.getMainHandItemScale());
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(ModuleAnimations.MainHand.INSTANCE.getMainHandPositiveX()));
@@ -142,7 +141,7 @@ public abstract class MixinHeldItemRenderer {
             ordinal = 4
     ), index = 2)
     private float applyEquipOffset(float equipProgress) {
-        if (ModuleAnimations.INSTANCE.getEnabled() && !ModuleAnimations.INSTANCE.getEquipOffset()) {
+        if (ModuleAnimations.INSTANCE.getRunning() && !ModuleAnimations.INSTANCE.getEquipOffset()) {
             return 0.0F;
         }
 
@@ -156,12 +155,12 @@ public abstract class MixinHeldItemRenderer {
                                                 Hand hand, float swingProgress, ItemStack item, float equipProgress,
                                                 MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light,
                                                 CallbackInfo ci) {
-        var shouldAnimate = ModuleSwordBlock.INSTANCE.getEnabled() || AutoBlock.INSTANCE.getBlockVisual();
+        var shouldAnimate = ModuleSwordBlock.INSTANCE.getRunning() || AutoBlock.INSTANCE.getBlockVisual();
 
         if (shouldAnimate && item.getItem() instanceof SwordItem) {
             final Arm arm = (hand == Hand.MAIN_HAND) ? player.getMainArm() : player.getMainArm().getOpposite();
 
-            if (ModuleAnimations.INSTANCE.getEnabled()) {
+            if (ModuleAnimations.INSTANCE.getRunning()) {
                 var activeChoice = ModuleAnimations.INSTANCE.getBlockAnimationChoice().getActiveChoice();
 
                 activeChoice.transform(matrices, arm, equipProgress, swingProgress);
@@ -175,7 +174,7 @@ public abstract class MixinHeldItemRenderer {
 
     @ModifyExpressionValue(method = "updateHeldItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getMainHandStack()Lnet/minecraft/item/ItemStack;"))
     private ItemStack injectSilentHotbar(ItemStack original) {
-        if (ModuleSilentHotbar.INSTANCE.getEnabled()) {
+        if (ModuleSilentHotbar.INSTANCE.getRunning()) {
             // noinspection DataFlowIssue
             return client.player.getInventory().main.get(SilentHotbar.INSTANCE.getClientsideSlot());
         }
@@ -185,7 +184,7 @@ public abstract class MixinHeldItemRenderer {
 
     @ModifyExpressionValue(method = "updateHeldItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getAttackCooldownProgress(F)F"))
     private float injectSilentHotbarNoCooldown(float original) {
-        if (ModuleSilentHotbar.INSTANCE.getEnabled() && ModuleSilentHotbar.INSTANCE.getNoCooldownProgress() && SilentHotbar.INSTANCE.isSlotModified()) {
+        if (ModuleSilentHotbar.INSTANCE.getRunning() && ModuleSilentHotbar.INSTANCE.getNoCooldownProgress() && SilentHotbar.INSTANCE.isSlotModified()) {
             return 1f;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinItem.java
@@ -46,7 +46,7 @@ public class MixinItem {
     private void hookSwordUse(World world, PlayerEntity user, Hand hand,
                               CallbackInfoReturnable<TypedActionResult<ItemStack>> cir) {
         // Hooks sword use - only if main hand (otherwise this makes no sense on 1.8)
-        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getEnabled() && !ModuleSwordBlock.INSTANCE.getOnlyVisual() && hand == Hand.MAIN_HAND) {
+        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getRunning() && !ModuleSwordBlock.INSTANCE.getOnlyVisual() && hand == Hand.MAIN_HAND) {
             var itemStack = user.getStackInHand(hand);
             user.setCurrentHand(hand);
             cir.setReturnValue(TypedActionResult.consume(itemStack));
@@ -56,7 +56,7 @@ public class MixinItem {
     @ModifyReturnValue(method = "getUseAction", at = @At("RETURN"))
     private UseAction hookSwordUseAction(UseAction original) {
         // Hooks sword use action
-        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getEnabled() && !ModuleSwordBlock.INSTANCE.getOnlyVisual()) {
+        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getRunning() && !ModuleSwordBlock.INSTANCE.getOnlyVisual()) {
             return UseAction.BLOCK;
         }
 
@@ -66,7 +66,7 @@ public class MixinItem {
     @ModifyReturnValue(method = "getMaxUseTime", at = @At("RETURN"))
     private int hookMaxUseTime(int original) {
         // Hooks sword max use time
-        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getEnabled() && !ModuleSwordBlock.INSTANCE.getOnlyVisual()) {
+        if (((Object) this) instanceof SwordItem && ModuleSwordBlock.INSTANCE.getRunning() && !ModuleSwordBlock.INSTANCE.getOnlyVisual()) {
             return 72000;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -89,7 +89,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         double y = args.get(1);
         double z = args.get(2);
 
-        if (ModuleAntiExploit.INSTANCE.getEnabled() && ModuleAntiExploit.INSTANCE.getLimitExplosionStrength()) {
+        if (ModuleAntiExploit.INSTANCE.getRunning() && ModuleAntiExploit.INSTANCE.getLimitExplosionStrength()) {
             double fixedX = MathHelper.clamp(x, -10.0, 10.0);
             double fixedY = MathHelper.clamp(y, -10.0, 10.0);
             double fixedZ = MathHelper.clamp(z, -10.0, 10.0);
@@ -106,7 +106,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
 
     @ModifyExpressionValue(method = "onParticle", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/s2c/play/ParticleS2CPacket;getCount()I", ordinal = 1))
     private int onParticleAmount(int original) {
-        if (ModuleAntiExploit.INSTANCE.getEnabled() && ModuleAntiExploit.INSTANCE.getLimitParticlesAmount() && 500 <= original) {
+        if (ModuleAntiExploit.INSTANCE.getRunning() && ModuleAntiExploit.INSTANCE.getLimitParticlesAmount() && 500 <= original) {
             ModuleAntiExploit.INSTANCE.notifyAboutExploit("Limited too many particles", true);
             return 100;
         }
@@ -115,7 +115,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
 
     @ModifyExpressionValue(method = "onParticle", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/s2c/play/ParticleS2CPacket;getSpeed()F"))
     private float onParticleSpeed(float original) {
-        if (ModuleAntiExploit.INSTANCE.getEnabled() && ModuleAntiExploit.INSTANCE.getLimitParticlesSpeed() && 10.0f <= original) {
+        if (ModuleAntiExploit.INSTANCE.getRunning() && ModuleAntiExploit.INSTANCE.getLimitParticlesSpeed() && 10.0f <= original) {
             ModuleAntiExploit.INSTANCE.notifyAboutExploit("Limited too fast particles speed", true);
             return 10.0f;
         }
@@ -124,7 +124,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
 
     @ModifyExpressionValue(method = "onExplosion", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/s2c/play/ExplosionS2CPacket;getRadius()F"))
     private float onExplosionWorld(float original) {
-        if (ModuleAntiExploit.INSTANCE.getEnabled() && ModuleAntiExploit.INSTANCE.getLimitExplosionRange()) {
+        if (ModuleAntiExploit.INSTANCE.getRunning() && ModuleAntiExploit.INSTANCE.getLimitExplosionRange()) {
             float radius = MathHelper.clamp(original, -1000.0f, 1000.0f);
             if (radius != original) {
                 ModuleAntiExploit.INSTANCE.notifyAboutExploit("Limited too big TNT explosion radius", true);
@@ -136,7 +136,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
 
     @ModifyExpressionValue(method = "onGameStateChange", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/s2c/play/GameStateChangeS2CPacket;getReason()Lnet/minecraft/network/packet/s2c/play/GameStateChangeS2CPacket$Reason;"))
     private GameStateChangeS2CPacket.Reason onGameStateChange(GameStateChangeS2CPacket.Reason original) {
-        if (ModuleAntiExploit.INSTANCE.getEnabled() && original == GameStateChangeS2CPacket.DEMO_MESSAGE_SHOWN && ModuleAntiExploit.INSTANCE.getCancelDemo()) {
+        if (ModuleAntiExploit.INSTANCE.getRunning() && original == GameStateChangeS2CPacket.DEMO_MESSAGE_SHOWN && ModuleAntiExploit.INSTANCE.getCancelDemo()) {
             ModuleAntiExploit.INSTANCE.notifyAboutExploit("Cancelled demo GUI (just annoying thing)", false);
             return null;
         }
@@ -164,7 +164,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         float j = packet.getYaw();
         float k = packet.getPitch();
 
-        if (!ModuleNoRotateSet.INSTANCE.getEnabled() || MinecraftClient.getInstance().currentScreen instanceof DownloadingTerrainScreen) {
+        if (!ModuleNoRotateSet.INSTANCE.getRunning() || MinecraftClient.getInstance().currentScreen instanceof DownloadingTerrainScreen) {
             return;
         }
 
@@ -196,7 +196,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
     private String handleSendMessage(String content) {
         var result = ModuleBetterChat.INSTANCE.modifyMessage(content);
 
-        if (ModuleDisabler.INSTANCE.getEnabled() && DisablerSpigotSpam.INSTANCE.getEnabled()) {
+        if (ModuleDisabler.INSTANCE.getRunning() && DisablerSpigotSpam.INSTANCE.getEnabled()) {
             return DisablerSpigotSpam.INSTANCE.getMessage() + " " + result;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayerInteractionManager.java
@@ -90,7 +90,7 @@ public class MixinClientPlayerInteractionManager {
 
     @Inject(method = "hasLimitedAttackSpeed", at = @At("HEAD"), cancellable = true)
     private void injectAutoClicker(CallbackInfoReturnable<Boolean> cir) {
-        if (ModuleAutoClicker.INSTANCE.getEnabled() && ModuleAutoClicker.Left.INSTANCE.getEnabled()) {
+        if (ModuleAutoClicker.INSTANCE.getRunning() && ModuleAutoClicker.Left.INSTANCE.getEnabled()) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinHandshakeC2SPacket.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinHandshakeC2SPacket.java
@@ -11,7 +11,7 @@ public class MixinHandshakeC2SPacket {
 
     @ModifyExpressionValue(method = "write", at = @At(value = "FIELD", target = "Lnet/minecraft/network/packet/c2s/handshake/HandshakeC2SPacket;address:Ljava/lang/String;"))
     private String modifyAddress(String original) {
-        if (ModuleBungeeSpoofer.INSTANCE.getEnabled()) {
+        if (ModuleBungeeSpoofer.INSTANCE.getRunning()) {
             return ModuleBungeeSpoofer.INSTANCE.modifyHandshakeAddress(original);
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinPlayerInteractBlockC2SPacket.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinPlayerInteractBlockC2SPacket.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinPlayerInteractBlockC2SPacket {
     @Redirect(method = "write", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;writeBlockHitResult(Lnet/minecraft/util/hit/BlockHitResult;)V"))
     private void writeBlockHitResult(PacketByteBuf buf, BlockHitResult hitResult) {
-        if (DisablerVerusScaffoldG.INSTANCE.getEnabled() && DisablerVerusScaffoldG.INSTANCE.isRunning()) {
+        if (DisablerVerusScaffoldG.INSTANCE.getEnabled() && DisablerVerusScaffoldG.INSTANCE.getRunning()) {
             buf.writeBlockPos(hitResult.getBlockPos());
             buf.writeVarInt(6 + hitResult.getSide().ordinal() * 7);
             buf.writeFloat((float) hitResult.getPos().x - hitResult.getBlockPos().getX());

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinBackgroundRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinBackgroundRenderer.java
@@ -45,7 +45,7 @@ public abstract class MixinBackgroundRenderer {
 
             final var module = ModuleAntiBlind.INSTANCE;
 
-            if (!module.getEnabled()) {
+            if (!module.getRunning()) {
                 return true;
             }
 
@@ -57,7 +57,7 @@ public abstract class MixinBackgroundRenderer {
     @Inject(method = "applyFog", at = @At(value = "INVOKE", shift = At.Shift.AFTER, ordinal = 0, target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogStart(F)V", remap = false))
     private static void injectLiquidsFog(Camera camera, FogType fogType, float viewDistance, boolean thickFog, float tickDelta, CallbackInfo callback) {
         ModuleAntiBlind module = ModuleAntiBlind.INSTANCE;
-        if (!module.getEnabled()) {
+        if (!module.getRunning()) {
             return;
         }
 
@@ -78,7 +78,7 @@ public abstract class MixinBackgroundRenderer {
     @Inject(method = "applyFog", at = @At(value = "INVOKE", shift = At.Shift.AFTER, ordinal = 0, target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderFogEnd(F)V", remap = false))
     private static void injectLiquidsFogEnd(Camera camera, FogType fogType, float viewDistance, boolean thickFog, float tickDelta, CallbackInfo info) {
         ModuleAntiBlind module = ModuleAntiBlind.INSTANCE;
-        if (!module.getEnabled()) {
+        if (!module.getRunning()) {
             return;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinBlockEntityRenderDispatcher.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinBlockEntityRenderDispatcher.java
@@ -44,8 +44,8 @@ public class MixinBlockEntityRenderDispatcher {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/entity/BlockEntityRenderer;render(Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;II)V")
     )
     private static void render(BlockEntityRenderer blockEntityRenderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
-        if (ModuleStorageESP.INSTANCE.getEnabled() && ModuleStorageESP.INSTANCE.isRunning()
-                && ModuleStorageESP.Glow.INSTANCE.isActive()) {
+        if (ModuleStorageESP.INSTANCE.getRunning() && ModuleStorageESP.INSTANCE.getRunning()
+                && ModuleStorageESP.Glow.INSTANCE.isSelected()) {
             var outlineVertexConsumerProvider = MinecraftClient.getInstance().getBufferBuilders()
                     .getOutlineVertexConsumers();
             var type = ModuleStorageESP.categorize(blockEntity);

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
@@ -56,8 +56,8 @@ public abstract class MixinCamera {
 
     @Inject(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/Camera;setPos(DDD)V", shift = At.Shift.AFTER), cancellable = true)
     private void modifyCameraOrientation(BlockView area, Entity focusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
-        var freeLook = ModuleFreeLook.INSTANCE.getEnabled();
-        var qps = ModuleQuickPerspectiveSwap.INSTANCE.getEnabled();
+        var freeLook = ModuleFreeLook.INSTANCE.getRunning();
+        var qps = ModuleQuickPerspectiveSwap.INSTANCE.getRunning();
         var rearView = qps && ModuleQuickPerspectiveSwap.INSTANCE.getRearView() && !freeLook && !thirdPerson;
 
         if (freeLook || qps) {
@@ -72,7 +72,7 @@ public abstract class MixinCamera {
             }
 
             float scale = focusedEntity instanceof LivingEntity livingEntity ? livingEntity.getScale() : 1.0F;
-            float desiredCameraDistance = ModuleCameraClip.INSTANCE.getEnabled() ? ModuleCameraClip.INSTANCE.getDistance() : 4f;
+            float desiredCameraDistance = ModuleCameraClip.INSTANCE.getRunning() ? ModuleCameraClip.INSTANCE.getDistance() : 4f;
 
             if (!rearView) {
                 moveBy(-clipToSpace(desiredCameraDistance * scale), 0.0f, 0.0f);
@@ -87,7 +87,7 @@ public abstract class MixinCamera {
         var previousRotation = RotationManager.INSTANCE.getPreviousRotation();
         var currentRotation = RotationManager.INSTANCE.getCurrentRotation();
 
-        boolean shouldModifyRotation = ModuleRotations.INSTANCE.getEnabled() && ModuleRotations.INSTANCE.getCamera()
+        boolean shouldModifyRotation = ModuleRotations.INSTANCE.getRunning() && ModuleRotations.INSTANCE.getCamera()
             || aimPlan != null && aimPlan.getChangeLook();
 
         if (currentRotation == null || previousRotation == null || !shouldModifyRotation) {
@@ -107,11 +107,11 @@ public abstract class MixinCamera {
 
     @ModifyConstant(method = "clipToSpace", constant = @Constant(intValue = 8))
     private int hookCameraClip(int constant) {
-        return ModuleCameraClip.INSTANCE.getEnabled() ? 0 : constant;
+        return ModuleCameraClip.INSTANCE.getRunning() ? 0 : constant;
     }
 
     @ModifyExpressionValue(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/Camera;clipToSpace(F)F"))
     private float modifyDesiredCameraDistance(float original) {
-        return ModuleCameraClip.INSTANCE.getEnabled() ? clipToSpace(ModuleCameraClip.INSTANCE.getDistance()) : original;
+        return ModuleCameraClip.INSTANCE.getRunning() ? clipToSpace(ModuleCameraClip.INSTANCE.getDistance()) : original;
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinChunkOcclusionDataBuilder.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinChunkOcclusionDataBuilder.java
@@ -30,7 +30,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinChunkOcclusionDataBuilder {
     @Inject(method = "markClosed", at = @At("HEAD"), cancellable = true)
     private void onMarkClosed(BlockPos pos, CallbackInfo cir) {
-        if(ModuleXRay.INSTANCE.getEnabled()) {
+        if(ModuleXRay.INSTANCE.getRunning()) {
             cir.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinEntityRenderDispatcher.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinEntityRenderDispatcher.java
@@ -45,7 +45,7 @@ public abstract class MixinEntityRenderDispatcher {
     @ModifyArg(method = "renderHitbox", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;drawBox(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;Lnet/minecraft/util/math/Box;FFFF)V", ordinal = 0), index = 2, require = 1, allow = 1)
     private static Box updateBoundingBox(Box box) {
         var moduleHitBox = ModuleHitbox.INSTANCE;
-        if (moduleHitBox.getEnabled() && CombatExtensionsKt.shouldBeAttacked(entity, CombatExtensionsKt.getCombatTargetsConfigurable())) {
+        if (moduleHitBox.getRunning() && CombatExtensionsKt.shouldBeAttacked(entity, CombatExtensionsKt.getCombatTargetsConfigurable())) {
             return box.expand(moduleHitBox.getSize());
         }
         return box;

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinEntityRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinEntityRenderer.java
@@ -54,7 +54,7 @@ public abstract class MixinEntityRenderer<T extends Entity> {
 
     @Inject(method = "shouldRender", at = @At("HEAD"), cancellable = true)
     private void shouldRender(T entity, Frustum frustum, double x, double y, double z, CallbackInfoReturnable<Boolean> cir) {
-        if (ModuleCombineMobs.INSTANCE.getEnabled() && ModuleCombineMobs.INSTANCE.trackEntity(entity)) {
+        if (ModuleCombineMobs.INSTANCE.getRunning() && ModuleCombineMobs.INSTANCE.trackEntity(entity)) {
             cir.setReturnValue(false);
         }
     }
@@ -100,7 +100,7 @@ public abstract class MixinEntityRenderer<T extends Entity> {
     @Inject(method = "renderLabelIfPresent", at = @At("HEAD"), cancellable = true)
     private void disableDuplicateNametagsAndInjectMobOwners(T entity, Text text, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, float tickDelta, CallbackInfo ci) {
         // Don't render nametags
-        if (ModuleNametags.INSTANCE.getEnabled() && ModuleNametags.shouldRenderNametag(entity)) {
+        if (ModuleNametags.INSTANCE.getRunning() && ModuleNametags.shouldRenderNametag(entity)) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
@@ -114,12 +114,12 @@ public abstract class MixinGameRenderer {
 
         var rotation = (RotationManager.INSTANCE.getCurrentRotation() != null) ?
                 RotationManager.INSTANCE.getCurrentRotation() :
-                ModuleFreeCam.INSTANCE.getEnabled() ?
+                ModuleFreeCam.INSTANCE.getRunning() ?
                         RotationManager.INSTANCE.getServerRotation() :
                         new Rotation(camera.getYaw(tickDelta), camera.getPitch(tickDelta), true);
 
         return RaytracingExtensionsKt.raycast(rotation, Math.max(blockInteractionRange, entityInteractionRange),
-                ModuleLiquidPlace.INSTANCE.getEnabled(), tickDelta);
+                ModuleLiquidPlace.INSTANCE.getRunning(), tickDelta);
     }
 
     @ModifyExpressionValue(method = "findCrosshairTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getRotationVec(F)Lnet/minecraft/util/math/Vec3d;"))
@@ -157,19 +157,19 @@ public abstract class MixinGameRenderer {
 
     @Inject(method = "tiltViewWhenHurt", at = @At("HEAD"), cancellable = true)
     private void injectHurtCam(MatrixStack matrixStack, float f, CallbackInfo callbackInfo) {
-        if (ModuleNoHurtCam.INSTANCE.getEnabled()) {
+        if (ModuleNoHurtCam.INSTANCE.getRunning()) {
             callbackInfo.cancel();
         }
     }
 
     @Inject(method = "bobView", at = @At("HEAD"), cancellable = true)
     private void injectBobView(MatrixStack matrixStack, float f, CallbackInfo callbackInfo) {
-        if (ModuleNoBob.INSTANCE.getEnabled() || ModuleTracers.INSTANCE.getEnabled()) {
+        if (ModuleNoBob.INSTANCE.getRunning() || ModuleTracers.INSTANCE.getRunning()) {
             callbackInfo.cancel();
             return;
         }
 
-        if (!ModuleDankBobbing.INSTANCE.getEnabled()) {
+        if (!ModuleDankBobbing.INSTANCE.getRunning()) {
             return;
         }
 
@@ -248,7 +248,7 @@ public abstract class MixinGameRenderer {
 
     @Inject(method = "showFloatingItem", at = @At("HEAD"), cancellable = true)
     private void hookShowFloatingItem(ItemStack floatingItem, CallbackInfo ci) {
-        if (ModuleAntiBlind.INSTANCE.getEnabled() && ModuleAntiBlind.INSTANCE.getFloatingItems()) {
+        if (ModuleAntiBlind.INSTANCE.getRunning() && ModuleAntiBlind.INSTANCE.getFloatingItems()) {
             ci.cancel();
         }
     }
@@ -262,13 +262,13 @@ public abstract class MixinGameRenderer {
     private int hookGetFov(int original) {
         int result;
 
-        if (ModuleZoom.INSTANCE.getEnabled()) {
+        if (ModuleZoom.INSTANCE.getRunning()) {
             return ModuleZoom.INSTANCE.getFov(true, 0);
         } else {
             result = ModuleZoom.INSTANCE.getFov(false, original);
         }
 
-        if (ModuleNoFov.INSTANCE.getEnabled() && result == original) {
+        if (ModuleNoFov.INSTANCE.getRunning() && result == original) {
             return ModuleNoFov.INSTANCE.getFov(result);
         }
 
@@ -278,7 +278,7 @@ public abstract class MixinGameRenderer {
     @Inject(method = "renderNausea", at = @At("HEAD"), cancellable = true)
     private void hookNauseaOverlay(DrawContext context, float distortionStrength, CallbackInfo ci) {
         var antiBlind = ModuleAntiBlind.INSTANCE;
-        if (antiBlind.getEnabled() && antiBlind.getAntiNausea()) {
+        if (antiBlind.getRunning() && antiBlind.getAntiNausea()) {
             ci.cancel();
         }
     }
@@ -286,7 +286,7 @@ public abstract class MixinGameRenderer {
     @ModifyExpressionValue(method = "renderWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F"))
     private float hookNausea(float original) {
         var antiBlind = ModuleAntiBlind.INSTANCE;
-        if (antiBlind.getEnabled() && antiBlind.getAntiNausea()) {
+        if (antiBlind.getRunning() && antiBlind.getAntiNausea()) {
             return 0f;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInGameOverlayRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInGameOverlayRenderer.java
@@ -38,13 +38,13 @@ public abstract class MixinInGameOverlayRenderer {
         return vertexConsumer.color(red,
                 green,
                 blue,
-                ModuleAntiBlind.INSTANCE.getEnabled() ? ModuleAntiBlind.INSTANCE.getFireOpacity() * alpha : alpha);
+                ModuleAntiBlind.INSTANCE.getRunning() ? ModuleAntiBlind.INSTANCE.getFireOpacity() * alpha : alpha);
     }
 
     @Inject(method = "renderInWallOverlay", at = @At("HEAD"), cancellable = true)
     private static void hookWallOverlay(Sprite sprite, MatrixStack matrices, CallbackInfo ci) {
         var antiBlind = ModuleAntiBlind.INSTANCE;
-        if (antiBlind.getEnabled() && antiBlind.getWallOverlay()) {
+        if (antiBlind.getRunning() && antiBlind.getWallOverlay()) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLightmapTextureManager.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLightmapTextureManager.java
@@ -67,13 +67,13 @@ public abstract class MixinLightmapTextureManager implements LightmapTextureMana
     @ModifyExpressionValue(method = "update(F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;", ordinal = 1))
     private Object injectXRayFullBright(Object original) {
         // If fullBright is enabled, we need to return our own gamma value
-        if (ModuleFullBright.INSTANCE.getEnabled() && ModuleFullBright.FullBrightGamma.INSTANCE.isActive()) {
+        if (ModuleFullBright.INSTANCE.getRunning() && ModuleFullBright.FullBrightGamma.INSTANCE.isSelected()) {
             return ModuleFullBright.FullBrightGamma.INSTANCE.getGamma();
         }
 
         // Xray fullbright
         final ModuleXRay module = ModuleXRay.INSTANCE;
-        if (!module.getEnabled() || !module.getFullBright()) {
+        if (!module.getRunning() || !module.getFullBright()) {
             return original;
         }
 
@@ -84,7 +84,7 @@ public abstract class MixinLightmapTextureManager implements LightmapTextureMana
 
     @Inject(method = "update(F)V", at = @At(value = "HEAD"))
     private void hookBlendTextureColors(float delta, CallbackInfo ci) {
-        if (!dirty && ModuleCustomAmbience.INSTANCE.getEnabled() && ModuleCustomAmbience.CustomLightColor.INSTANCE.getEnabled()) {
+        if (!dirty && ModuleCustomAmbience.INSTANCE.getRunning() && ModuleCustomAmbience.CustomLightColor.INSTANCE.getEnabled()) {
             liquid_bounce$dirty = true;
             liquid_bounce$currentIndex = 0;
             for (int y = 0; y < 16; y++) {
@@ -99,7 +99,7 @@ public abstract class MixinLightmapTextureManager implements LightmapTextureMana
 
     @Inject(method = "update(F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/GameOptions;getDarknessEffectScale()Lnet/minecraft/client/option/SimpleOption;"))
     private void hookResetIndex(float delta, CallbackInfo ci) {
-        if (ModuleCustomAmbience.INSTANCE.getEnabled() && ModuleCustomAmbience.CustomLightColor.INSTANCE.getEnabled()) {
+        if (ModuleCustomAmbience.INSTANCE.getRunning() && ModuleCustomAmbience.CustomLightColor.INSTANCE.getEnabled()) {
             liquid_bounce$dirty = true;
             liquid_bounce$currentIndex = 0;
         }
@@ -137,7 +137,7 @@ public abstract class MixinLightmapTextureManager implements LightmapTextureMana
     private StatusEffectInstance injectAntiDarkness(ClientPlayerEntity instance, RegistryEntry<StatusEffect> registryEntry) {
         final var module = ModuleAntiBlind.INSTANCE;
 
-        if (module.getEnabled() && module.getAntiDarkness()) {
+        if (module.getRunning() && module.getAntiDarkness()) {
             return null;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLivingEntityRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinLivingEntityRenderer.java
@@ -79,8 +79,8 @@ public class MixinLivingEntityRenderer<T extends LivingEntity> {
     @ModifyExpressionValue(method = "render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isInvisibleTo(Lnet/minecraft/entity/player/PlayerEntity;)Z"))
     private boolean injectTrueSight(boolean original, T livingEntity) {
         // Check if TrueSight is enabled and entities are enabled or ESP is enabled and in glow mode
-        if (ModuleTrueSight.INSTANCE.getEnabled() && ModuleTrueSight.INSTANCE.getEntities() ||
-                ModuleESP.INSTANCE.getEnabled() && ModuleESP.INSTANCE.requiresTrueSight(livingEntity)) {
+        if (ModuleTrueSight.INSTANCE.getRunning() && ModuleTrueSight.INSTANCE.getEntities() ||
+                ModuleESP.INSTANCE.getRunning() && ModuleESP.INSTANCE.requiresTrueSight(livingEntity)) {
             return false;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinSignText.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinSignText.java
@@ -36,7 +36,7 @@ public class MixinSignText {
 
     @Inject(method = "getOrderedMessages", at = @At("HEAD"), cancellable = true)
     private void injectNoSignRender(boolean filtered, Function<Text, OrderedText> messageOrderer, CallbackInfoReturnable<OrderedText[]> cir) {
-        if (ModuleNoSignRender.INSTANCE.getEnabled()) {
+        if (ModuleNoSignRender.INSTANCE.getRunning()) {
             var signText = new OrderedText[4];
             Arrays.fill(signText, OrderedText.EMPTY);
             cir.setReturnValue(signText);

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinTextRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinTextRenderer.java
@@ -39,7 +39,7 @@ public abstract class MixinTextRenderer {
 
     @Redirect(method = "drawLayer(Lnet/minecraft/text/OrderedText;FFIZLorg/joml/Matrix4f;Lnet/minecraft/client/render/VertexConsumerProvider;Lnet/minecraft/client/font/TextRenderer$TextLayerType;II)F", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/OrderedText;accept(Lnet/minecraft/text/CharacterVisitor;)Z"))
     private boolean injectNameProtectB(OrderedText orderedText, CharacterVisitor visitor) {
-        if (ModuleNameProtect.INSTANCE.getEnabled()) {
+        if (ModuleNameProtect.INSTANCE.getRunning()) {
             final OrderedText wrapped = new ModuleNameProtect.NameProtectOrderedText(orderedText);
             return wrapped.accept(visitor);
         }
@@ -49,7 +49,7 @@ public abstract class MixinTextRenderer {
 
     @ModifyArg(method = "getWidth(Ljava/lang/String;)I", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/font/TextHandler;getWidth(Ljava/lang/String;)F"), index = 0)
     private @Nullable String injectNameProtectWidthA(@Nullable String text) {
-        if (text != null && ModuleNameProtect.INSTANCE.getEnabled()) {
+        if (text != null && ModuleNameProtect.INSTANCE.getRunning()) {
             return ModuleNameProtect.INSTANCE.replace(text);
         }
 
@@ -60,7 +60,7 @@ public abstract class MixinTextRenderer {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/font/TextHandler;getWidth(Lnet/minecraft/text/OrderedText;)F"),
             index = 0)
     private OrderedText injectNameProtectWidthB(OrderedText text) {
-        if (ModuleNameProtect.INSTANCE.getEnabled()) {
+        if (ModuleNameProtect.INSTANCE.getRunning()) {
             return new ModuleNameProtect.NameProtectOrderedText(text);
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
@@ -110,10 +110,10 @@ public abstract class MixinWorldRenderer {
 
         Color4b color;
 
-        if (ModuleESP.INSTANCE.getEnabled() && ModuleESP.OutlineMode.INSTANCE.isActive() &&
+        if (ModuleESP.INSTANCE.getRunning() && ModuleESP.OutlineMode.INSTANCE.isSelected() &&
                 entity instanceof LivingEntity && CombatExtensionsKt.shouldBeShown(entity)) {
             color = ModuleESP.INSTANCE.getColor((LivingEntity) entity);
-        } else if (ModuleItemESP.INSTANCE.getEnabled() && ModuleItemESP.OutlineMode.INSTANCE.isActive()
+        } else if (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.OutlineMode.INSTANCE.isSelected()
                 && ModuleItemESP.INSTANCE.shouldRender(entity)) {
             color = ModuleItemESP.INSTANCE.getColor();
         } else {
@@ -142,7 +142,7 @@ public abstract class MixinWorldRenderer {
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;draw()V"))
     private void onDrawOutlines(RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
-        if (!ModuleESP.INSTANCE.getEnabled() || !ModuleESP.OutlineMode.INSTANCE.isActive()) {
+        if (!ModuleESP.INSTANCE.getRunning() || !ModuleESP.OutlineMode.INSTANCE.isSelected()) {
             return;
         }
 
@@ -161,7 +161,7 @@ public abstract class MixinWorldRenderer {
 
     @Inject(method = "renderEntity", at = @At("HEAD"))
     private void injectChamsForEntity(Entity entity, double cameraX, double cameraY, double cameraZ, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, CallbackInfo ci) {
-        if (ModuleChams.INSTANCE.getEnabled() && CombatExtensionsKt.getCombatTargetsConfigurable().shouldShow(entity)) {
+        if (ModuleChams.INSTANCE.getRunning() && CombatExtensionsKt.getCombatTargetsConfigurable().shouldShow(entity)) {
             glEnable(GL_POLYGON_OFFSET_FILL);
             glPolygonOffset(1f, -1000000F);
 
@@ -171,7 +171,7 @@ public abstract class MixinWorldRenderer {
 
     @Inject(method = "renderEntity", at = @At("RETURN"))
     private void injectChamsForEntityPost(Entity entity, double cameraX, double cameraY, double cameraZ, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, CallbackInfo ci) {
-        if (ModuleChams.INSTANCE.getEnabled() && CombatExtensionsKt.getCombatTargetsConfigurable().shouldShow(entity) && this.isRenderingChams) {
+        if (ModuleChams.INSTANCE.getRunning() && CombatExtensionsKt.getCombatTargetsConfigurable().shouldShow(entity) && this.isRenderingChams) {
             glPolygonOffset(1f, 1000000F);
             glDisable(GL_POLYGON_OFFSET_FILL);
 
@@ -196,18 +196,18 @@ public abstract class MixinWorldRenderer {
      */
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"))
     private boolean injectHasOutline(MinecraftClient instance, Entity entity) {
-        if (ModuleItemESP.INSTANCE.getEnabled() && ModuleItemESP.GlowMode.INSTANCE.isActive() && ModuleItemESP.INSTANCE.shouldRender(entity)) {
+        if (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.GlowMode.INSTANCE.isSelected() && ModuleItemESP.INSTANCE.shouldRender(entity)) {
             return true;
         }
-        if (ModuleESP.INSTANCE.getEnabled() && ModuleESP.GlowMode.INSTANCE.isActive() && CombatExtensionsKt.shouldBeShown(entity)) {
+        if (ModuleESP.INSTANCE.getRunning() && ModuleESP.GlowMode.INSTANCE.isSelected() && CombatExtensionsKt.shouldBeShown(entity)) {
             return true;
         }
-        if (ModuleTNTTimer.INSTANCE.getEnabled() && ModuleTNTTimer.INSTANCE.getEsp() && entity instanceof TntEntity) {
+        if (ModuleTNTTimer.INSTANCE.getRunning() && ModuleTNTTimer.INSTANCE.getEsp() && entity instanceof TntEntity) {
             return true;
         }
 
-        if (ModuleStorageESP.INSTANCE.getEnabled() && ModuleStorageESP.INSTANCE.isRunning() &&
-                ModuleStorageESP.Glow.INSTANCE.isActive() && ModuleStorageESP.categorize(entity) != null) {
+        if (ModuleStorageESP.INSTANCE.getRunning() && ModuleStorageESP.INSTANCE.getRunning() &&
+                ModuleStorageESP.Glow.INSTANCE.isSelected() && ModuleStorageESP.categorize(entity) != null) {
             return true;
         }
 
@@ -221,24 +221,24 @@ public abstract class MixinWorldRenderer {
      */
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getTeamColorValue()I"))
     private int injectTeamColor(Entity instance) {
-        if (ModuleItemESP.INSTANCE.getEnabled() && ModuleItemESP.GlowMode.INSTANCE.isActive() && ModuleItemESP.INSTANCE.shouldRender(instance)) {
+        if (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.GlowMode.INSTANCE.isSelected() && ModuleItemESP.INSTANCE.shouldRender(instance)) {
             return ModuleItemESP.INSTANCE.getColor().toARGB();
         }
 
-        if (instance instanceof TntEntity && ModuleTNTTimer.INSTANCE.getEnabled() && ModuleTNTTimer.INSTANCE.getEsp()) {
+        if (instance instanceof TntEntity && ModuleTNTTimer.INSTANCE.getRunning() && ModuleTNTTimer.INSTANCE.getEsp()) {
             return ModuleTNTTimer.INSTANCE.getTntColor(((TntEntity) instance).getFuse()).toARGB();
         }
 
-        if (ModuleStorageESP.INSTANCE.getEnabled() && ModuleStorageESP.INSTANCE.isRunning()
-                && ModuleStorageESP.Glow.INSTANCE.isActive()) {
+        if (ModuleStorageESP.INSTANCE.getRunning() && ModuleStorageESP.INSTANCE.getRunning()
+                && ModuleStorageESP.Glow.INSTANCE.isSelected()) {
             var categorizedEntity = ModuleStorageESP.categorize(instance);
             if (categorizedEntity != null) {
                 return categorizedEntity.getColor().toARGB();
             }
         }
 
-        if (instance instanceof LivingEntity && ModuleESP.INSTANCE.getEnabled()
-                && ModuleESP.GlowMode.INSTANCE.isActive()) {
+        if (instance instanceof LivingEntity && ModuleESP.INSTANCE.getRunning()
+                && ModuleESP.GlowMode.INSTANCE.isSelected()) {
             final Color4b color = ModuleESP.INSTANCE.getColor((LivingEntity) instance);
             return color.toARGB();
         }
@@ -281,14 +281,14 @@ public abstract class MixinWorldRenderer {
 
     @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;setupTerrain(Lnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/Frustum;ZZ)V"), index = 3)
     private boolean renderSetupTerrainModifyArg(boolean spectator) {
-        return ModuleFreeCam.INSTANCE.getEnabled() || spectator;
+        return ModuleFreeCam.INSTANCE.getRunning() || spectator;
     }
 
     @ModifyExpressionValue(method = "renderWeather", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/biome/Biome;getPrecipitation(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/biome/Biome$Precipitation;"))
     private Biome.Precipitation modifyBiomePrecipitation(Biome.Precipitation original) {
         var moduleOverrideWeather = ModuleCustomAmbience.INSTANCE;
 
-        if (moduleOverrideWeather.getEnabled() && moduleOverrideWeather.getWeather().get() == ModuleCustomAmbience.WeatherType.SNOWY) {
+        if (moduleOverrideWeather.getRunning() && moduleOverrideWeather.getWeather().get() == ModuleCustomAmbience.WeatherType.SNOWY) {
             return Biome.Precipitation.SNOW;
         }
 
@@ -299,7 +299,7 @@ public abstract class MixinWorldRenderer {
     private float removeRainSplashing(float original) {
         var moduleOverrideWeather = ModuleCustomAmbience.INSTANCE;
 
-        if (moduleOverrideWeather.getEnabled() && moduleOverrideWeather.getWeather().get() == ModuleCustomAmbience.WeatherType.SNOWY) {
+        if (moduleOverrideWeather.getRunning() && moduleOverrideWeather.getWeather().get() == ModuleCustomAmbience.WeatherType.SNOWY) {
             return 0f;
         }
 
@@ -325,7 +325,7 @@ public abstract class MixinWorldRenderer {
         //		float blue,
         //		float alpha
 
-        if (!ModuleBlockOutline.INSTANCE.getEnabled()) {
+        if (!ModuleBlockOutline.INSTANCE.getRunning()) {
             return;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/sodium/MixinSodiumBlockOcclusionCache.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/sodium/MixinSodiumBlockOcclusionCache.java
@@ -38,7 +38,7 @@ public class MixinSodiumBlockOcclusionCache {
     @Inject(method = "shouldDrawSide", at = @At("RETURN"), cancellable = true)
     private void injectXRay(BlockState selfState, BlockView view, BlockPos pos, Direction facing, CallbackInfoReturnable<Boolean> cir) {
         ModuleXRay module = ModuleXRay.INSTANCE;
-        if (!module.getEnabled()) {
+        if (!module.getRunning()) {
             return;
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/sodium/MixinSodiumLightDataAccessMixin.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/sodium/MixinSodiumLightDataAccessMixin.java
@@ -50,7 +50,7 @@ public class MixinSodiumLightDataAccessMixin {
     @ModifyVariable(method = "compute", at = @At(value = "TAIL"), name = "bl")
     private int modifyLightLevel(int original) {
         var xray = ModuleXRay.INSTANCE;
-        if (xray.getEnabled() && xray.getFullBright()) {
+        if (xray.getRunning() && xray.getFullBright()) {
             var blockState = level.getBlockState(pos);
 
             if (xray.shouldRender(blockState, pos)) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.api.oauth.ClientAccountManager
 import net.ccbluex.liquidbounce.api.oauth.OAuthClient
 import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.ClientStartEvent
@@ -42,7 +42,7 @@ import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.misc.proxy.ProxyManager
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.modules.client.ipcConfiguration
-import net.ccbluex.liquidbounce.integration.IntegrationHandler
+import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.integration.browser.BrowserManager
 import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.ActiveServerList
@@ -80,7 +80,7 @@ import kotlin.time.measureTime
  *
  * @author kawaiinekololis (@team CCBlueX)
  */
-object LiquidBounce : EventHandler {
+object LiquidBounce : EventListener {
 
     /**
      * CLIENT INFORMATION
@@ -181,7 +181,7 @@ object LiquidBounce : EventHandler {
             // Initialize browser
             logger.info("Refresh Rate: ${mc.window.refreshRate} Hz")
 
-            IntegrationHandler
+            IntegrationListener
             BrowserManager.initBrowser()
 
             // Register resource reloader

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -27,8 +27,8 @@ import net.ccbluex.liquidbounce.api.oauth.ClientAccountManager
 import net.ccbluex.liquidbounce.api.oauth.OAuthClient
 import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.ConfigSystem
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.ClientStartEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -80,7 +80,7 @@ import kotlin.time.measureTime
  *
  * @author kawaiinekololis (@team CCBlueX)
  */
-object LiquidBounce : Listenable {
+object LiquidBounce : EventHandler {
 
     /**
      * CLIENT INFORMATION

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.DynamicConfigurable
 import net.ccbluex.liquidbounce.config.types.Value
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -179,7 +179,7 @@ object ConfigSystem {
      * Deserialize module configurable from a reader
      */
     fun deserializeModuleConfigurable(
-        modules: List<Module>,
+        modules: List<ClientModule>,
         reader: Reader,
         gson: Gson = fileGson
     ) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ConfigurableSerializer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ConfigurableSerializer.kt
@@ -25,7 +25,7 @@ import com.google.gson.JsonSerializer
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import java.lang.reflect.Type
 
 class ConfigurableSerializer(
@@ -83,7 +83,7 @@ class ConfigurableSerializer(
         }
 
         // Might check if value is module
-        if (value is Module) {
+        if (value is ClientModule) {
             /**
              * Do not include modules that are heavily user-personalised
              */

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ChoiceConfigurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ChoiceConfigurable.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.config.types
 
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
 import net.ccbluex.liquidbounce.utils.kotlin.mapArray
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.mapArray
  * Allows to configure and manage modes
  */
 class ChoiceConfigurable<T : Choice>(
-    @Exclude @ProtocolExclude val eventHandler: EventHandler,
+    @Exclude @ProtocolExclude val eventListener: EventListener,
     name: String,
     activeChoiceCallback: (ChoiceConfigurable<T>) -> T,
     choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
@@ -112,7 +112,7 @@ class ChoiceConfigurable<T : Choice>(
 /**
  * A mode is sub-module to separate different bypasses into extra classes
  */
-abstract class Choice(name: String) : Configurable(name), EventHandler, NamedChoice, MinecraftShortcuts {
+abstract class Choice(name: String) : Configurable(name), EventListener, NamedChoice, MinecraftShortcuts {
 
     override val choiceName: String
         get() = this.name
@@ -136,7 +136,7 @@ abstract class Choice(name: String) : Configurable(name), EventHandler, NamedCho
     override val running: Boolean
         get() = super.running && isSelected
 
-    override fun parent() = this.parent.eventHandler
+    override fun parent() = this.parent.eventListener
 
     protected fun <T: Choice> choices(name: String, active: T, choices: Array<T>) =
         choices(this, name, active, choices)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ChoiceConfigurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ChoiceConfigurable.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.config.types
 
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
 import net.ccbluex.liquidbounce.utils.kotlin.mapArray
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.mapArray
  * Allows to configure and manage modes
  */
 class ChoiceConfigurable<T : Choice>(
-    @Exclude @ProtocolExclude val listenable: Listenable,
+    @Exclude @ProtocolExclude val eventHandler: EventHandler,
     name: String,
     activeChoiceCallback: (ChoiceConfigurable<T>) -> T,
     choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
@@ -70,7 +70,7 @@ class ChoiceConfigurable<T : Choice>(
             return
         }
 
-        if (this.activeChoice.isRunning()) {
+        if (this.activeChoice.running) {
             this.activeChoice.disable()
         }
 
@@ -81,7 +81,7 @@ class ChoiceConfigurable<T : Choice>(
             this.activeChoice = it[0] as T
         })
 
-        if (this.activeChoice.isRunning()) {
+        if (this.activeChoice.running) {
             this.activeChoice.enable()
         }
     }
@@ -91,7 +91,7 @@ class ChoiceConfigurable<T : Choice>(
             return
         }
 
-        if (this.activeChoice.isRunning()) {
+        if (this.activeChoice.running) {
             this.activeChoice.disable()
         }
 
@@ -99,7 +99,7 @@ class ChoiceConfigurable<T : Choice>(
             this.activeChoice = it[0] as T
         })
 
-        if (this.activeChoice.isRunning()) {
+        if (this.activeChoice.running) {
             this.activeChoice.enable()
         }
     }
@@ -112,27 +112,31 @@ class ChoiceConfigurable<T : Choice>(
 /**
  * A mode is sub-module to separate different bypasses into extra classes
  */
-abstract class Choice(name: String) : Configurable(name), Listenable, NamedChoice, MinecraftShortcuts {
+abstract class Choice(name: String) : Configurable(name), EventHandler, NamedChoice, MinecraftShortcuts {
 
     override val choiceName: String
         get() = this.name
 
-    val isActive: Boolean
-        get() = this.parent.activeChoice === this
-
     abstract val parent: ChoiceConfigurable<*>
 
-    open fun enable() {}
+    open fun enable() { }
 
-    open fun disable() {}
+    open fun disable() { }
+
+    /**
+     * Check if the choice is selected on the parent.
+     */
+    val isSelected: Boolean
+        get() = this.parent.activeChoice === this
 
     /**
      * We check if the parent is active and if the mode is active, if so
      * we handle the events.
      */
-    override fun isRunning() = super.isRunning() && isActive
+    override val running: Boolean
+        get() = super.running && isSelected
 
-    override fun parent() = this.parent.listenable
+    override fun parent() = this.parent.eventHandler
 
     protected fun <T: Choice> choices(name: String, active: T, choices: Array<T>) =
         choices(this, name, active, choices)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.config.types
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.client.toLowerCamelCase
 import net.ccbluex.liquidbounce.utils.input.InputBind
@@ -144,7 +144,7 @@ open class Configurable(
             if (currentValue is ChoiceConfigurable<*>) {
                 output.add(currentValue)
 
-                currentValue.choices.filter { it.isActive }.forEach {
+                currentValue.choices.filter { it.isSelected }.forEach {
                     it.getContainedValuesRecursivelyInternal(output)
                 }
             }
@@ -244,12 +244,12 @@ open class Configurable(
         ChooseListValue(name, default, choices).apply { this@Configurable.inner.add(this) }
 
     fun <T : Choice> choices(
-        listenable: Listenable,
+        eventHandler: EventHandler,
         name: String,
         active: T,
         choices: Array<T>
     ): ChoiceConfigurable<T> {
-        return ChoiceConfigurable<T>(listenable, name, { active }) { choices }.apply {
+        return ChoiceConfigurable<T>(eventHandler, name, { active }) { choices }.apply {
             this@Configurable.inner.add(this)
             this.base = this@Configurable
         }
@@ -260,23 +260,23 @@ open class Configurable(
         ReplaceWith("choices(listenable, name, activeIndex, choicesCallback)")
     )
     fun <T : Choice> choices(
-        listenable: Listenable,
+        eventHandler: EventHandler,
         name: String,
         activeCallback: (ChoiceConfigurable<T>) -> T,
         choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
     ): ChoiceConfigurable<T> {
-        return ChoiceConfigurable(listenable, name, activeCallback, choicesCallback).apply {
+        return ChoiceConfigurable(eventHandler, name, activeCallback, choicesCallback).apply {
             this@Configurable.inner.add(this)
             this.base = this@Configurable
         }
     }
 
     protected fun <T : Choice> choices(
-        listenable: Listenable,
+        eventHandler: EventHandler,
         name: String,
         activeIndex: Int,
         choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
-    ) = choices(listenable, name, { it.choices[activeIndex] }, choicesCallback)
+    ) = choices(eventHandler, name, { it.choices[activeIndex] }, choicesCallback)
 
     fun value(value: Value<*>) = value.apply { this@Configurable.inner.add(this) }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.config.types
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.client.toLowerCamelCase
 import net.ccbluex.liquidbounce.utils.input.InputBind
@@ -244,12 +244,12 @@ open class Configurable(
         ChooseListValue(name, default, choices).apply { this@Configurable.inner.add(this) }
 
     fun <T : Choice> choices(
-        eventHandler: EventHandler,
+        eventListener: EventListener,
         name: String,
         active: T,
         choices: Array<T>
     ): ChoiceConfigurable<T> {
-        return ChoiceConfigurable<T>(eventHandler, name, { active }) { choices }.apply {
+        return ChoiceConfigurable<T>(eventListener, name, { active }) { choices }.apply {
             this@Configurable.inner.add(this)
             this.base = this@Configurable
         }
@@ -260,23 +260,23 @@ open class Configurable(
         ReplaceWith("choices(listenable, name, activeIndex, choicesCallback)")
     )
     fun <T : Choice> choices(
-        eventHandler: EventHandler,
+        eventListener: EventListener,
         name: String,
         activeCallback: (ChoiceConfigurable<T>) -> T,
         choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
     ): ChoiceConfigurable<T> {
-        return ChoiceConfigurable(eventHandler, name, activeCallback, choicesCallback).apply {
+        return ChoiceConfigurable(eventListener, name, activeCallback, choicesCallback).apply {
             this@Configurable.inner.add(this)
             this.base = this@Configurable
         }
     }
 
     protected fun <T : Choice> choices(
-        eventHandler: EventHandler,
+        eventListener: EventListener,
         name: String,
         activeIndex: Int,
         choicesCallback: (ChoiceConfigurable<T>) -> Array<T>
-    ) = choices(eventHandler, name, { it.choices[activeIndex] }, choicesCallback)
+    ) = choices(eventListener, name, { it.choices[activeIndex] }, choicesCallback)
 
     fun value(value: Value<*>) = value.apply { this@Configurable.inner.add(this) }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ToggleableConfigurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ToggleableConfigurable.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.config.types
 
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
 
@@ -31,10 +31,10 @@ import net.ccbluex.liquidbounce.script.ScriptApiRequired
  * it also features [enable] and [disable] which are called when the state is toggled.
  */
 abstract class ToggleableConfigurable(
-    @Exclude @ProtocolExclude val parent: EventHandler? = null,
+    @Exclude @ProtocolExclude val parent: EventListener? = null,
     name: String,
     enabled: Boolean
-) : EventHandler, Configurable(name, valueType = ValueType.TOGGLEABLE), MinecraftShortcuts {
+) : EventListener, Configurable(name, valueType = ValueType.TOGGLEABLE), MinecraftShortcuts {
 
     // TODO: Make enabled change also call newState
     var enabled by boolean("Enabled", enabled)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ToggleableConfigurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ToggleableConfigurable.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.config.types
 
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
 
@@ -31,10 +31,10 @@ import net.ccbluex.liquidbounce.script.ScriptApiRequired
  * it also features [enable] and [disable] which are called when the state is toggled.
  */
 abstract class ToggleableConfigurable(
-    @Exclude @ProtocolExclude val parent: Listenable? = null,
+    @Exclude @ProtocolExclude val parent: EventHandler? = null,
     name: String,
     enabled: Boolean
-) : Listenable, Configurable(name, valueType = ValueType.TOGGLEABLE), MinecraftShortcuts {
+) : EventHandler, Configurable(name, valueType = ValueType.TOGGLEABLE), MinecraftShortcuts {
 
     // TODO: Make enabled change also call newState
     var enabled by boolean("Enabled", enabled)
@@ -62,7 +62,8 @@ abstract class ToggleableConfigurable(
      * Because we pass the parent to the Listenable, we can simply
      * call the super.handleEvents() and it will return false if the upper-listenable is disabled.
      */
-    override fun isRunning() = super.isRunning() && enabled
+    override val running: Boolean
+        get() = super.running && enabled
 
     override fun parent() = parent
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventHandler.kt
@@ -24,13 +24,13 @@ import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 typealias Handler<T> = (T) -> Unit
 
 class EventHook<T : Event>(
-    val handlerClass: Listenable,
+    val handlerClass: EventHandler,
     val handler: Handler<T>,
-    val ignoreRunning: Boolean,
+    val ignoreNotRunning: Boolean,
     val priority: Int = 0
 )
 
-interface Listenable {
+interface EventHandler {
 
     /**
      * Returns whether the listenable is running or not, this is based on the parent listenable
@@ -39,19 +39,20 @@ interface Listenable {
      * When destructed, the listenable will not handle any events. This is likely to be overridden by
      * the implementing class to provide a toggleable feature.
      *
-     * This can be ignored by handlers when [ignoreRunning] is set to true on the [EventHook].
+     * This can be ignored by handlers when [ignoreNotRunning] is set to true on the [EventHook].
      */
-    fun isRunning(): Boolean = parent()?.isRunning() ?: !isDestructed
+    val running: Boolean
+        get() = parent()?.running ?: !isDestructed
 
     /**
      * Parent listenable
      */
-    fun parent(): Listenable? = null
+    fun parent(): EventHandler? = null
 
     /**
      * Children listenables
      */
-    fun children(): List<Listenable> = emptyList()
+    fun children(): List<EventHandler> = emptyList()
 
     /**
      * Unregisters the event handler from the manager. This decision is FINAL!
@@ -67,43 +68,45 @@ interface Listenable {
 
 }
 
-inline fun <reified T : Event> Listenable.handler(
-    ignoreCondition: Boolean = false,
+inline fun <reified T : Event> EventHandler.handler(
+    ignoreNotRunning: Boolean = false,
     priority: Int = 0,
     noinline handler: Handler<T>
-) {
-    EventManager.registerEventHook(T::class.java, EventHook(this, handler, ignoreCondition, priority))
+): EventHook<T> {
+    return EventManager.registerEventHook(T::class.java,
+        EventHook(this, handler, ignoreNotRunning, priority)
+    )
 }
 
 /**
  * Registers an event hook for events of type [T] and launches a sequence
  */
-inline fun <reified T : Event> Listenable.sequenceHandler(
-    ignoreCondition: Boolean = false,
+inline fun <reified T : Event> EventHandler.sequenceHandler(
+    ignoreNotRunning: Boolean = false,
     priority: Int = 0,
     noinline eventHandler: SuspendableHandler<T>
 ) {
-    handler<T>(ignoreCondition, priority) { event -> Sequence(this, eventHandler, event) }
+    handler<T>(ignoreNotRunning, priority) { event -> Sequence(this, eventHandler, event) }
 }
 
 /**
  * Registers a repeatable sequence which repeats the execution of code on GameTickEvent.
  */
-fun Listenable.repeatable(eventHandler: SuspendableHandler<DummyEvent>) {
+fun EventHandler.tickHandler(eventHandler: SuspendableHandler<DummyEvent>) {
     // We store our sequence in this variable.
     // That can be done because our variable will survive the scope of this function
     // and can be used in the event handler function. This is a very useful pattern to use in Kotlin.
-    var sequence: RepeatingSequence? = RepeatingSequence(this, eventHandler)
+    var sequence: TickSequence? = TickSequence(this, eventHandler)
 
     // Ignore condition makes sense because we do not want our sequence to run after we do not handle events anymore
-    handler<GameTickEvent>(ignoreCondition = true) {
+    handler<GameTickEvent>(ignoreNotRunning = true) {
         // Check if we should start or stop the sequence
-        if (this.isRunning()) {
+        if (this.running) {
             // Check if the sequence is already running
             if (sequence == null) {
                 // If not, start it
                 // This will start a new repeating sequence which will run until the condition is false
-                sequence = RepeatingSequence(this, eventHandler)
+                sequence = TickSequence(this, eventHandler)
             }
         } else if (sequence != null) { // This condition is only true if the sequence is running
             // If the sequence is running, we should stop it

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -24,13 +24,13 @@ import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 typealias Handler<T> = (T) -> Unit
 
 class EventHook<T : Event>(
-    val handlerClass: EventHandler,
+    val handlerClass: EventListener,
     val handler: Handler<T>,
     val ignoreNotRunning: Boolean,
     val priority: Int = 0
 )
 
-interface EventHandler {
+interface EventListener {
 
     /**
      * Returns whether the listenable is running or not, this is based on the parent listenable
@@ -47,12 +47,12 @@ interface EventHandler {
     /**
      * Parent listenable
      */
-    fun parent(): EventHandler? = null
+    fun parent(): EventListener? = null
 
     /**
      * Children listenables
      */
-    fun children(): List<EventHandler> = emptyList()
+    fun children(): List<EventListener> = emptyList()
 
     /**
      * Unregisters the event handler from the manager. This decision is FINAL!
@@ -68,7 +68,7 @@ interface EventHandler {
 
 }
 
-inline fun <reified T : Event> EventHandler.handler(
+inline fun <reified T : Event> EventListener.handler(
     ignoreNotRunning: Boolean = false,
     priority: Int = 0,
     noinline handler: Handler<T>
@@ -81,7 +81,7 @@ inline fun <reified T : Event> EventHandler.handler(
 /**
  * Registers an event hook for events of type [T] and launches a sequence
  */
-inline fun <reified T : Event> EventHandler.sequenceHandler(
+inline fun <reified T : Event> EventListener.sequenceHandler(
     ignoreNotRunning: Boolean = false,
     priority: Int = 0,
     noinline eventHandler: SuspendableHandler<T>
@@ -92,7 +92,7 @@ inline fun <reified T : Event> EventHandler.sequenceHandler(
 /**
  * Registers a repeatable sequence which repeats the execution of code on GameTickEvent.
  */
-fun EventHandler.tickHandler(eventHandler: SuspendableHandler<DummyEvent>) {
+fun EventListener.tickHandler(eventHandler: SuspendableHandler<DummyEvent>) {
     // We store our sequence in this variable.
     // That can be done because our variable will survive the scope of this function
     // and can be used in the event handler function. This is a very useful pattern to use in Kotlin.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -178,9 +178,9 @@ object EventManager {
         registry[eventClass]?.removeAll(hooks.toHashSet())
     }
 
-    fun unregisterEventHandler(eventHandler: EventHandler) {
+    fun unregisterEventHandler(eventListener: EventListener) {
         registry.values.forEach {
-            it.removeIf { it.handlerClass == eventHandler }
+            it.removeIf { it.handlerClass == eventListener }
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -149,7 +149,7 @@ object EventManager {
     /**
      * Used by handler methods
      */
-    fun <T : Event> registerEventHook(eventClass: Class<out Event>, eventHook: EventHook<T>) {
+    fun <T : Event> registerEventHook(eventClass: Class<out Event>, eventHook: EventHook<T>): EventHook<T> {
         val handlers = registry[eventClass]
             ?: error("The event '${eventClass.name}' is not registered in Events.kt::ALL_EVENT_CLASSES.")
 
@@ -160,6 +160,8 @@ object EventManager {
             // `handlers` is sorted descending by EventHook.priority
             handlers.sortedInsert(hook) { -it.priority }
         }
+
+        return eventHook
     }
 
     /**
@@ -176,7 +178,7 @@ object EventManager {
         registry[eventClass]?.removeAll(hooks.toHashSet())
     }
 
-    fun unregisterEventHandler(eventHandler: Listenable) {
+    fun unregisterEventHandler(eventHandler: EventHandler) {
         registry.values.forEach {
             it.removeIf { it.handlerClass == eventHandler }
         }
@@ -199,7 +201,7 @@ object EventManager {
         for (eventHook in target) {
             EventScheduler.process(event)
 
-            if (!eventHook.ignoreRunning && !eventHook.handlerClass.isRunning()) {
+            if (!eventHook.ignoreNotRunning && !eventHook.handlerClass.running) {
                 continue
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
@@ -29,7 +29,7 @@ import kotlin.coroutines.suspendCoroutine
 
 typealias SuspendableHandler<T> = suspend Sequence<T>.(T) -> Unit
 
-object SequenceManager : EventHandler {
+object SequenceManager : EventListener {
 
     // Running sequences
     internal val sequences = Lists.newCopyOnWriteArrayList<Sequence<*>>()
@@ -56,7 +56,7 @@ object SequenceManager : EventHandler {
 
 }
 
-open class Sequence<T : Event>(val owner: EventHandler, val handler: SuspendableHandler<T>, protected val event: T) {
+open class Sequence<T : Event>(val owner: EventListener, val handler: SuspendableHandler<T>, protected val event: T) {
 
     private var coroutine: Job
 
@@ -177,7 +177,7 @@ open class Sequence<T : Event>(val owner: EventHandler, val handler: Suspendable
 
 class DummyEvent : Event()
 
-class TickSequence(owner: EventHandler, handler: SuspendableHandler<DummyEvent>)
+class TickSequence(owner: EventListener, handler: SuspendableHandler<DummyEvent>)
     : Sequence<DummyEvent>(owner, handler, DummyEvent()) {
 
     private var continueLoop = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
@@ -29,7 +29,7 @@ import kotlin.coroutines.suspendCoroutine
 
 typealias SuspendableHandler<T> = suspend Sequence<T>.(T) -> Unit
 
-object SequenceManager : Listenable {
+object SequenceManager : EventHandler {
 
     // Running sequences
     internal val sequences = Lists.newCopyOnWriteArrayList<Sequence<*>>()
@@ -45,7 +45,7 @@ object SequenceManager : Listenable {
     val tickSequences = handler<GameTickEvent>(priority = 1000) {
         for (sequence in sequences) {
             // Prevent modules handling events when not supposed to
-            if (!sequence.owner.isRunning()) {
+            if (!sequence.owner.running) {
                 sequence.cancel()
                 continue
             }
@@ -56,7 +56,7 @@ object SequenceManager : Listenable {
 
 }
 
-open class Sequence<T : Event>(val owner: Listenable, val handler: SuspendableHandler<T>, protected val event: T) {
+open class Sequence<T : Event>(val owner: EventHandler, val handler: SuspendableHandler<T>, protected val event: T) {
 
     private var coroutine: Job
 
@@ -82,7 +82,7 @@ open class Sequence<T : Event>(val owner: Listenable, val handler: SuspendableHa
     }
 
     internal open suspend fun coroutineRun() {
-        if (owner.isRunning()) {
+        if (owner.running) {
             runCatching {
                 handler(event)
             }.onFailure {
@@ -177,7 +177,7 @@ open class Sequence<T : Event>(val owner: Listenable, val handler: SuspendableHa
 
 class DummyEvent : Event()
 
-class RepeatingSequence(owner: Listenable, handler: SuspendableHandler<DummyEvent>)
+class TickSequence(owner: EventHandler, handler: SuspendableHandler<DummyEvent>)
     : Sequence<DummyEvent>(owner, handler, DummyEvent()) {
 
     private var continueLoop = true
@@ -185,7 +185,7 @@ class RepeatingSequence(owner: Listenable, handler: SuspendableHandler<DummyEven
     override suspend fun coroutineRun() {
         sync()
 
-        while (continueLoop && owner.isRunning()) {
+        while (continueLoop && owner.running) {
             super.coroutineRun()
             sync()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
@@ -22,7 +22,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.authlib.account.AlteningAccount
 import net.ccbluex.liquidbounce.authlib.account.CrackedAccount
 import net.ccbluex.liquidbounce.authlib.account.MicrosoftAccount
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.AccountManager
@@ -34,7 +34,7 @@ import net.minecraft.client.network.ServerAddress
 import net.minecraft.client.network.ServerInfo
 import org.apache.commons.lang3.RandomStringUtils
 
-object Reconnect : Listenable {
+object Reconnect : EventHandler {
 
     private var lastServer: ServerInfo? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
@@ -22,7 +22,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.authlib.account.AlteningAccount
 import net.ccbluex.liquidbounce.authlib.account.CrackedAccount
 import net.ccbluex.liquidbounce.authlib.account.MicrosoftAccount
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.AccountManager
@@ -34,7 +34,7 @@ import net.minecraft.client.network.ServerAddress
 import net.minecraft.client.network.ServerInfo
 import org.apache.commons.lang3.RandomStringUtils
 
-object Reconnect : EventHandler {
+object Reconnect : EventListener {
 
     private var lastServer: ServerInfo? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -22,7 +22,7 @@ import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.ChatSendEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.commands.client.*
@@ -50,7 +50,7 @@ class CommandException(val text: MutableText, cause: Throwable? = null, val usag
  * Links minecraft with the command engine
  */
 
-object CommandExecutor : Listenable {
+object CommandExecutor : EventHandler {
 
     /**
      * Handles command execution

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -22,7 +22,7 @@ import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.ChatSendEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.commands.client.*
@@ -50,7 +50,7 @@ class CommandException(val text: MutableText, cause: Throwable? = null, val usag
  * Links minecraft with the command engine
  */
 
-object CommandExecutor : EventHandler {
+object CommandExecutor : EventListener {
 
     /**
      * Handles command execution

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterBuilder.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.features.command.AutoCompletionHandler
 import net.ccbluex.liquidbounce.features.command.Parameter
 import net.ccbluex.liquidbounce.features.command.ParameterValidationResult
 import net.ccbluex.liquidbounce.features.command.ParameterVerifier
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.mc
 
@@ -36,7 +36,7 @@ class ParameterBuilder<T> private constructor(val name: String) {
 
     companion object {
         val STRING_VALIDATOR: ParameterVerifier<String> = { ParameterValidationResult.ok(it) }
-        val MODULE_VALIDATOR: ParameterVerifier<Module> = { name ->
+        val MODULE_VALIDATOR: ParameterVerifier<ClientModule> = { name ->
             val mod = ModuleManager.find { it.name.equals(name, true) }
 
             if (mod == null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/Parameters.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/Parameters.kt
@@ -19,9 +19,8 @@
 
 package net.ccbluex.liquidbounce.features.command.builder
 
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
-import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.world
 import net.minecraft.registry.Registries
 import net.minecraft.registry.RegistryKeys
@@ -70,7 +69,7 @@ fun pageParameter(name: String = "page"): ParameterBuilder<Int> {
         .verifiedBy(ParameterBuilder.POSITIVE_INTEGER_VALIDATOR)
 }
 
-fun moduleParameter(name: String = "module", validator: (Module) -> Boolean = { true }): ParameterBuilder<String> {
+fun moduleParameter(name: String = "module", validator: (ClientModule) -> Boolean = { true }): ParameterBuilder<String> {
     return ParameterBuilder
         .begin<String>(name)
         .verifiedBy(ParameterBuilder.STRING_VALIDATOR)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandCenter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandCenter.kt
@@ -18,8 +18,8 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.client
 
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventState
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.Command
@@ -33,7 +33,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
  *
  * Centers you at your current position.
  */
-object CommandCenter : Listenable {
+object CommandCenter : EventHandler {
 
     var state = CenterHandlerState.INACTIVE
 
@@ -59,7 +59,8 @@ object CommandCenter : Listenable {
             state = CenterHandlerState.INACTIVE
         }
 
-    override fun isRunning() = super.isRunning() && inGame && state == CenterHandlerState.APPLY_ON_NEXT_EVENT
+    override val running: Boolean
+        get() = super.running && inGame && state == CenterHandlerState.APPLY_ON_NEXT_EVENT
 
     enum class CenterHandlerState {
         INACTIVE,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandCenter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandCenter.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.client
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -33,7 +33,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
  *
  * Centers you at your current position.
  */
-object CommandCenter : EventHandler {
+object CommandCenter : EventListener {
 
     var state = CenterHandlerState.INACTIVE
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandClient.kt
@@ -37,8 +37,8 @@ import net.ccbluex.liquidbounce.features.misc.HideAppearance.wipeClient
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleHud
 import net.ccbluex.liquidbounce.integration.BrowserScreen
-import net.ccbluex.liquidbounce.integration.IntegrationHandler
-import net.ccbluex.liquidbounce.integration.IntegrationHandler.clientJcef
+import net.ccbluex.liquidbounce.integration.IntegrationListener
+import net.ccbluex.liquidbounce.integration.IntegrationListener.clientJcef
 import net.ccbluex.liquidbounce.integration.VirtualScreenType
 import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.liquidbounce.integration.theme.component.ComponentOverlay
@@ -191,7 +191,7 @@ object CommandClient {
         ).subcommand(CommandBuilder.begin("reset")
             .handler { command, args ->
                 chat(regular("Resetting client JCEF browser..."))
-                IntegrationHandler.updateIntegrationBrowser()
+                IntegrationListener.updateIntegrationBrowser()
             }.build()
         )
         .build()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandConfig.kt
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
 import net.ccbluex.liquidbounce.features.command.builder.moduleParameter
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.io.HttpClient.get
@@ -184,7 +184,7 @@ object CommandConfig {
             .build()
     }
 
-    fun autoComplete(begin: String, validator: (Module) -> Boolean = { true }): List<String> {
+    fun autoComplete(begin: String, validator: (ClientModule) -> Boolean = { true }): List<String> {
         return configsCache?.map { it.settingId }?.filter { it.startsWith(begin, true) } ?: emptyList()
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandDebug.kt
@@ -139,7 +139,7 @@ object CommandDebug {
         addProperty("config", autoConfigPaste)
 
         add("activeModules", JsonArray().apply {
-            ModuleManager.filter { it.enabled }.forEach { module ->
+            ModuleManager.filter { it.running }.forEach { module ->
                 add(JsonPrimitive(module.name))
             }
         })

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.gson.publicGson
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
@@ -153,7 +153,7 @@ object CommandLocalConfig {
             .build()
     }
 
-    private fun autoComplete(begin: String, validator: (Module) -> Boolean = { true }): List<String> {
+    private fun autoComplete(begin: String, validator: (ClientModule) -> Boolean = { true }): List<String> {
         return ConfigSystem.userConfigsFolder.listFiles()?.map { it.nameWithoutExtension }
             ?.filter { it.startsWith(begin) } ?: emptyList()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandPanic.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandPanic.kt
@@ -48,7 +48,7 @@ object CommandPanic {
                     .build()
             )
             .handler { command, args ->
-                var modules = ModuleManager.filter { it.enabled }
+                var modules = ModuleManager.filter { it.running }
                 val msg: MutableText
 
                 when (val type = args.getOrNull(0) as String? ?: "nonrender") {
@@ -68,7 +68,9 @@ object CommandPanic {
 
                 AutoConfig.loadingNow = true
                 runCatching {
-                    modules.forEach { it.enabled = false }
+                    for (module in modules) {
+                        module.enabled = false
+                    }
                 }.onSuccess {
                     AutoConfig.loadingNow = false
                     chat(regular(msg))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandToggle.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandToggle.kt
@@ -48,7 +48,7 @@ object CommandToggle {
                 val module = ModuleManager.find { it.name.equals(name, true) }
                     ?: throw CommandException(command.result("moduleNotFound", name))
 
-                val newState = !module.enabled
+                val newState = !module.running
                 module.enabled = newState
                 chat(
                     regular(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandValue.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandValue.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandException
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleClickGui
 import net.ccbluex.liquidbounce.utils.client.chat
@@ -40,7 +40,7 @@ object CommandValue {
             .begin("value")
             .parameter(
                 ParameterBuilder
-                    .begin<Module>("moduleName")
+                    .begin<ClientModule>("moduleName")
                     .verifiedBy(ParameterBuilder.MODULE_VALIDATOR)
                     .autocompletedWith(ModuleManager::autoComplete)
                     .required()
@@ -70,7 +70,7 @@ object CommandValue {
                     .build()
             )
             .handler { command, args ->
-                val module = args[0] as Module
+                val module = args[0] as ClientModule
                 val valueName = args[1] as String
                 val valueString = args[2] as String
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/fakeplayer/CommandFakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/fakeplayer/CommandFakePlayer.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.command.commands.client.fakeplayer
 
 import com.mojang.authlib.GameProfile
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -44,7 +44,7 @@ import java.util.*
  *
  * Allows you to spawn a client side player for testing purposes.
  */
-object CommandFakePlayer : Listenable {
+object CommandFakePlayer : EventHandler {
 
     /**
      * Stores all fake players.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/fakeplayer/CommandFakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/fakeplayer/CommandFakePlayer.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.command.commands.client.fakeplayer
 
 import com.mojang.authlib.GameProfile
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -44,7 +44,7 @@ import java.util.*
  *
  * Allows you to spawn a client side player for testing purposes.
  */
-object CommandFakePlayer : EventHandler {
+object CommandFakePlayer : EventListener {
 
     /**
      * Stores all fake players.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CosmeticService.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CosmeticService.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.api.oauth.ClientAccountManager
 import net.ccbluex.liquidbounce.api.oauth.OAuthClient
 import net.ccbluex.liquidbounce.config.gson.util.decode
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.SessionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -48,7 +48,7 @@ import kotlin.concurrent.thread
  * shown immediately when account switches, but we can reduce the stress
  * on the API and the connection of the user.
  */
-object CosmeticService : Listenable, Configurable("Cosmetics") {
+object CosmeticService : EventHandler, Configurable("Cosmetics") {
 
     private const val COSMETICS_API = "$API_V3_ENDPOINT/cosmetics"
     private const val CARRIERS_URL = "$COSMETICS_API/carriers"
@@ -194,7 +194,7 @@ object CosmeticService : Listenable, Configurable("Cosmetics") {
     }
 
     @Suppress("unused")
-    private val sessionHandler = handler<SessionEvent>(ignoreCondition = true) { event ->
+    private val sessionHandler = handler<SessionEvent>(ignoreNotRunning = true) { event ->
         val session = event.session
 
         // Check if the account is valid

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CosmeticService.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CosmeticService.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.api.oauth.ClientAccountManager
 import net.ccbluex.liquidbounce.api.oauth.OAuthClient
 import net.ccbluex.liquidbounce.config.gson.util.decode
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.SessionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -48,7 +48,7 @@ import kotlin.concurrent.thread
  * shown immediately when account switches, but we can reduce the stress
  * on the API and the connection of the user.
  */
-object CosmeticService : EventHandler, Configurable("Cosmetics") {
+object CosmeticService : EventListener, Configurable("Cosmetics") {
 
     private const val COSMETICS_API = "$API_V3_ENDPOINT/cosmetics"
     private const val CARRIERS_URL = "$COSMETICS_API/carriers"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/fakelag/FakeLag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/fakelag/FakeLag.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.fakelag
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleFakeLag
@@ -67,7 +67,7 @@ import net.minecraft.util.math.Vec3d
  *
  * Simulates lag by holding back packets.
  */
-object FakeLag : EventHandler {
+object FakeLag : EventListener {
 
     /**
      * Whether we are lagging.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/fakelag/FakeLag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/fakelag/FakeLag.kt
@@ -18,13 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.fakelag
 
-import net.ccbluex.liquidbounce.event.Listenable
-import net.ccbluex.liquidbounce.event.events.PacketEvent
-import net.ccbluex.liquidbounce.event.events.TransferOrigin
-import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
-import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
+import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleFakeLag
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.AutoBlock
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleClickTp
@@ -45,7 +41,10 @@ import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.Vec3
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withColor
-import net.ccbluex.liquidbounce.utils.client.*
+import net.ccbluex.liquidbounce.utils.client.inGame
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.client.sendPacketSilently
+import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.entity.RigidPlayerSimulation
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.ccbluex.liquidbounce.utils.kotlin.mapArray
@@ -68,7 +67,7 @@ import net.minecraft.util.math.Vec3d
  *
  * Simulates lag by holding back packets.
  */
-object FakeLag : Listenable {
+object FakeLag : EventHandler {
 
     /**
      * Whether we are lagging.
@@ -92,7 +91,7 @@ object FakeLag : Listenable {
         }
 
         @Suppress("ComplexCondition")
-        if (ModuleBlink.enabled || AntiVoidBlinkMode.requiresLag || ModuleFakeLag.shouldLag(packet)
+        if (ModuleBlink.running || AntiVoidBlinkMode.requiresLag || ModuleFakeLag.shouldLag(packet)
             || NoFallBlink.shouldLag() || ModuleInventoryMove.Blink.shouldLag() || ModuleClickTp.requiresLag
             || FlyNcpClip.shouldLag || ScaffoldBlinkFeature.shouldBlink || FlyVerusB3869Flat.requiresLag
             || AutoBlock.shouldBlink || ModuleStep.BlocksMC.stepping
@@ -114,9 +113,10 @@ object FakeLag : Listenable {
     val packetQueue = LinkedHashSet<DelayData>()
     val positions = LinkedHashSet<PositionData>()
 
-    val repeatable = repeatable {
+    @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
         if (!inGame) {
-            return@repeatable
+            return@handler
         }
 
         if (shouldLag(null, TransferOrigin.SEND) == null) {
@@ -124,7 +124,8 @@ object FakeLag : Listenable {
         }
     }
 
-    val packetHandler = handler<PacketEvent>(priority = EventPriorityConvention.READ_FINAL_STATE) { event ->
+    @Suppress("unused")
+    private val packetHandler = handler<PacketEvent>(priority = EventPriorityConvention.READ_FINAL_STATE) { event ->
         // Ignore packets that are already cancelled, as they are already handled
         if (event.isCancelled || !inGame) {
             return@handler
@@ -203,6 +204,7 @@ object FakeLag : Listenable {
         }
     }
 
+    @Suppress("unused")
     val worldChangeHandler = handler<WorldChangeEvent> {
         // Clear packets on disconnect
         if (it.world == null) {
@@ -210,6 +212,7 @@ object FakeLag : Listenable {
         }
     }
 
+    @Suppress("unused")
     val renderHandler = handler<WorldRenderEvent> { event ->
         val matrixStack = event.matrixStack
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/AccountManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/AccountManager.kt
@@ -26,8 +26,8 @@ import net.ccbluex.liquidbounce.authlib.yggdrasil.clientIdentifier
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.AccountManagerAdditionResultEvent
 import net.ccbluex.liquidbounce.event.events.AccountManagerLoginResultEvent
 import net.ccbluex.liquidbounce.event.events.SessionEvent
@@ -39,7 +39,7 @@ import net.minecraft.client.session.Session
 import java.net.Proxy
 import java.util.*
 
-object AccountManager : Configurable("Accounts"), Listenable {
+object AccountManager : Configurable("Accounts"), EventHandler {
 
     val accounts by value(name, mutableListOf<MinecraftAccount>(), listType = ListValueType.Account)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/AccountManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/AccountManager.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.authlib.yggdrasil.clientIdentifier
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.AccountManagerAdditionResultEvent
 import net.ccbluex.liquidbounce.event.events.AccountManagerLoginResultEvent
@@ -39,7 +39,7 @@ import net.minecraft.client.session.Session
 import java.net.Proxy
 import java.util.*
 
-object AccountManager : Configurable("Accounts"), EventHandler {
+object AccountManager : Configurable("Accounts"), EventListener {
 
     val accounts by value(name, mutableListOf<MinecraftAccount>(), listType = ListValueType.Account)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/FriendManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/FriendManager.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.misc
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 import java.util.*
 
-object FriendManager : Configurable("Friends"), Listenable {
+object FriendManager : Configurable("Friends"), EventHandler {
 
     val friends by value(name, TreeSet<Friend>(), listType = ListValueType.Friend)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/FriendManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/FriendManager.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.misc
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 import java.util.*
 
-object FriendManager : Configurable("Friends"), EventHandler {
+object FriendManager : Configurable("Friends"), EventListener {
 
     val friends by value(name, TreeSet<Friend>(), listType = ListValueType.Friend)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -20,14 +20,14 @@ package net.ccbluex.liquidbounce.features.misc
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.EventManager.callEvent
 import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.ModuleManager
-import net.ccbluex.liquidbounce.integration.IntegrationHandler
+import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -43,7 +43,7 @@ import kotlin.concurrent.thread
  *
  * using 2x CRTL + SHIFT to hide and unhide the client
  */
-object HideAppearance : EventHandler {
+object HideAppearance : EventListener {
 
     val shiftChronometer = Chronometer()
 
@@ -56,9 +56,9 @@ object HideAppearance : EventHandler {
 
     private fun updateClient() {
         if (isHidingNow) {
-            IntegrationHandler.restoreOriginalScreen()
+            IntegrationListener.restoreOriginalScreen()
         } else {
-            IntegrationHandler.updateIntegrationBrowser()
+            IntegrationListener.updateIntegrationBrowser()
         }
 
         mc.updateWindowTitle()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -20,9 +20,9 @@ package net.ccbluex.liquidbounce.features.misc
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.ConfigSystem
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.EventManager.callEvent
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -43,7 +43,7 @@ import kotlin.concurrent.thread
  *
  * using 2x CRTL + SHIFT to hide and unhide the client
  */
-object HideAppearance : Listenable {
+object HideAppearance : EventHandler {
 
     val shiftChronometer = Chronometer()
 
@@ -68,7 +68,7 @@ object HideAppearance : Listenable {
     }
 
     @Suppress("unused")
-    val keyHandler = handler<KeyboardKeyEvent>(ignoreCondition = true) {
+    val keyHandler = handler<KeyboardKeyEvent>(ignoreNotRunning = true) {
         val keyCode = it.keyCode
         val modifier = it.mods
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
@@ -24,8 +24,8 @@ import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
 import net.ccbluex.liquidbounce.config.types.ValueType
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.PipelineEvent
 import net.ccbluex.liquidbounce.event.events.ProxyAdditionResultEvent
 import net.ccbluex.liquidbounce.event.events.ProxyCheckResultEvent
@@ -38,7 +38,7 @@ import net.ccbluex.liquidbounce.features.misc.proxy.Proxy.Credentials.Companion.
  *
  * Only supports SOCKS5 proxies.
  */
-object ProxyManager : Configurable("proxy"), Listenable {
+object ProxyManager : Configurable("proxy"), EventHandler {
 
     private val NO_PROXY = Proxy("", 0, null)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyManager.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ListValueType
 import net.ccbluex.liquidbounce.config.types.ValueType
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.PipelineEvent
 import net.ccbluex.liquidbounce.event.events.ProxyAdditionResultEvent
@@ -38,7 +38,7 @@ import net.ccbluex.liquidbounce.features.misc.proxy.Proxy.Credentials.Companion.
  *
  * Only supports SOCKS5 proxies.
  */
-object ProxyManager : Configurable("proxy"), EventHandler {
+object ProxyManager : Configurable("proxy"), EventListener {
 
     private val NO_PROXY = Proxy("", 0, null)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
@@ -8,13 +8,15 @@ import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.timeout.ReadTimeoutHandler
 import net.ccbluex.liquidbounce.api.IpInfoApi
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.convertToString
 import net.ccbluex.liquidbounce.utils.client.logger
-import net.minecraft.client.network.*
+import net.minecraft.client.network.Address
+import net.minecraft.client.network.AllowedAddressResolver
+import net.minecraft.client.network.ServerAddress
 import net.minecraft.network.ClientConnection
 import net.minecraft.network.DisconnectionInfo
 import net.minecraft.network.NetworkSide
@@ -56,7 +58,7 @@ import kotlin.jvm.optionals.getOrNull
 private const val PING_SERVER = "ping.liquidproxy.net"
 private const val PING_TIMEOUT = 5
 
-class ClientConnectionTicker(private val clientConnection: ClientConnection) : Listenable {
+class ClientConnectionTicker(private val clientConnection: ClientConnection) : EventHandler {
     @Suppress("unused")
     private val tickHandler = handler<GameTickEvent> {
         clientConnection.tick()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/proxy/ProxyValidator.kt
@@ -8,7 +8,7 @@ import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.timeout.ReadTimeoutHandler
 import net.ccbluex.liquidbounce.api.IpInfoApi
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -58,7 +58,7 @@ import kotlin.jvm.optionals.getOrNull
 private const val PING_SERVER = "ping.liquidproxy.net"
 private const val PING_TIMEOUT = 5
 
-class ClientConnectionTicker(private val clientConnection: ClientConnection) : EventHandler {
+class ClientConnectionTicker(private val clientConnection: ClientConnection) : EventListener {
     @Suppress("unused")
     private val tickHandler = handler<GameTickEvent> {
         clientConnection.tick()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.AutoConfig.loadingNow
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.types.*
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
@@ -51,7 +51,7 @@ open class ClientModule(
     hide: Boolean = false, // default hide
     @Exclude val disableOnQuit: Boolean = false, // disables module when player leaves the world,
     @Exclude val aliases: Array<out String> = emptyArray() // additional names under which the module is known
-) : EventHandler, Configurable(name), MinecraftShortcuts {
+) : EventListener, Configurable(name), MinecraftShortcuts {
 
     /**
      * Option to enable or disable the module, this DOES NOT mean the module is running. This

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -22,11 +22,10 @@ import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.AutoConfig.loadingNow
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.types.*
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.ccbluex.liquidbounce.lang.LanguageManager
 import net.ccbluex.liquidbounce.lang.translation
@@ -42,7 +41,7 @@ import net.minecraft.client.util.InputUtil
  * A module also called 'hack' can be enabled and handle events
  */
 @Suppress("LongParameterList")
-open class Module(
+open class ClientModule(
     name: String, // name parameter in configurable
     @Exclude val category: Category, // module category
     bind: Int = InputUtil.UNKNOWN_KEY.code, // default bind
@@ -52,9 +51,13 @@ open class Module(
     hide: Boolean = false, // default hide
     @Exclude val disableOnQuit: Boolean = false, // disables module when player leaves the world,
     @Exclude val aliases: Array<out String> = emptyArray() // additional names under which the module is known
-) : Listenable, Configurable(name), MinecraftShortcuts {
+) : EventHandler, Configurable(name), MinecraftShortcuts {
 
-    val valueEnabled = boolean("Enabled", state).also {
+    /**
+     * Option to enable or disable the module, this DOES NOT mean the module is running. This
+     * should be checked with [running] instead. Only use this for toggling the module!
+     */
+    var enabled by boolean("Enabled", state).also {
         // Might not include the enabled state of the module depending on the category
         if (category == Category.MISC || category == Category.FUN || category == Category.RENDER) {
             if (this is ModuleAntiBot) {
@@ -63,12 +66,7 @@ open class Module(
 
             it.doNotIncludeAlways()
         }
-    }.notAnOption()
-
-    private var calledSinceStartup = false
-
-    // Module options
-    var enabled by valueEnabled.onChange { new ->
+    }.notAnOption().onChange { new ->
         // Check if the module is locked
         locked?.let { locked ->
             if (locked.get()) {
@@ -130,6 +128,12 @@ open class Module(
         new
     }
 
+    /**
+     * If the module is running and in game. Can be overridden to add additional checks.
+     */
+    override val running: Boolean
+        get() = super.running && inGame && enabled
+
     val bind by bind("Bind", InputBind(InputUtil.Type.KEYSYM, bind, bindAction))
         .doNotIncludeWhen { !AutoConfig.includeConfiguration.includeBinds }
         .independentDescription()
@@ -161,6 +165,8 @@ open class Module(
     @ScriptApiRequired
     open val settings by lazy { inner.associateBy { it.name } }
 
+    private var calledSinceStartup = false
+
     /**
      * Called when module is turned on
      */
@@ -177,22 +183,17 @@ open class Module(
     open fun init() {}
 
     /**
-     * Events should be handled when module is enabled
-     */
-    override fun isRunning() = enabled && inGame && !isDestructed
-
-    /**
      * Handles disconnect and if [disableOnQuit] is true disables module
      */
     @Suppress("unused")
-    val onDisconnect = handler<DisconnectEvent>(ignoreCondition = true) {
+    val onDisconnect = handler<DisconnectEvent>(ignoreNotRunning = true) {
         if (enabled && disableOnQuit) {
             enabled = false
         }
     }
 
     @Suppress("unused")
-    val onWorldChange = handler<WorldChangeEvent>(ignoreCondition = true) {
+    val onWorldChange = handler<WorldChangeEvent>(ignoreNotRunning = true) {
         if (enabled && !calledSinceStartup && it.world != null) {
             calledSinceStartup = true
             enable()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module
 
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
@@ -89,12 +89,12 @@ import org.lwjgl.glfw.GLFW
 /**
  * Should be sorted by Module::name
  */
-private val modules = ArrayList<Module>(256)
+private val modules = ArrayList<ClientModule>(256)
 
 /**
  * A fairly simple module manager
  */
-object ModuleManager : Listenable, Iterable<Module> by modules {
+object ModuleManager : EventHandler, Iterable<ClientModule> by modules {
 
     val modulesConfigurable = ConfigSystem.root("modules", modules)
 
@@ -128,7 +128,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
             GLFW.GLFW_PRESS -> if (mc.currentScreen == null) {
                 filter { m -> m.bind.matchesMouse(event.button) }
                     .forEach { m ->
-                        m.enabled = !m.enabled || m.bind.action == InputBind.BindAction.HOLD
+                        m.enabled = !m.running || m.bind.action == InputBind.BindAction.HOLD
                     }
             }
             GLFW.GLFW_RELEASE ->
@@ -368,14 +368,14 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
         }
     }
 
-    private fun addModule(module: Module) {
+    private fun addModule(module: ClientModule) {
         module.initConfigurable()
         module.init()
-        modules.sortedInsert(module, Module::name)
+        modules.sortedInsert(module, ClientModule::name)
     }
 
-    private fun removeModule(module: Module) {
-        if (module.enabled) {
+    private fun removeModule(module: ClientModule) {
+        if (module.running) {
             module.disable()
         }
         module.unregister()
@@ -385,19 +385,19 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
     /**
      * Allow `ModuleManager += Module` syntax
      */
-    operator fun plusAssign(module: Module) {
+    operator fun plusAssign(module: ClientModule) {
         addModule(module)
     }
 
-    operator fun plusAssign(modules: Iterable<Module>) {
+    operator fun plusAssign(modules: Iterable<ClientModule>) {
         modules.forEach(this::addModule)
     }
 
-    operator fun minusAssign(module: Module) {
+    operator fun minusAssign(module: ClientModule) {
         removeModule(module)
     }
 
-    operator fun minusAssign(modules: Iterable<Module>) {
+    operator fun minusAssign(modules: Iterable<ClientModule>) {
         modules.forEach(this::removeModule)
     }
 
@@ -405,7 +405,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
         modules.clear()
     }
 
-    fun autoComplete(begin: String, args: List<String>, validator: (Module) -> Boolean = { true }): List<String> {
+    fun autoComplete(begin: String, args: List<String>, validator: (ClientModule) -> Boolean = { true }): List<String> {
         val parts = begin.split(",")
         val matchingPrefix = parts.last()
         val resultPrefix = parts.dropLast(1).joinToString(",") + ","
@@ -419,7 +419,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
             }
     }
 
-    fun parseModulesFromParameter(name: String?): List<Module> {
+    fun parseModulesFromParameter(name: String?): List<ClientModule> {
         if (name == null) return emptyList()
         return name.split(",").mapNotNull { getModuleByName(it) }
     }
@@ -432,7 +432,7 @@ object ModuleManager : Listenable, Iterable<Module> by modules {
     fun getCategories() = Category.entries.mapArray { it.readableName }
 
     @JvmName("getModules")
-    fun getModules(): Iterable<Module> = modules
+    fun getModules(): Iterable<ClientModule> = modules
 
     @JvmName("getModuleByName")
     @ScriptApiRequired

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module
 
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
@@ -94,7 +94,7 @@ private val modules = ArrayList<ClientModule>(256)
 /**
  * A fairly simple module manager
  */
-object ModuleManager : EventHandler, Iterable<ClientModule> by modules {
+object ModuleManager : EventListener, Iterable<ClientModule> by modules {
 
     val modulesConfigurable = ConfigSystem.root("modules", modules)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleAutoConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleAutoConfig.kt
@@ -26,15 +26,16 @@ import net.ccbluex.liquidbounce.config.AutoConfig.configs
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.dropPort
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.rootDomain
 
-object ModuleAutoConfig : Module("AutoConfig", Category.CLIENT, state = true, aliases = arrayOf("AutoSettings")) {
+object ModuleAutoConfig : ClientModule("AutoConfig", Category.CLIENT, state = true, aliases = arrayOf("AutoSettings")) {
 
     private val blacklistedServer = mutableListOf(
         // Common anticheat test server
@@ -68,7 +69,7 @@ object ModuleAutoConfig : Module("AutoConfig", Category.CLIENT, state = true, al
         super.disable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (requiresConfigLoad && inGame && mc.currentScreen == null) {
             enable()
             requiresConfigLoad = false
@@ -113,8 +114,8 @@ object ModuleAutoConfig : Module("AutoConfig", Category.CLIENT, state = true, al
     }
 
     /**
-     * Overwrites the condition requirement for being in game
+     * Overwrites the condition requirement for being in-game
      */
-    override fun isRunning() = enabled
+    override val running = !isDestructed && enabled
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
@@ -23,20 +23,21 @@ package net.ccbluex.liquidbounce.features.module.modules.client
 
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.chat.ChatClient
 import net.ccbluex.liquidbounce.features.chat.packet.ServerRequestJWTPacket
 import net.ccbluex.liquidbounce.features.command.CommandManager
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
+import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.lang.translation
 import net.ccbluex.liquidbounce.utils.client.*
 import net.minecraft.text.Text
 import net.minecraft.util.Formatting
 
-object ModuleLiquidChat : Module("LiquidChat", Category.CLIENT, hide = true, state = true,
+object ModuleLiquidChat : ClientModule("LiquidChat", Category.CLIENT, hide = true, state = true,
     aliases = arrayOf("GlobalChat")) {
 
     private var jwtToken by text("JwtToken", "")
@@ -116,7 +117,7 @@ object ModuleLiquidChat : Module("LiquidChat", Category.CLIENT, hide = true, sta
         super.disable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!chatClient.connected) {
             chatClient.connectAsync()
 
@@ -207,6 +208,9 @@ object ModuleLiquidChat : Module("LiquidChat", Category.CLIENT, hide = true, sta
         }
     }
 
-    override fun isRunning() = enabled
+    /**
+     * Overwrites the condition requirement for being in-game
+     */
+    override val running = !isDestructed && enabled
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
@@ -37,9 +37,9 @@ import net.ccbluex.liquidbounce.config.gson.util.jsonObjectOf
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.hideSensitiveAddress
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -57,7 +57,7 @@ val ipcConfiguration by lazy {
     decode<IpcConfiguration>(HttpClient.get("$CLIENT_CLOUD/discord.json"))
 }
 
-object ModuleRichPresence : Module("RichPresence", Category.CLIENT, state = true, hide = true,
+object ModuleRichPresence : ClientModule("RichPresence", Category.CLIENT, state = true, hide = true,
     aliases = arrayOf("DiscordPresence")) {
 
     private val detailsText by text("Details", "Nextgen v%clientVersion% by %clientAuthor%")
@@ -130,7 +130,7 @@ object ModuleRichPresence : Module("RichPresence", Category.CLIENT, state = true
     }
 
     @Suppress("unused")
-    val updateCycle = repeatable {
+    val updateCycle = tickHandler {
         waitTicks(20)
 
         /**
@@ -189,14 +189,17 @@ object ModuleRichPresence : Module("RichPresence", Category.CLIENT, state = true
         .replace("%clientName%", CLIENT_NAME)
         .replace("%clientBranch%", clientBranch)
         .replace("%clientCommit%", clientCommit)
-        .replace("%enabledModules%", ModuleManager.count { it.enabled }.toString())
+        .replace("%enabledModules%", ModuleManager.count { it.running }.toString())
         .replace("%totalModules%", ModuleManager.count().toString())
         .replace("%protocol%", protocolVersion.let { "${it.name} (${it.version})" })
         .replace("%server%", hideSensitiveAddress(mc.currentServerEntry?.address ?: "none"))
 
-    override fun isRunning() = true
-
     private inline fun IPCClient.sendRichPresence(builderAction: RichPresence.Builder.() -> Unit) =
         sendRichPresence(RichPresence.Builder().apply(builderAction).build())
+
+    /**
+     * Always running
+     */
+    override val running = true
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleTargets.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleTargets.kt
@@ -22,11 +22,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.client
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.combat.combatTargetsConfigurable
 import net.ccbluex.liquidbounce.utils.combat.visualTargetsConfigurable
 
-object ModuleTargets : Module("Targets", Category.CLIENT, disableActivation = true, hide = true,
+object ModuleTargets : ClientModule("Targets", Category.CLIENT, disableActivation = true, hide = true,
     aliases = arrayOf("Enemies")) {
     init {
         tree(combatTargetsConfigurable)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.aiming.*
 import net.ccbluex.liquidbounce.utils.aiming.anglesmooth.AngleSmoothMode
@@ -45,7 +45,7 @@ import net.minecraft.util.math.MathHelper
  *
  * Automatically faces selected entities around you.
  */
-object ModuleAimbot : Module("Aimbot", Category.COMBAT, aliases = arrayOf("AimAssist", "AutoAim")) {
+object ModuleAimbot : ClientModule("Aimbot", Category.COMBAT, aliases = arrayOf("AimAssist", "AutoAim")) {
 
     private val range by float("Range", 4.2f, 1f..8f)
 
@@ -83,7 +83,7 @@ object ModuleAimbot : Module("Aimbot", Category.COMBAT, aliases = arrayOf("AimAs
         }
 
         if (OnClick.enabled && (clickTimer.hasElapsed(OnClick.delayUntilStop * 50L)
-                || !mc.options.attackKey.isPressed && ModuleAutoClicker.enabled)) {
+                || !mc.options.attackKey.isPressed && ModuleAutoClicker.running)) {
             this.targetRotation = null
             return@handler
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoBow.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoBow.kt
@@ -22,9 +22,9 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.renderEnvironmentForGUI
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
@@ -58,7 +58,7 @@ import kotlin.math.*
  * Automatically shoots with your bow when it's fully charged
  *  + and make it possible to shoot faster
  */
-object ModuleAutoBow : Module("AutoBow", Category.COMBAT, aliases = arrayOf("BowAssist", "BowAimbot")) {
+object ModuleAutoBow : ClientModule("AutoBow", Category.COMBAT, aliases = arrayOf("BowAssist", "BowAimbot")) {
     const val ACCELERATION = -0.006
     const val REAL_ACCELERATION = -0.005
 
@@ -228,13 +228,13 @@ object ModuleAutoBow : Module("AutoBow", Category.COMBAT, aliases = arrayOf("Bow
         private val targetRenderer = tree(OverlayTargetRenderer(ModuleAutoBow))
 
         @Suppress("unused")
-        val tickRepeatable = repeatable {
+        val tickRepeatable = tickHandler {
             targetTracker.cleanup()
 
             // Should check if player is using bow
             val activeItem = player.activeItem?.item
             if (activeItem !is BowItem && activeItem !is TridentItem) {
-                return@repeatable
+                return@tickHandler
             }
 
             val eyePos = player.eyes
@@ -250,7 +250,7 @@ object ModuleAutoBow : Module("AutoBow", Category.COMBAT, aliases = arrayOf("Bow
             }
 
             if (rotation == null) {
-                return@repeatable
+                return@tickHandler
             }
 
             RotationManager.aimAt(
@@ -432,21 +432,21 @@ object ModuleAutoBow : Module("AutoBow", Category.COMBAT, aliases = arrayOf("Bow
         private val packetType by enumChoice("PacketType", MovePacketType.FULL)
 
         @Suppress("unused")
-        val tickRepeatable = repeatable {
+        val tickRepeatable = tickHandler {
             val currentItem = player.activeItem
 
             // Should accelerated game ticks when using bow
             if (currentItem?.item is BowItem) {
                 if (notInTheAir && !player.isOnGround) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 if (notDuringMove && player.moving) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 if (notDuringRegeneration && player.hasStatusEffect(StatusEffects.REGENERATION)) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 repeat(speed) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -21,9 +21,9 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.Sequence
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.combat.ClickScheduler
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.minecraft.client.option.KeyBinding
@@ -39,7 +39,7 @@ import net.minecraft.util.hit.EntityHitResult
  * Clicks automatically when holding down a mouse button.
  */
 
-object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arrayOf("TriggerBot")) {
+object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases = arrayOf("TriggerBot")) {
 
     object Left : ToggleableConfigurable(this, "Attack", true) {
 
@@ -140,7 +140,7 @@ object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arra
     val use: Boolean
         get() = mc.options.useKey.isPressed || Right.requiresNoInput
 
-    val tickHandler = repeatable {
+    val tickHandler = tickHandler {
         Left.run {
             if (!enabled || !attack || !isWeaponSelected() || !isOnObjective()) {
                 return@run
@@ -156,7 +156,7 @@ object ModuleAutoClicker : Module("AutoClicker", Category.COMBAT, aliases = arra
                 val encounterItemUse = encounterItemUse()
 
                 if (encounterItemUse) {
-                    return@repeatable
+                    return@tickHandler
                 }
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoLeave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoLeave.kt
@@ -18,9 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleKick
 
 /**
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleKick
  *
  * Automatically makes you leave the server whenever your health is low.
  */
-object ModuleAutoLeave : Module("AutoLeave", Category.COMBAT) {
+object ModuleAutoLeave : ClientModule("AutoLeave", Category.COMBAT) {
 
     private val health by float("Health", 8f, 0f..20f)
 
@@ -36,7 +36,7 @@ object ModuleAutoLeave : Module("AutoLeave", Category.COMBAT) {
     private val mode by enumChoice("Mode", ModuleKick.KickModeEnum.QUIT)
 
     @Suppress("unused")
-    val tickRepeatable = repeatable {
+    val tickRepeatable = tickHandler {
         if (player.health <= health && !player.abilities.creativeMode && !mc.isIntegratedServerRunning) {
             // Delay to bypass anti cheat or combat log detections
             waitTicks(delay)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -23,10 +23,10 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.AttackEvent
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemCategorization
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.WeaponItemFacet
@@ -43,7 +43,7 @@ import net.minecraft.item.SwordItem
  *
  * Automatically selects the best weapon in your hotbar
  */
-object ModuleAutoWeapon : Module("AutoWeapon", Category.COMBAT) {
+object ModuleAutoWeapon : ClientModule("AutoWeapon", Category.COMBAT) {
 
     private val slotMode = choices("SlotMode", BestSlotMode, arrayOf(
         BestSlotMode,
@@ -58,12 +58,12 @@ object ModuleAutoWeapon : Module("AutoWeapon", Category.COMBAT) {
         private val range by float("Range", 4.2f, 1f..8f)
 
         @Suppress("unused")
-        private val prepareHandler = repeatable {
-            val enemy = world.findEnemy(0f..range) ?: return@repeatable
+        private val prepareHandler = tickHandler {
+            val enemy = world.findEnemy(0f..range) ?: return@tickHandler
 
             SilentHotbar.selectSlotSilently(
                 this,
-                determineWeaponSlot(enemy) ?: return@repeatable,
+                determineWeaponSlot(enemy) ?: return@tickHandler,
                 resetDelay
             )
         }
@@ -128,7 +128,7 @@ object ModuleAutoWeapon : Module("AutoWeapon", Category.COMBAT) {
             }
         }
 
-        return if (BestSlotMode.isActive) {
+        return if (BestSlotMode.isSelected) {
             val bestSlot = itemMap
                 .filter(BestSlotMode.weaponType.filter)
                 .maxOrNull()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleBacktrack.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleBacktrack.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.fakelag.DelayData
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.drawSolidBox
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
@@ -49,7 +49,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 
-object ModuleBacktrack : Module("Backtrack", Category.COMBAT) {
+object ModuleBacktrack : ClientModule("Backtrack", Category.COMBAT) {
 
     private val range by floatRange("Range", 1f..3f, 0f..10f)
     private val delay by intRange("Delay", 100..150, 0..1000, "ms")
@@ -328,7 +328,7 @@ object ModuleBacktrack : Module("Backtrack", Category.COMBAT) {
             !shouldPause()
     }
 
-    fun isLagging() = enabled && packetQueue.isNotEmpty()
+    fun isLagging() = running && packetQueue.isNotEmpty()
 
     private fun shouldPause() = pauseOnHit && shouldPause
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleHitbox.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleHitbox.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 import net.ccbluex.liquidbounce.event.events.EntityMarginEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 
 /**
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
  *
  * Enlarges the hitbox of other entities.
  */
-object ModuleHitbox : Module("Hitbox", Category.COMBAT) {
+object ModuleHitbox : ClientModule("Hitbox", Category.COMBAT) {
 
     val size by float("Size", 0.4f, 0f..1f).apply { tagBy(this) }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKeepSprint.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKeepSprint.kt
@@ -22,13 +22,13 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.kotlin.random
 
 /**
  * When hitting an entity, the player will keep sprinting
  */
-object ModuleKeepSprint : Module("KeepSprint", Category.COMBAT) {
+object ModuleKeepSprint : ClientModule("KeepSprint", Category.COMBAT) {
     private val motion by floatRange("Motion", 100f..100f, 0f..100f, "%")
 
     fun getMotion(): Double {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleMaceKill.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleMaceKill.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.warp
 import net.minecraft.item.Items
 import net.minecraft.util.shape.VoxelShapes
@@ -31,7 +31,7 @@ import kotlin.math.ceil
 /**
  * Makes the mace powerful by faking fall height.
  */
-object ModuleMaceKill : Module("MaceKill", Category.COMBAT) {
+object ModuleMaceKill : ClientModule("MaceKill", Category.COMBAT) {
 
     private val fallHeight by int("FallHeight", 22, 1..170).apply { tagBy(this) }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleNoMissCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleNoMissCooldown.kt
@@ -1,9 +1,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
-object ModuleNoMissCooldown : Module("NoMissCooldown", Category.COMBAT) {
+object ModuleNoMissCooldown : ClientModule("NoMissCooldown", Category.COMBAT) {
 
     /**
      * Disables the miss-cooldown of 10 ticks when missing an attack.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSuperKnockback.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSuperKnockback.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.math.minus
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
@@ -37,7 +37,7 @@ import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
  *
  * Increases knockback dealt to other entities.
  */
-object ModuleSuperKnockback : Module("SuperKnockback", Category.COMBAT, aliases = arrayOf("WTap")) {
+object ModuleSuperKnockback : ClientModule("SuperKnockback", Category.COMBAT, aliases = arrayOf("WTap")) {
 
     val modes = choices("Mode", Packet, arrayOf(Packet, SprintTap, WTap)).apply(::tagBy)
     val hurtTime by int("HurtTime", 10, 0..10)
@@ -63,16 +63,17 @@ object ModuleSuperKnockback : Module("SuperKnockback", Category.COMBAT, aliases 
         }
     }
 
-    override fun isRunning(): Boolean {
-        val handleEvents = super.isRunning()
+    override val running: Boolean
+        get() {
+            val running = super.running
 
-        // Reset if the module is not handling events anymore
-        if (!handleEvents) {
-            reset()
+            // Reset if the module is not handling events anymore
+            if (!running) {
+                reset()
+            }
+
+            return running
         }
-
-        return handleEvents
-    }
 
     object Packet : Choice("Packet") {
         override val parent: ChoiceConfigurable<Choice>
@@ -154,9 +155,9 @@ object ModuleSuperKnockback : Module("SuperKnockback", Category.COMBAT, aliases 
         }
     }
 
-    fun shouldBlockSprinting() = enabled && SprintTap.isActive && SprintTap.antiSprint
+    fun shouldBlockSprinting() = running && SprintTap.isSelected && SprintTap.antiSprint
 
-    fun shouldStopMoving() = enabled && WTap.isActive && WTap.stopMoving
+    fun shouldStopMoving() = running && WTap.isSelected && WTap.stopMoving
 
     private fun shouldStopSprinting(event: AttackEvent): Boolean {
         val enemy = event.enemy

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSwordBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSwordBlock.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.AutoBlock
 import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
 import net.minecraft.entity.player.PlayerEntity
@@ -34,7 +34,7 @@ import net.minecraft.util.Hand
 /**
  * This module allows the user to block with swords. This makes sense to be used on servers with ViaVersion.
  */
-object ModuleSwordBlock : Module("SwordBlock", Category.COMBAT, aliases = arrayOf("OldBlocking")) {
+object ModuleSwordBlock : ClientModule("SwordBlock", Category.COMBAT, aliases = arrayOf("OldBlocking")) {
 
     val onlyVisual by boolean("OnlyVisual", false)
     val hideShieldSlot by boolean("HideShieldSlot", false).doNotIncludeAlways()
@@ -45,8 +45,8 @@ object ModuleSwordBlock : Module("SwordBlock", Category.COMBAT, aliases = arrayO
         player: PlayerEntity = this.player,
         offHandItem: Item = player.offHandStack.item,
         mainHandItem: Item = player.mainHandStack.item,
-    ) = (isRunning() || AutoBlock.blockVisual) && offHandItem is ShieldItem
-        && (mainHandItem is SwordItem || player === this.player && isRunning() && alwaysHideShield)
+    ) = (running || AutoBlock.blockVisual) && offHandItem is ShieldItem
+        && (mainHandItem is SwordItem || player === this.player && running && alwaysHideShield)
 
     @Suppress("UNUSED")
     private val packetHandler = sequenceHandler<PacketEvent> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.render.drawLineStrip
@@ -42,7 +42,7 @@ import kotlin.math.min
  *
  * Calls tick function to speed up, when needed
  */
-internal object ModuleTickBase : Module("TickBase", Category.COMBAT) {
+internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
 
     /**
      * The range defines where we want to tickbase into. The first value is the minimum range, which we can
@@ -70,7 +70,7 @@ internal object ModuleTickBase : Module("TickBase", Category.COMBAT) {
     @Suppress("unused")
     private val tickHandler = handler<PlayerTickEvent> {
         // We do not want this module to conflict with blink
-        if (player.vehicle != null || ModuleBlink.enabled) {
+        if (player.vehicle != null || ModuleBlink.running) {
             return@handler
         }
 
@@ -84,7 +84,7 @@ internal object ModuleTickBase : Module("TickBase", Category.COMBAT) {
     @Suppress("unused")
     private val postTickHandler = sequenceHandler<PlayerPostTickEvent> {
         // We do not want this module to conflict with blink
-        if (player.vehicle != null || ModuleBlink.enabled || duringTickModification) {
+        if (player.vehicle != null || ModuleBlink.running || duringTickModification) {
             return@sequenceHandler
         }
 
@@ -124,7 +124,7 @@ internal object ModuleTickBase : Module("TickBase", Category.COMBAT) {
         }
 
         // We do not want to tickbase if killaura is not ready to attack
-        if (requiresKillAura && !(ModuleKillAura.enabled &&
+        if (requiresKillAura && !(ModuleKillAura.running &&
                 ModuleKillAura.clickScheduler.isClickOnNextTick(bestTick))) {
             return@sequenceHandler
         }
@@ -147,7 +147,7 @@ internal object ModuleTickBase : Module("TickBase", Category.COMBAT) {
     @Suppress("unused")
     private val inputHandler = handler<MovementInputEvent> { event ->
         // We do not want this module to conflict with blink
-        if (player.vehicle != null || ModuleBlink.enabled) {
+        if (player.vehicle != null || ModuleBlink.running) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTimerRange.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTimerRange.kt
@@ -20,9 +20,9 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.client.Timer.timerSpeed
 import net.ccbluex.liquidbounce.utils.combat.findEnemy
@@ -35,7 +35,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  * Automatically speeds up when you are near an enemy.
  */
 
-object ModuleTimerRange : Module("TimerRange", Category.COMBAT) {
+object ModuleTimerRange : ClientModule("TimerRange", Category.COMBAT) {
 
     private val timerBalanceLimit by float("TimerBalanceLimit", 20f, 0f..50f)
     private val normalSpeed by float("NormalSpeed", 0.9F, 0.1F..10F)
@@ -55,7 +55,7 @@ object ModuleTimerRange : Module("TimerRange", Category.COMBAT) {
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val newTimerSpeed = updateTimerSpeed()
 
         if (newTimerSpeed != null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ArmorItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemSlot
@@ -36,7 +36,7 @@ import net.minecraft.item.Items
  *
  * Automatically put on the best armor.
  */
-object ModuleAutoArmor : Module("AutoArmor", Category.COMBAT) {
+object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
 
     private val inventoryConstraints = tree(PlayerInventoryConstraints())
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalAuraSpeedDebugger.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import java.util.concurrent.ConcurrentLinkedDeque
 
@@ -31,7 +31,7 @@ object CrystalAuraSpeedDebugger : CrystalPostAttackTracker() {
     private var cps = ConcurrentLinkedDeque<Long>()
 
     @Suppress("unused")
-    val repeatable1 = repeatable {
+    val repeatable1 = tickHandler {
         val currentTime = System.currentTimeMillis()
         val cpsTime = currentTime - 1000L
         while (cps.isNotEmpty()) {
@@ -53,6 +53,6 @@ object CrystalAuraSpeedDebugger : CrystalPostAttackTracker() {
         attackedIds.clear()
     }
 
-    override fun isRunning() = ModuleCrystalAura.isRunning() && ModuleDebug.enabled
+    override val running = ModuleCrystalAura.running && ModuleDebug.running
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
 import it.unimi.dsi.fastutil.ints.Int2LongLinkedOpenHashMap
 import it.unimi.dsi.fastutil.ints.Int2LongMaps
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -32,7 +32,7 @@ import net.minecraft.sound.SoundEvents
 /**
  * Can be implemented to handle actions after crystals got attacked.
  */
-abstract class CrystalPostAttackTracker : EventHandler {
+abstract class CrystalPostAttackTracker : EventListener {
 
     protected val attackedIds: MutableMap<Int, Long> = Int2LongMaps.synchronize(Int2LongLinkedOpenHashMap())
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/CrystalPostAttackTracker.kt
@@ -20,11 +20,11 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
 import it.unimi.dsi.fastutil.ints.Int2LongLinkedOpenHashMap
 import it.unimi.dsi.fastutil.ints.Int2LongMaps
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket
 import net.minecraft.network.packet.s2c.play.PlaySoundFromEntityS2CPacket
 import net.minecraft.sound.SoundEvents
@@ -32,11 +32,11 @@ import net.minecraft.sound.SoundEvents
 /**
  * Can be implemented to handle actions after crystals got attacked.
  */
-abstract class CrystalPostAttackTracker : Listenable {
+abstract class CrystalPostAttackTracker : EventHandler {
 
     protected val attackedIds: MutableMap<Int, Long> = Int2LongMaps.synchronize(Int2LongLinkedOpenHashMap())
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val currentTime = System.currentTimeMillis()
         val attackTime = currentTime - timeOutAfter()
         attackedIds.entries.iterator().apply {
@@ -110,7 +110,7 @@ abstract class CrystalPostAttackTracker : Listenable {
      * @param id The id of the attacked entity.
      */
     open fun attacked(id: Int) {
-        if (!isRunning()) {
+        if (!running) {
             return
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/ModuleCrystalAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/ModuleCrystalAura.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.aiming.NoRotationMode
 import net.ccbluex.liquidbounce.utils.aiming.NormalRotationMode
@@ -34,7 +34,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.render.WorldTargetRenderer
 import net.minecraft.entity.LivingEntity
 
-object ModuleCrystalAura : Module(
+object ModuleCrystalAura : ClientModule(
     "CrystalAura",
     Category.COMBAT,
     aliases = arrayOf("AutoCrystal"),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleBasePlace.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleBasePlace.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.render.FULL_BOX
 import net.ccbluex.liquidbounce.utils.block.getCenterDistanceSquared
 import net.ccbluex.liquidbounce.utils.block.getState
@@ -137,7 +137,7 @@ object SubmoduleBasePlace : ToggleableConfigurable(ModuleCrystalAura, "BasePlace
     private val calculations = Chronometer()
     private val trying = Chronometer()
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (currentTarget != null && trying.hasElapsed(timeOut.toLong())) {
             placer.clear()
             currentTarget = null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleSetDead.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleSetDead.kt
@@ -41,7 +41,7 @@ object SubmoduleSetDead : ToggleableConfigurable(ModuleCrystalAura, "SetDead", t
         val entities: MutableMap<Int, EndCrystalEntity> = Int2ObjectMaps.synchronize(Int2ObjectOpenHashMap())
 
         override fun attacked(id: Int) {
-            if (!isRunning()) {
+            if (!running) {
                 return
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/AutoBlock.kt
@@ -70,7 +70,7 @@ object AutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking", false)
      * @see net.minecraft.client.render.item.HeldItemRenderer renderFirstPersonItem
      */
     var blockVisual = false
-        get() = field && super.isRunning()
+        get() = field && super.running
 
     val shouldUnblockToHit
         get() = unblockMode != UnblockMode.NONE

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/FightBot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/FightBot.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.killaura.feature
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.clickScheduler
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.targetTracker
@@ -46,7 +46,7 @@ object FightBot : ToggleableConfigurable(ModuleKillAura, "FightBot", false) {
     private val safeRange by float("SafeRange", 4f, 0.1f..5f)
     private var sideToGo = false
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         sideToGo = !sideToGo
 
         waitTicks(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/NotifyWhenFail.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/NotifyWhenFail.kt
@@ -91,7 +91,7 @@ internal object NotifyWhenFail {
     }
 
     internal fun renderFailedHits(matrixStack: MatrixStack) {
-        if (failedHits.isEmpty() || (!enabled || !Box.isActive)) {
+        if (failedHits.isEmpty() || (!enabled || !Box.isSelected)) {
             failedHits.clear()
             return
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
@@ -22,9 +22,9 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.modes.AStarMode
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.modes.ImmediateMode
 import net.ccbluex.liquidbounce.render.engine.Color4b
@@ -38,7 +38,7 @@ import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.render.WireframePlayer
 import net.minecraft.util.math.Vec3d
 
-object ModuleTpAura : Module("TpAura", Category.COMBAT, disableOnQuit = true) {
+object ModuleTpAura : ClientModule("TpAura", Category.COMBAT, disableOnQuit = true) {
 
     private val attackRange by float("AttackRange", 4.2f, 3f..5f)
 
@@ -50,7 +50,7 @@ object ModuleTpAura : Module("TpAura", Category.COMBAT, disableOnQuit = true) {
     var desyncPlayerPosition: Vec3d? = null
 
     @Suppress("unused")
-    private val attackRepeatable = repeatable {
+    private val attackRepeatable = tickHandler {
         val position = desyncPlayerPosition ?: player.pos
 
         clickScheduler.clicks {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
@@ -3,17 +3,17 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.modes
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.clickScheduler
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.desyncPlayerPosition
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.stuckChronometer
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.targetTracker
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.TpAuraChoice
-import net.ccbluex.liquidbounce.render.*
+import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.Color4b
-import net.ccbluex.liquidbounce.utils.block.getState
-import net.ccbluex.liquidbounce.utils.block.toBlockPos
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
 import net.ccbluex.liquidbounce.utils.entity.blockVecPosition
@@ -25,7 +25,6 @@ import net.minecraft.entity.LivingEntity
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.PositionAndOnGround
 import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
-import net.minecraft.registry.tag.BlockTags
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3i
 import kotlin.concurrent.thread
@@ -50,11 +49,11 @@ object AStarMode : TpAuraChoice("AStar") {
     private var pathFinderThread: Thread? = null
 
     @Suppress("unused")
-    private val tickHandler = repeatable {
-        val (_, path) = pathCache ?: return@repeatable
+    private val tickHandler = tickHandler {
+        val (_, path) = pathCache ?: return@tickHandler
 
         if (!clickScheduler.goingToClick) {
-            return@repeatable
+            return@tickHandler
         }
 
         travel(path)
@@ -66,7 +65,7 @@ object AStarMode : TpAuraChoice("AStar") {
 
     override fun enable() {
         pathFinderThread = thread(name = "TpAura-AStarPathFinder") {
-            while (ModuleTpAura.enabled) {
+            while (ModuleTpAura.running) {
                 runCatching {
                     val playerPosition = player.pos
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -3,7 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.modes
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.clickScheduler
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.desyncPlayerPosition
 import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.ModuleTpAura.stuckChronometer
@@ -26,14 +26,14 @@ import kotlin.math.floor
 
 object ImmediateMode : TpAuraChoice("Immediate") {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!clickScheduler.goingToClick) {
-            return@repeatable
+            return@tickHandler
         }
 
         val playerPosition = player.pos
         val enemyPosition = targetTracker.enemies().minByOrNull { it.squaredBoxedDistanceTo(playerPosition) }?.pos
-            ?: return@repeatable
+            ?: return@tickHandler
 
         travel(enemyPosition)
         waitTicks(20)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode.*
 import net.minecraft.network.listener.ClientPlayPacketListener
 import net.minecraft.network.packet.Packet
@@ -39,7 +39,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  * Modifies the amount of velocity you take.
  */
 
-object ModuleVelocity : Module("Velocity", Category.COMBAT) {
+object ModuleVelocity : ClientModule("Velocity", Category.COMBAT) {
 
     init {
         enableLock()
@@ -66,7 +66,7 @@ object ModuleVelocity : Module("Velocity", Category.COMBAT) {
     private var pause = 0
 
     @Suppress("unused")
-    private val countHandler = handler<GameTickEvent>(ignoreCondition = true) {
+    private val countHandler = handler<GameTickEvent>(ignoreNotRunning = true) {
         if (pause > 0) {
             pause--
         }
@@ -105,6 +105,7 @@ object ModuleVelocity : Module("Velocity", Category.COMBAT) {
         }
     }
 
-    override fun isRunning() = super.isRunning() && pause == 0
+    override val running: Boolean
+        get() = super.running && pause == 0
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityAAC442.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityAAC442.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.ModuleVelocity.modes
 
 /**
@@ -36,7 +36,7 @@ internal object VelocityAAC442 : Choice("AAC4.4.2") {
     private val reduce by float("Reduce", 0.62f, 0f..1f)
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (player.hurtTime > 0 && !player.isOnGround) {
             player.velocity.x *= reduce
             player.velocity.z *= reduce

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityHylex.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityHylex.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.ModuleVelocity.modes
 import net.ccbluex.liquidbounce.utils.entity.moving
 
@@ -75,7 +75,7 @@ object VelocityHylex : Choice("Hylex") {
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         val shouldJump = player.hurtTime > 5
         val canJump = player.isOnGround
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
@@ -21,10 +21,10 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.ModuleVelocity.modes
 import net.minecraft.client.gui.screen.ingame.InventoryScreen
 
@@ -32,7 +32,7 @@ object VelocityIntave : Choice("Intave") {
     override val parent: ChoiceConfigurable<Choice>
         get() = modes
 
-    private class ReduceOnAttack(parent: Listenable?) : ToggleableConfigurable(
+    private class ReduceOnAttack(parent: EventHandler?) : ToggleableConfigurable(
         parent, "ReduceOnAttack",
         true
     ) {
@@ -54,7 +54,7 @@ object VelocityIntave : Choice("Intave") {
         tree(ReduceOnAttack(this))
     }
 
-    private class JumpReset(parent: Listenable?) : ToggleableConfigurable(
+    private class JumpReset(parent: EventHandler?) : ToggleableConfigurable(
         parent, "JumpReset",
         true
     ) {
@@ -62,7 +62,7 @@ object VelocityIntave : Choice("Intave") {
         private val chance by float("Chance", 50f, 0f..100f, "%")
 
         @Suppress("unused")
-        private val repeatable = repeatable {
+        private val repeatable = tickHandler {
             val shouldJump = Math.random() * 100 < chance && player.hurtTime > 5
             val canJump = player.isOnGround && mc.currentScreen !is InventoryScreen
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
@@ -32,7 +32,7 @@ object VelocityIntave : Choice("Intave") {
     override val parent: ChoiceConfigurable<Choice>
         get() = modes
 
-    private class ReduceOnAttack(parent: EventHandler?) : ToggleableConfigurable(
+    private class ReduceOnAttack(parent: EventListener?) : ToggleableConfigurable(
         parent, "ReduceOnAttack",
         true
     ) {
@@ -54,7 +54,7 @@ object VelocityIntave : Choice("Intave") {
         tree(ReduceOnAttack(this))
     }
 
-    private class JumpReset(parent: EventHandler?) : ToggleableConfigurable(
+    private class JumpReset(parent: EventListener?) : ToggleableConfigurable(
         parent, "JumpReset",
         true
     ) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityWatchdog.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityWatchdog.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.ModuleVelocity.modes
 import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket
 
@@ -52,7 +52,7 @@ internal object VelocityWatchdog : Choice("Watchdog") {
     }
 
     @Suppress("unused")
-    private val gameHandler = repeatable {
+    private val gameHandler = tickHandler {
         if (player.isOnGround) {
             absorbedVelocity = false
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAbortBreaking.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAbortBreaking.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.CancelBlockBreakingEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * AbortBreaking module
  *
  * Allows you to abort breaking without losing the progress.
  */
-object ModuleAbortBreaking : Module("AbortBreaking", Category.EXPLOIT) {
+object ModuleAbortBreaking : ClientModule("AbortBreaking", Category.EXPLOIT) {
 
     @Suppress("unused")
     val cancelBlockBreakingHandler = handler<CancelBlockBreakingEvent> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAntiHunger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAntiHunger.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
@@ -38,7 +38,7 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
  * Prevents some cases of exhaustion explained in the increaseTravelMotionStats method of
  * @see net.minecraft.server.network.ServerPlayerEntity
  */
-object ModuleAntiHunger : Module("AntiHunger", Category.EXPLOIT) {
+object ModuleAntiHunger : ClientModule("AntiHunger", Category.EXPLOIT) {
 
     /**
      * Cancels hunger decrease by making the player not sprint server side

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAntiReducedDebugInfo.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleAntiReducedDebugInfo.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * AntiReducedDebugInfo module
@@ -27,4 +27,4 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Allows you to see extended debug information.
  */
 
-object ModuleAntiReducedDebugInfo : Module("AntiReducedDebugInfo", Category.EXPLOIT)
+object ModuleAntiReducedDebugInfo : ClientModule("AntiReducedDebugInfo", Category.EXPLOIT)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleBungeeSpoofer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleBungeeSpoofer.kt
@@ -20,10 +20,10 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 // TODO: add this to configure page, whenever it is finished
-object ModuleBungeeSpoofer : Module("BungeeSpoofer", Category.EXPLOIT) {
+object ModuleBungeeSpoofer : ClientModule("BungeeSpoofer", Category.EXPLOIT) {
 
     val host by text("Host", "127.0.0.1")
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
@@ -22,11 +22,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.event.Sequence
-import net.ccbluex.liquidbounce.event.events.*
+import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
+import net.ccbluex.liquidbounce.event.events.MovementInputEvent
+import net.ccbluex.liquidbounce.event.events.NotificationEvent
+import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.aiming.raycast
@@ -50,7 +53,7 @@ import net.minecraft.util.shape.VoxelShapes
  *
  * Only works for Vulcan AntiCheat
  */
-object ModuleClickTp : Module("ClickTp", Category.EXPLOIT, aliases = arrayOf("ClickTeleport")) {
+object ModuleClickTp : ClientModule("ClickTp", Category.EXPLOIT, aliases = arrayOf("ClickTeleport")) {
 
     private val range by float("Range", 60f, 10f..500f)
     private val cooldown by int("Cooldown", 20, 0..120)
@@ -65,24 +68,24 @@ object ModuleClickTp : Module("ClickTp", Category.EXPLOIT, aliases = arrayOf("Cl
 
     private var highlightBlock: BlockPos? = null
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val raycast = raycast(player.rotation, range = range.toDouble())
         val blockPos = raycast?.blockPos.apply {
             highlightBlock = this
         }
 
         if (!mc.options.pickItemKey.isPressed) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (blockPos == null) {
             chat(markAsError(message("noSelection")))
-            return@repeatable
+            return@tickHandler
         }
 
         if (!isSuitable(blockPos)) {
             chat(markAsError(message("noSuitableBlock", blockPos.x, blockPos.y, blockPos.z)))
-            return@repeatable
+            return@tickHandler
         }
 
         val pos = blockPos.up().toCenterPos()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForGUI
@@ -44,7 +44,7 @@ import kotlin.math.sin
  *
  * Allows you to clip through blocks by jumping or snekaing.
  */
-object ModuleClip : Module("Clip", Category.MOVEMENT) {
+object ModuleClip : ClientModule("Clip", Category.MOVEMENT) {
 
     val modes = choices("Choice", Fancy, arrayOf(Fancy, Old))
 
@@ -84,11 +84,11 @@ object ModuleClip : Module("Clip", Category.MOVEMENT) {
         private val possibleClipDirections = hashSetOf<Direction>()
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             possibleClipDirections.clear()
 
-            if (ModuleFly.enabled) {
-                return@repeatable
+            if (ModuleFly.running) {
+                return@tickHandler
             }
 
             arrayOf(Direction.UP, Direction.DOWN).forEach { direction ->
@@ -103,11 +103,11 @@ object ModuleClip : Module("Clip", Category.MOVEMENT) {
                     mc.options.backKey.isPressed -> player.horizontalFacing.opposite
                     mc.options.leftKey.isPressed -> player.horizontalFacing.rotateClockwise(Direction.Axis.Y).opposite
                     mc.options.rightKey.isPressed -> player.horizontalFacing.rotateClockwise(Direction.Axis.Y)
-                    else -> return@repeatable
+                    else -> return@tickHandler
                 }
                 mc.options.sneakKey.isPressed -> Direction.DOWN
                 mc.options.jumpKey.isPressed -> Direction.UP
-                else -> return@repeatable
+                else -> return@tickHandler
             }
 
             val clipLength = when (movementDirection) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleConsoleSpammer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleConsoleSpammer.kt
@@ -1,12 +1,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import io.netty.buffer.Unpooled
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 
-object ModuleConsoleSpammer : Module("ConsoleSpammer", Category.EXPLOIT, disableOnQuit = true) {
+object ModuleConsoleSpammer : ClientModule("ConsoleSpammer", Category.EXPLOIT, disableOnQuit = true) {
 
     // Invalid Packet id, cannot bypass Velocity/BungeeCord
     // Allows you to bypass ViaVersion
@@ -24,7 +24,7 @@ object ModuleConsoleSpammer : Module("ConsoleSpammer", Category.EXPLOIT, disable
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         repeat(packets) {
             // Send packet directly without passing it through the entire pipeline.
             player.networkHandler.connection.channel.pipeline().firstContext()
@@ -33,7 +33,7 @@ object ModuleConsoleSpammer : Module("ConsoleSpammer", Category.EXPLOIT, disable
 
         // Wait 1 tick between packet bundle, so you won't be timed out when you don't want to.
         waitTicks(1)
-        return@repeatable
+        return@tickHandler
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDamage.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.exactPosition
 import net.ccbluex.liquidbounce.utils.math.component1
 import net.ccbluex.liquidbounce.utils.math.component2
@@ -33,7 +33,7 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
  * Deals the specified amount of damage to yourself.
  */
 
-object ModuleDamage : Module("Damage", Category.EXPLOIT, disableActivation = true) {
+object ModuleDamage : ClientModule("Damage", Category.EXPLOIT, disableActivation = true) {
 
     private val mode by enumChoice("Mode", DamageModeEnum.NCP)
     private val damage by int("Damage", 1, 0..20, "HP")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleGhostHand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleGhostHand.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.block.Blocks
 
 /**
@@ -27,7 +27,7 @@ import net.minecraft.block.Blocks
  *
  * Allows you to interact with selected blocks through walls.
  */
-object ModuleGhostHand : Module("GhostHand", Category.EXPLOIT) {
+object ModuleGhostHand : ClientModule("GhostHand", Category.EXPLOIT) {
 
     val targetedBlocks by blocks("TargetedBlocks", hashSetOf(
         Blocks.CHEST,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
@@ -33,7 +33,7 @@ import kotlin.random.Random
  *
  * Kick yourself from the server.
  */
-object ModuleKick : Module("Kick", Category.EXPLOIT, disableActivation = true) {
+object ModuleKick : ClientModule("Kick", Category.EXPLOIT, disableActivation = true) {
 
     private val mode by enumChoice("Mode", KickModeEnum.QUIT)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleMoreCarry.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleMoreCarry.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
 
 /**
@@ -31,7 +31,7 @@ import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
  *
  * @warning Only works on multiplayer!
  */
-object ModuleMoreCarry : Module("MoreCarry", Category.EXPLOIT, aliases = arrayOf("XCarry")) {
+object ModuleMoreCarry : ClientModule("MoreCarry", Category.EXPLOIT, aliases = arrayOf("XCarry")) {
 
     val packetHandler = handler<PacketEvent> { event ->
         if (event.packet is CloseHandledScreenC2SPacket) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleMultiActions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleMultiActions.kt
@@ -19,9 +19,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
-object ModuleMultiActions : Module("MultiActions", Category.EXPLOIT, aliases = arrayOf("MultiTask")) {
+object ModuleMultiActions : ClientModule("MultiActions", Category.EXPLOIT, aliases = arrayOf("MultiTask")) {
     val placingWhileBreaking by boolean("PlacingWhileBreaking", true)
     val attackingWhileUsing by boolean("AttackingWhileUsing", true)
     val breakingWhileUsing by boolean("BreakingWhileUsing", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleNameCollector.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleNameCollector.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.notification
 
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.utils.client.notification
  *
  * Collects all player names to the file
  */
-object ModuleNameCollector : Module("NameCollector", Category.EXPLOIT, disableActivation = true) {
+object ModuleNameCollector : ClientModule("NameCollector", Category.EXPLOIT, disableActivation = true) {
 
     private val captureDirectory = ConfigSystem.rootFolder.resolve("name-captures").apply { mkdirs() }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleNoPitchLimit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleNoPitchLimit.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
 /**
@@ -29,7 +29,7 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
  *
  * Allows you to rotate your head over the pitch limit!
  */
-object ModuleNoPitchLimit : Module("NoPitchLimit", Category.EXPLOIT) {
+object ModuleNoPitchLimit : ClientModule("NoPitchLimit", Category.EXPLOIT) {
 
     private val serverSide by boolean("ServerSide", true)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.fakelag.DelayData
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.handlePacket
 import net.ccbluex.liquidbounce.utils.client.markAsError
@@ -37,7 +37,7 @@ import net.minecraft.network.packet.s2c.common.KeepAliveS2CPacket
  * Spoofs your ping to a specified value.
  */
 
-object ModulePingSpoof : Module("PingSpoof", Category.EXPLOIT) {
+object ModulePingSpoof : ClientModule("PingSpoof", Category.EXPLOIT) {
 
     private val delay by int("Delay", 500, 0..25000, "ms")
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePlugins.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePlugins.kt
@@ -21,10 +21,10 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
@@ -35,7 +35,7 @@ import net.minecraft.network.packet.s2c.play.CommandSuggestionsS2CPacket
  *
  * Allows you to see a server's plugins.
  */
-object ModulePlugins : Module("Plugins", Category.EXPLOIT) {
+object ModulePlugins : ClientModule("Plugins", Category.EXPLOIT) {
 
     private val trySlash by boolean("TrySlash", true)
     private val tryColonSlash by boolean("TryColonSlash", true)
@@ -64,7 +64,7 @@ object ModulePlugins : Module("Plugins", Category.EXPLOIT) {
         step = 0
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         when (step) {
             // Works only on servers that did not block the plugins command.
             0 -> if (trySlash) network.sendCommand("plugins") else step++

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePortalMenu.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePortalMenu.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * PortalMenu module
  *
  * Allows you to open a menu while being in a portal.
  */
-object ModulePortalMenu : Module("PortalMenu", Category.EXPLOIT)
+object ModulePortalMenu : ClientModule("PortalMenu", Category.EXPLOIT)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResetVL.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResetVL.kt
@@ -19,9 +19,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.entity.downwards
@@ -34,14 +34,14 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
  * Allows you to reset anticheat violations
  * Only works on older/flawed anticheats
  */
-object ModuleResetVL : Module("ResetVL", Category.EXPLOIT) {
+object ModuleResetVL : ClientModule("ResetVL", Category.EXPLOIT) {
 
     private val times by int("Times", 10, 1..50)
     private val timer by float("Timer", 2f, 0.1f..10f)
     private var count = 0
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         Timer.requestTimerSpeed(timer, priority = Priority.IMPORTANT_FOR_USER_SAFETY, provider = ModuleResetVL)
 
         if (player.isOnGround) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResourceSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResourceSpoof.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.network.packet.c2s.common.ResourcePackStatusC2SPacket
 import net.minecraft.network.packet.c2s.common.ResourcePackStatusC2SPacket.Status.*
 import net.minecraft.network.packet.s2c.common.ResourcePackSendS2CPacket
@@ -31,7 +31,7 @@ import net.minecraft.network.packet.s2c.common.ResourcePackSendS2CPacket
  *
  * Prevents servers from forcing you to download their resource pack.
  */
-object ModuleResourceSpoof : Module("ResourceSpoof", Category.EXPLOIT) {
+object ModuleResourceSpoof : ClientModule("ResourceSpoof", Category.EXPLOIT) {
 
     val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSleepWalker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSleepWalker.kt
@@ -18,9 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.entity.EntityPose
 
 /**
@@ -28,9 +28,9 @@ import net.minecraft.entity.EntityPose
  *
  * Allows you to walk while sleeping, also makes your hitbox small.
  */
-object ModuleSleepWalker : Module("SleepWalker", Category.EXPLOIT, aliases = arrayOf("BedGodMode")) {
+object ModuleSleepWalker : ClientModule("SleepWalker", Category.EXPLOIT, aliases = arrayOf("BedGodMode")) {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isSleeping) {
             player.pose = EntityPose.STANDING
             player.clearSleepingPosition()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleSpoofer.kt
@@ -21,11 +21,11 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 // TODO: add this to configure page, whenever it is finished
 @Suppress("SpellCheckingInspection")
-object ModuleSpoofer : Module("ClientSpoofer", Category.EXPLOIT) {
+object ModuleSpoofer : ClientModule("ClientSpoofer", Category.EXPLOIT) {
 
     val mode = choices(
         "Mode",
@@ -33,7 +33,7 @@ object ModuleSpoofer : Module("ClientSpoofer", Category.EXPLOIT) {
         arrayOf(Vanilla, Lunar, Cheatbreaker, Custom)
     )
 
-    fun clientBrand(brand: String) = if (enabled) mode.activeChoice.getBrand() else brand
+    fun clientBrand(brand: String) = if (running) mode.activeChoice.getBrand() else brand
 
     private object Vanilla : SpoofMode("Vanilla") {
         override fun getBrand(): String = "vanilla"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTimeShift.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTimeShift.kt
@@ -19,9 +19,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -41,7 +41,7 @@ import kotlin.math.min
  * FastUse on the other hand is a separate module because it has a few options that are not
  * related to time shift.
  */
-object ModuleTimeShift : Module("TimeShift", Category.EXPLOIT, disableOnQuit = true,
+object ModuleTimeShift : ClientModule("TimeShift", Category.EXPLOIT, disableOnQuit = true,
     aliases = arrayOf("Regen", "Zoot")) {
 
     private object Health : ToggleableConfigurable(this, "Health", true) {
@@ -102,30 +102,30 @@ object ModuleTimeShift : Module("TimeShift", Category.EXPLOIT, disableOnQuit = t
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         // Check if the player is in creative mode or dead, if so, skip the time shift
         if (player.abilities.creativeMode || player.isDead) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Check if the player is not on the ground and the player is not allowed to be in the air
         if (notInTheAir && !player.isOnGround) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Check if the player is moving and the player is not allowed to move
         if (notDuringMove && player.moving) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Check if the player has the regeneration effect and the player is not allowed to regenerate
         if (notDuringRegeneration && player.hasStatusEffect(StatusEffects.REGENERATION)) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Check if the player is not allowed to cause hunger and the player's hunger level is not full
         if (doNotCauseHunger && player.hungerManager.foodLevel < 20) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Calculate the tick speed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTranslationFix.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTranslationFix.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * TranslationFix module
  *
  * Can be used to switch the translation fix on or off
  */
-object ModuleTranslationFix : Module("TranslationFix", Category.EXPLOIT, state = true, hide = true)
+object ModuleTranslationFix : ClientModule("TranslationFix", Category.EXPLOIT, state = true, hide = true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleVehicleOneHit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleVehicleOneHit.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
 import net.minecraft.entity.vehicle.BoatEntity
 import net.minecraft.entity.vehicle.MinecartEntity
@@ -33,7 +33,7 @@ import net.minecraft.util.Hand
  *
  * Allows you to break vehicles with a single hit.
  */
-object ModuleVehicleOneHit : Module("VehicleOneHit", Category.EXPLOIT) {
+object ModuleVehicleOneHit : ClientModule("VehicleOneHit", Category.EXPLOIT) {
 
     /**
      * How many hits are required to break a vehicle?

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/ModuleDisabler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/ModuleDisabler.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.disabler
 
 import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disablers.*
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.regular
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.utils.client.regular
  *
  * Disables either a specific anti-cheat or server.
  */
-object ModuleDisabler : Module("Disabler", Category.EXPLOIT) {
+object ModuleDisabler : ClientModule("Disabler", Category.EXPLOIT) {
 
 
     init {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
@@ -194,7 +194,7 @@ internal object DisablerVerusExperimental : ToggleableConfigurable(ModuleDisable
 
     // ping spoof, multiple checks
     fun shouldBlink(packet: Packet<*>?): Boolean {
-        if (!this.isRunning()) return false
+        if (!this.running) return false
         if (waitTime > System.currentTimeMillis()) return false
 
         if (packet == null && lastFlush + delayTime < System.currentTimeMillis()) {
@@ -220,7 +220,7 @@ internal object DisablerVerusExperimental : ToggleableConfigurable(ModuleDisable
 
     // meant to trigger playerData.hasLag
     fun shouldPrepareToFlush(packet: Packet<*>?): Boolean {
-        if (!this.isRunning()) return false
+        if (!this.running) return false
         if (waitTime > System.currentTimeMillis()) return false
         if (packet !is PlayerMoveC2SPacket) return false
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVulcanRiptide.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVulcanRiptide.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disabl
 
 import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
 import net.ccbluex.liquidbounce.lang.translation
 import net.ccbluex.liquidbounce.utils.client.chat
@@ -54,7 +54,7 @@ internal object DisablerVulcanRiptide : ToggleableConfigurable(ModuleDisabler, "
     }
 
     @Suppress("unused")
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (checkItem()) {
             waitTicks(20)
             interaction.sendSequencedPacket(world) { sequence ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/dupe/ModuleDupe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/dupe/ModuleDupe.kt
@@ -20,10 +20,10 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.dupe
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.exploit.dupe.exploits.DupePaperDupe
 
-object ModuleDupe : Module("Dupe", Category.EXPLOIT, disableOnQuit = true, disableActivation = true) {
+object ModuleDupe : ClientModule("Dupe", Category.EXPLOIT, disableOnQuit = true, disableActivation = true) {
 
     override fun enable() {
         exploitChoices.activeChoice.enable()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
@@ -20,11 +20,11 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.exploits.*
 import net.ccbluex.liquidbounce.utils.client.chat
 
-object ModuleServerCrasher : Module("ServerCrasher", Category.EXPLOIT, disableOnQuit = true) {
+object ModuleServerCrasher : ClientModule("ServerCrasher", Category.EXPLOIT, disableOnQuit = true) {
 
     override fun enable() {
         if (mc.isIntegratedServerRunning) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/CompletionExploit.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.e
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
 import java.util.stream.Collectors
@@ -57,16 +57,16 @@ object CompletionExploit : Choice("Completion") {
         ModuleServerCrasher.enabled = false
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if(!autoMode) {
-            return@repeatable
+            return@tickHandler
         }
 
         //Send all known command completions.
         if(messageIndex == knownWorkingMessages.size - 1) {
             messageIndex = 0
             ModuleServerCrasher.enabled = false
-            return@repeatable
+            return@tickHandler
         }
 
         waitTicks(20)
@@ -82,7 +82,7 @@ object CompletionExploit : Choice("Completion") {
         }
 
         messageIndex++
-        return@repeatable
+        return@tickHandler
     }
 
     private fun generateJsonObject(levels: Int): String {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperWindowExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperWindowExploit.kt
@@ -3,7 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.e
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
@@ -29,7 +29,7 @@ object PaperWindowExploit : Choice("PaperWindow") {
      */
     private val packets by int("Packets", 6, 2..12)
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val handler = player.currentScreenHandler
         val packet = ClickSlotC2SPacket(
             handler.syncId,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/types/CommandExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/types/CommandExploit.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.exploits.types
 
-import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher.enabled
+import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleResetVL.enabled
 import net.ccbluex.liquidbounce.utils.client.chat
 
 open class CommandExploit(name: String, private val command: () -> String) : Exploit(name) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDankBobbing.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDankBobbing.kt
@@ -19,14 +19,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * Dank bobbing module
  *
  * Adds more bobbing effect.
  */
-object ModuleDankBobbing : Module("DankBobbing", Category.FUN) {
+object ModuleDankBobbing : ClientModule("DankBobbing", Category.FUN) {
 
     val motion by float("Motion", 5f, 1f..50f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDerp.kt
@@ -20,9 +20,9 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
@@ -34,7 +34,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.random
  *
  * Makes it look as if you were derping around.
  */
-object ModuleDerp : Module("Derp", Category.FUN) {
+object ModuleDerp : ClientModule("Derp", Category.FUN) {
 
     private val yawMode = choices("Yaw", YawSpin,
         arrayOf(YawStatic, YawOffset, YawRandom, YawJitter, YawSpin))
@@ -46,9 +46,9 @@ object ModuleDerp : Module("Derp", Category.FUN) {
     // DO NOT USE TREE TO MAKE SURE THAT THE ROTATIONS ARE NOT CHANGED
     private val rotationsConfigurable = RotationsConfigurable(this)
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (notDuringSprint && (mc.options.sprintKey.isPressed || player.isSprinting)) {
-            return@repeatable
+            return@tickHandler
         }
 
         val yaw = yawMode.activeChoice.yaw
@@ -96,7 +96,7 @@ object ModuleDerp : Module("Derp", Category.FUN) {
         val yawBackwardTicks by int("BackwardTicks", 2, 0..100, "ticks")
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             repeat(yawForwardTicks) {
                 yaw = player.yaw
                 waitTicks(1)
@@ -117,7 +117,7 @@ object ModuleDerp : Module("Derp", Category.FUN) {
         val yawSpinSpeed by int("Speed", 50, -70..70, "°/tick")
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             yaw += yawSpinSpeed
             waitTicks(1)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleHandDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleHandDerp.kt
@@ -21,10 +21,10 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.entity.MixinPlayerEntityAccessor
 import net.minecraft.network.packet.c2s.common.ClientOptionsC2SPacket
 import net.minecraft.network.packet.c2s.common.SyncedClientOptions
@@ -37,7 +37,7 @@ import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket
  *
  * Switches your main hand.
  */
-object ModuleHandDerp : Module("HandDerp", Category.FUN) {
+object ModuleHandDerp : ClientModule("HandDerp", Category.FUN) {
 
 
     private val silent by boolean("Silent", false)
@@ -97,7 +97,7 @@ object ModuleHandDerp : Module("HandDerp", Category.FUN) {
         val delayValue by int("Delay", 1, 0..20, "ticks")
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             waitTicks(delayValue)
             switchHand()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleSkinDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleSkinDerp.kt
@@ -18,9 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.entity.player.PlayerModelPart
 import kotlin.random.Random
 
@@ -29,7 +29,7 @@ import kotlin.random.Random
  *
  * Makes your skin blink (Requires multi-layer skin).
  */
-object ModuleSkinDerp : Module("SkinDerp", Category.FUN) {
+object ModuleSkinDerp : ClientModule("SkinDerp", Category.FUN) {
 
     private val sync by boolean("Sync", false)
     private val delay by int("Delay", 0, 0..20, "ticks")
@@ -58,7 +58,7 @@ object ModuleSkinDerp : Module("SkinDerp", Category.FUN) {
         }
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         waitTicks(delay)
         val partsMap = mapOf(
             PlayerModelPart.HAT to hat,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleTwerk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleTwerk.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * Twerk module
  *
  * Automatically sneaks and unsneaks.
  */
-object ModuleTwerk : Module("Twerk", Category.FUN) {
+object ModuleTwerk : ClientModule("Twerk", Category.FUN) {
 
     /**
      * How long each sneak / normal period is.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleVomit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleVomit.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.inventory.*
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
 import net.minecraft.item.ItemStack
@@ -34,7 +34,7 @@ import net.minecraft.util.math.random.Random
  * Drops items from the inventory in a random order to make it look like the player is vomiting.
  * If the player is in creative mode, the player will drop random block items.
  */
-object ModuleVomit : Module("Vomit", Category.FUN) {
+object ModuleVomit : ClientModule("Vomit", Category.FUN) {
 
     private val inventoryConstraints = tree(PlayerInventoryConstraints())
     private val random = Random.create()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
@@ -8,7 +8,7 @@ import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.io.HttpClient
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -19,7 +19,7 @@ import kotlin.concurrent.thread
 /**
  * Notifies you about staff actions.
  */
-object ModuleAntiStaff : Module("AntiStaff", Category.MISC) {
+object ModuleAntiStaff : ClientModule("AntiStaff", Category.MISC) {
 
     object VelocityCheck : ToggleableConfigurable(this, "VelocityCheck", true) {
 
@@ -137,7 +137,7 @@ object ModuleAntiStaff : Module("AntiStaff", Category.MISC) {
         }
 
         fun shouldShowAsStaffOnTab(username: String): Boolean {
-            if (!showInTabList || !ModuleAntiStaff.enabled || !enabled) {
+            if (!showInTabList || !ModuleAntiStaff.running || !enabled) {
                 return false
             }
 
@@ -153,7 +153,7 @@ object ModuleAntiStaff : Module("AntiStaff", Category.MISC) {
 
         }
 
-        override fun isRunning() = ModuleAntiStaff.enabled && enabled
+        override val running = ModuleAntiStaff.running && enabled
 
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoAccount.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoAccount.kt
@@ -23,8 +23,9 @@ import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.SuspendableHandler
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.misc.HideAppearance
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 
 
@@ -33,7 +34,7 @@ import net.ccbluex.liquidbounce.utils.client.chat
  *
  * Automatically handles logins or registrations on servers when requested.
  */
-object ModuleAutoAccount : Module("AutoAccount", Category.MISC, aliases = arrayOf("AutoLogin", "AutoRegister")) {
+object ModuleAutoAccount : ClientModule("AutoAccount", Category.MISC, aliases = arrayOf("AutoLogin", "AutoRegister")) {
 
     private val password by text("Password", "a1b2c3d4")
         .doNotIncludeAlways()
@@ -49,7 +50,7 @@ object ModuleAutoAccount : Module("AutoAccount", Category.MISC, aliases = arrayO
 
     // We can receive chat messages before the world is initialized,
     // so we have to handel events even before the that
-    override fun isRunning() = enabled
+    override val running = !HideAppearance.isDestructed && enabled
 
     fun login() {
         chat("login")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
@@ -20,10 +20,10 @@ package net.ccbluex.liquidbounce.features.module.modules.misc
 
 import kotlinx.coroutines.delay
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -34,7 +34,7 @@ import kotlin.concurrent.thread
 /**
  * Automatically solves chat game riddles.
  */
-object ModuleAutoChatGame : Module("AutoChatGame", Category.MISC) {
+object ModuleAutoChatGame : ClientModule("AutoChatGame", Category.MISC) {
 
     private val baseUrl by text("BaseUrl", OPENAI_BASE_URL)
         .doNotIncludeAlways() // Keeps API key private
@@ -129,12 +129,12 @@ object ModuleAutoChatGame : Module("AutoChatGame", Category.MISC) {
         }
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         // Has the trigger word been said and has the buffer time elapsed?
         if (triggerWordChronometer.hasElapsed(bufferTime.toLong())) {
             // Is the buffer empty? - If it is we already answered the question.
             if (chatBuffer.isEmpty()) {
-                return@repeatable
+                return@tickHandler
             }
 
             // Handle questions

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFlagCheck.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFlagCheck.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.client.MessageMetadata
 import net.ccbluex.liquidbounce.utils.client.chat
@@ -42,7 +42,7 @@ import org.apache.commons.lang3.StringUtils
  *
  * Alerts you about set backs.
  */
-object ModuleFlagCheck : Module("FlagCheck", Category.MISC, aliases = arrayOf("FlagDetect")) {
+object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = arrayOf("FlagDetect")) {
 
     private var chatMessage by boolean("ChatMessage", true)
     private var notification by boolean("Notification", false)
@@ -53,7 +53,7 @@ object ModuleFlagCheck : Module("FlagCheck", Category.MISC, aliases = arrayOf("F
         private var afterSeconds by int("After", 30, 1..300, "s")
 
         @Suppress("unused")
-        private val repeatable = repeatable {
+        private val repeatable = tickHandler {
             flagCount = 0
             waitSeconds(afterSeconds)
         }
@@ -134,16 +134,16 @@ object ModuleFlagCheck : Module("FlagCheck", Category.MISC, aliases = arrayOf("F
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (!invalidAttributes) {
-            return@repeatable
+            return@tickHandler
         }
 
         val invalidHeath = player.health <= 0f && player.isAlive
         val invalidHunger = player.hungerManager.foodLevel <= 0
 
         if (!invalidHeath && !invalidHunger) {
-            return@repeatable
+            return@tickHandler
         }
 
         val invalidReasons = mutableListOf<String>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFocus.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFocus.kt
@@ -26,9 +26,9 @@ import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.minecraft.client.network.AbstractClientPlayerEntity
 
@@ -37,7 +37,7 @@ import net.minecraft.client.network.AbstractClientPlayerEntity
  *
  * Filters out any other entity to be targeted except the one focus is set to
  */
-object ModuleFocus : Module("Focus", Category.MISC) {
+object ModuleFocus : ClientModule("Focus", Category.MISC) {
 
     private val mode = choices("Mode", Filter, arrayOf(Temporary, Filter))
 
@@ -105,10 +105,10 @@ object ModuleFocus : Module("Focus", Category.MISC) {
         }
 
         @Suppress("unused")
-        private val cleanUpTask = repeatable {
+        private val cleanUpTask = tickHandler {
             if (player.isDead) {
                 focus.clear()
-                return@repeatable
+                return@tickHandler
             }
 
             val currentTime = System.currentTimeMillis()
@@ -171,7 +171,7 @@ object ModuleFocus : Module("Focus", Category.MISC) {
      * Check if [entity] is in your focus
      */
     private fun isInFocus(entity: AbstractClientPlayerEntity): Boolean {
-        if (!enabled) {
+        if (!running) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleInventoryTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleInventoryTracker.kt
@@ -1,12 +1,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
-import net.ccbluex.liquidbounce.event.events.*
+import net.ccbluex.liquidbounce.event.events.ItemLoreQueryEvent
+import net.ccbluex.liquidbounce.event.events.PlayerEquipmentChangeEvent
+import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.commands.client.CommandInvsee
 import net.ccbluex.liquidbounce.features.command.commands.client.NoInteractInventory
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.minecraft.client.network.OtherClientPlayerEntity
 import net.minecraft.entity.EquipmentSlot
@@ -16,7 +18,7 @@ import net.minecraft.entity.EquipmentSlot.Type.*
 import net.minecraft.item.ItemStack
 import java.util.*
 
-object ModuleInventoryTracker : Module("InventoryTracker", Category.MISC) {
+object ModuleInventoryTracker : ClientModule("InventoryTracker", Category.MISC) {
 
     private val playerMap = HashMap<UUID, TrackedInventory>()
 
@@ -72,7 +74,7 @@ object ModuleInventoryTracker : Module("InventoryTracker", Category.MISC) {
     }
 
     val itemLoreQueryHandler = handler<ItemLoreQueryEvent> { event ->
-        if (!enabled || mc.currentScreen !is NoInteractInventory) return@handler
+        if (!running || mc.currentScreen !is NoInteractInventory) return@handler
         val player = CommandInvsee.viewedPlayer ?: return@handler
         val timeStamp = playerMap[player.uuid]?.timeMap?.getLong(event.itemStack)?.takeIf { it != 0L } ?: return@handler
         val lastSeen = System.currentTimeMillis() - timeStamp

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleMiddleClickAction.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleMiddleClickAction.kt
@@ -23,10 +23,10 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.facingEnemy
 import net.ccbluex.liquidbounce.utils.aiming.raytraceEntity
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
@@ -42,7 +42,7 @@ import net.minecraft.item.Items
  *
  * Allows you to perform actions with middle clicks.
  */
-object ModuleMiddleClickAction : Module(
+object ModuleMiddleClickAction : ClientModule(
     "MiddleClickAction",
     Category.MISC,
     aliases = arrayOf("FriendClicker", "MiddleClickPearl")
@@ -60,17 +60,17 @@ object ModuleMiddleClickAction : Module(
 
         private var wasPressed = false
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (mc.currentScreen != null) {
                 wasPressed = false
-                return@repeatable
+                return@tickHandler
             }
 
             val pickup = mc.options.pickItemKey.isPressed
 
             if (pickup) {
                 // visually select the slot
-                val slot = findHotbarItemSlot(Items.ENDER_PEARL)?.hotbarSlotForServer ?: return@repeatable
+                val slot = findHotbarItemSlot(Items.ENDER_PEARL)?.hotbarSlotForServer ?: return@tickHandler
                 SilentHotbar.selectSlotSilently(this, slot, slotResetDelay)
                 wasPressed = true
             } else if (wasPressed) { // the key was released
@@ -91,7 +91,7 @@ object ModuleMiddleClickAction : Module(
         }
 
         fun cancelPick(): Boolean {
-            return ModuleMiddleClickAction.enabled &&
+            return ModuleMiddleClickAction.running &&
                 mode.activeChoice == this &&
                 findHotbarItemSlot(Items.ENDER_PEARL) != null
         }
@@ -107,11 +107,11 @@ object ModuleMiddleClickAction : Module(
 
         private var clicked = false
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             val rotation = player.rotation
 
             val entity = (raytraceEntity(pickUpRange.toDouble(), rotation) { it is PlayerEntity }
-                ?: return@repeatable).entity as PlayerEntity
+                ?: return@tickHandler).entity as PlayerEntity
 
             val facesEnemy = facingEnemy(
                 toEntity = entity, rotation = rotation, range = pickUpRange.toDouble(),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.regular
@@ -35,7 +35,7 @@ import java.util.*
  *
  * Notifies you about all kinds of events.
  */
-object ModuleNotifier : Module("Notifier", Category.MISC) {
+object ModuleNotifier : ClientModule("Notifier", Category.MISC) {
 
     private val joinMessages by boolean("JoinMessages", true)
     private val joinMessageFormat by text("JoinMessageFormat", "%s joined")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleSpammer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleSpammer.kt
@@ -19,9 +19,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import org.apache.commons.lang3.RandomStringUtils
 import kotlin.random.Random
@@ -31,7 +31,7 @@ import kotlin.random.Random
  *
  * Spams the chat with a given message.
  */
-object ModuleSpammer : Module("Spammer", Category.MISC, disableOnQuit = true) {
+object ModuleSpammer : ClientModule("Spammer", Category.MISC, disableOnQuit = true) {
 
     private val delay by intRange("Delay", 2..4, 0..300, "secs")
     private val mps by intRange("MPS", 1..1, 1..500, "messages")
@@ -50,7 +50,7 @@ object ModuleSpammer : Module("Spammer", Category.MISC, disableOnQuit = true) {
 
     private var linear = 0
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         repeat(mps.random()) {
             val chosenMessage = when (pattern) {
                 SpammerPattern.RANDOM -> message.random()
@@ -68,7 +68,7 @@ object ModuleSpammer : Module("Spammer", Category.MISC, disableOnQuit = true) {
 
             if (text.length > 256) {
                 chat("Spammer message is too long! (Max 256 characters)")
-                return@repeatable
+                return@tickHandler
             }
 
             // Check if message text is command

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleTeams.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleTeams.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.client.stripMinecraftColorCodes
 import net.ccbluex.liquidbounce.utils.inventory.getArmorColor
@@ -38,7 +38,7 @@ import java.awt.Color
  *
  * Prevents KillAura from attacking teammates.
  */
-object ModuleTeams : Module("Teams", Category.MISC) {
+object ModuleTeams : ClientModule("Teams", Category.MISC) {
 
     private val scoreboard by boolean("ScoreboardTeam", true)
     private val nameColor by boolean("NameColor", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/ModuleAntiBot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/ModuleAntiBot.kt
@@ -23,16 +23,15 @@ import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes.CustomAntiBotMode
-import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes.CustomAntiBotMode.reset
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes.HorizonAntiBotMode
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes.IntaveHeavyAntiBotMode
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes.MatrixAntiBotMode
 import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
 
-object ModuleAntiBot : Module("AntiBot", Category.MISC) {
+object ModuleAntiBot : ClientModule("AntiBot", Category.MISC) {
 
     val modes = choices("Mode", CustomAntiBotMode, arrayOf(
         CustomAntiBotMode,
@@ -79,7 +78,7 @@ object ModuleAntiBot : Module("AntiBot", Category.MISC) {
      * Check if player might be a bot
      */
     fun isBot(player: Entity): Boolean {
-        if (!enabled) {
+        if (!running) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/CustomAntiBotMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/CustomAntiBotMode.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot.isADuplicate
 import net.ccbluex.liquidbounce.utils.math.sq
@@ -81,7 +81,7 @@ object CustomAntiBotMode : Choice("Custom"), ModuleAntiBot.IAntiBotMode {
     private val attributesSet = IntOpenHashSet()
     private val ageSet = IntOpenHashSet()
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val rangeSquared = AlwaysInRadius.alwaysInRadiusRange.sq()
         for (entity in world.players) {
             if (player.squaredDistanceTo(entity) > rangeSquared) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/MatrixAntiBotMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/MatrixAntiBotMode.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot.isADuplicate
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot.isGameProfileUnique
@@ -71,9 +71,9 @@ object MatrixAntiBotMode : Choice("Matrix"), ModuleAntiBot.IAntiBotMode {
         }
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (suspectList.isEmpty()) {
-            return@repeatable
+            return@tickHandler
         }
 
         for (entity in world.players) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/ModuleBetterChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/ModuleBetterChat.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.CommandManager
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.client.gui.screen.ChatScreen
 import net.minecraft.client.gui.screen.DeathScreen
 
@@ -32,7 +32,7 @@ import net.minecraft.client.gui.screen.DeathScreen
  *
  * Quality of life improvements to the in-game chat.
  */
-object ModuleBetterChat : Module("BetterChat", Category.MISC, aliases = arrayOf("AntiSpam")) {
+object ModuleBetterChat : ClientModule("BetterChat", Category.MISC, aliases = arrayOf("AntiSpam")) {
 
     val infiniteLength by boolean("Infinite", true)
     val antiClear by boolean("AntiClear", true)
@@ -91,7 +91,7 @@ object ModuleBetterChat : Module("BetterChat", Category.MISC, aliases = arrayOf(
     }
 
     fun modifyMessage(content: String): String {
-        if (!enabled) {
+        if (!running) {
             return content
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/ModuleDebugRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/ModuleDebugRecorder.kt
@@ -5,7 +5,7 @@ import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes.AimDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes.BoxDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes.DebugCPSRecorder
@@ -18,7 +18,7 @@ import java.nio.file.Files
 import java.text.SimpleDateFormat
 import java.util.*
 
-object ModuleDebugRecorder : Module("DebugRecorder", Category.MISC) {
+object ModuleDebugRecorder : ClientModule("DebugRecorder", Category.MISC) {
     val modes = choices("Mode", GenericDebugRecorder, arrayOf(
         GenericDebugRecorder,
         DebugCPSRecorder,
@@ -33,7 +33,7 @@ object ModuleDebugRecorder : Module("DebugRecorder", Category.MISC) {
         private val packets = mutableListOf<Any>()
 
         protected fun recordPacket(packet: Any) {
-            if (!this.isActive) {
+            if (!this.isSelected) {
                 return
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/AimDebugRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/AimDebugRecorder.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes
 
 import com.google.gson.JsonObject
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
@@ -33,7 +33,7 @@ import net.minecraft.util.hit.HitResult
 
 object AimDebugRecorder : ModuleDebugRecorder.DebugRecorderMode("Aim") {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val playerRotation = player.rotation
         val playerLastRotation = player.lastRotation
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/BoxDebugRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/BoxDebugRecorder.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes
 
 import com.google.gson.JsonObject
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.box
@@ -32,11 +32,11 @@ import net.minecraft.util.hit.HitResult
 
 object BoxDebugRecorder : ModuleDebugRecorder.DebugRecorderMode("Box") {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val crosshairTarget = mc.crosshairTarget
 
         if (crosshairTarget?.type != HitResult.Type.ENTITY || crosshairTarget !is EntityHitResult) {
-            return@repeatable
+            return@tickHandler
         }
 
         recordPacket(JsonObject().apply {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/GenericDebugRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/GenericDebugRecorder.kt
@@ -2,8 +2,8 @@ package net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.mode
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import net.ccbluex.liquidbounce.event.repeatable
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.utils.io.toJson
 import net.minecraft.entity.Entity
@@ -19,7 +19,7 @@ object GenericDebugRecorder : ModuleDebugRecorder.DebugRecorderMode("Generic") {
         waitingEntites.add(ScheduledEntityDebug(ticks, entity.id))
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val due = waitingEntites.filter {
             it.ticksLeft--
             it.ticksLeft <= 0
@@ -36,7 +36,7 @@ object GenericDebugRecorder : ModuleDebugRecorder.DebugRecorderMode("Generic") {
         waitingEntites.removeAll(due)
     }
 
-    fun recordDebugInfo(module: Module, packetName: String, packet: JsonElement) {
+    fun recordDebugInfo(module: ClientModule, packetName: String, packet: JsonElement) {
         recordPacket(JsonObject().apply {
             addProperty("module", module.name)
             addProperty("packet", packetName)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.GenericColorMode
 import net.ccbluex.liquidbounce.render.GenericRainbowColorMode
 import net.ccbluex.liquidbounce.render.GenericStaticColorMode
@@ -41,7 +41,7 @@ import net.minecraft.text.Text
  * Changes players names clientside.
  */
 
-object ModuleNameProtect : Module("NameProtect", Category.MISC) {
+object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
 
     private val replacement by text("Replacement", "You")
 
@@ -118,7 +118,7 @@ object ModuleNameProtect : Module("NameProtect", Category.MISC) {
     }
 
     fun replace(original: String): String {
-        if (!enabled) {
+        if (!running) {
             return original
         }
 
@@ -232,7 +232,7 @@ object ModuleNameProtect : Module("NameProtect", Category.MISC) {
 }
 
 fun Text.sanitizeWithNameProtect(): Text {
-    if (!ModuleNameProtect.enabled) {
+    if (!ModuleNameProtect.running) {
         return this
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAirJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAirJump.kt
@@ -22,21 +22,21 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.util.shape.VoxelShapes
 
-object ModuleAirJump : Module("AirJump", Category.MOVEMENT) {
+object ModuleAirJump : ClientModule("AirJump", Category.MOVEMENT) {
 
     val mode by enumChoice("Mode", Mode.JUMP_FREELY)
 
     private var doubleJump = true
 
     val allowJump: Boolean
-        get() = enabled && (mode == Mode.JUMP_FREELY || mode == Mode.DOUBLE_JUMP && doubleJump)
+        get() = running && (mode == Mode.JUMP_FREELY || mode == Mode.DOUBLE_JUMP && doubleJump)
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isOnGround) {
             doubleJump = true
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAntiBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAntiBounce.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * Prevents bouncing on blocks
  *
  * @see net.ccbluex.liquidbounce.injection.mixins.minecraft.entity.MixinEntity
  */
-object ModuleAntiBounce : Module("AntiBounce", Category.MOVEMENT)
+object ModuleAntiBounce : ClientModule("AntiBounce", Category.MOVEMENT)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAntiLevitation.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAntiLevitation.kt
@@ -19,13 +19,13 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * A anti levitation module
  *
  * Stops the levitation and slow falling effect.
  */
-object ModuleAntiLevitation : Module("AntiLevitation", Category.MOVEMENT) {
+object ModuleAntiLevitation : ClientModule("AntiLevitation", Category.MOVEMENT) {
     // @see net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLivingEntity hookTravelStatusEffect
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAvoidHazards.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleAvoidHazards.kt
@@ -21,15 +21,9 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.getBlock
-import net.minecraft.block.AbstractPressurePlateBlock
-import net.minecraft.block.Block
-import net.minecraft.block.CactusBlock
-import net.minecraft.block.CobwebBlock
-import net.minecraft.block.FireBlock
-import net.minecraft.block.MagmaBlock
-import net.minecraft.block.SweetBerryBushBlock
+import net.minecraft.block.*
 import net.minecraft.fluid.Fluids
 import net.minecraft.util.shape.VoxelShapes
 
@@ -38,7 +32,7 @@ import net.minecraft.util.shape.VoxelShapes
  *
  * Prevents you walking into blocks that might be malicious for you.
  */
-object ModuleAvoidHazards : Module("AvoidHazards", Category.MOVEMENT) {
+object ModuleAvoidHazards : ClientModule("AvoidHazards", Category.MOVEMENT) {
 
     private val cacti by boolean("Cacti", true)
     private val berryBush by boolean("BerryBush", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleBlockBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleBlockBounce.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.isBlockAtPosition
 import net.ccbluex.liquidbounce.utils.entity.box
 import net.minecraft.block.BedBlock
@@ -33,7 +33,7 @@ import net.minecraft.block.SlimeBlock
  *
  * Allows you to bounce higher on bouncy blocks.
  */
-object ModuleBlockBounce : Module("BlockBounce", Category.MOVEMENT) {
+object ModuleBlockBounce : ClientModule("BlockBounce", Category.MOVEMENT) {
 
     private val motion by float("Motion", 0.42f, 0.2f..2f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleBlockWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleBlockWalk.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.block.Blocks
 import net.minecraft.util.shape.VoxelShapes
 
@@ -31,7 +31,7 @@ import net.minecraft.util.shape.VoxelShapes
  * Allows you to walk on non-fullblock blocks.
  */
 
-object ModuleBlockWalk : Module("BlockWalk", Category.MOVEMENT) {
+object ModuleBlockWalk : ClientModule("BlockWalk", Category.MOVEMENT) {
 
     private val blocks by blocks("Blocks", hashSetOf(Blocks.COBWEB, Blocks.SNOW))
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleElytraRecast.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleElytraRecast.kt
@@ -20,7 +20,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.entity.effect.StatusEffects
@@ -35,7 +35,7 @@ import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
  *
  * @author Pivo1lovv
  */
-object ModuleElytraRecast : Module("ElytraRecast", Category.MOVEMENT) {
+object ModuleElytraRecast : ClientModule("ElytraRecast", Category.MOVEMENT) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleEntityControl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleEntityControl.kt
@@ -19,14 +19,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * Entity Control module
  *
  * Control rideable entities without a saddle
  */
-object ModuleEntityControl : Module("EntityControl", Category.MOVEMENT) {
+object ModuleEntityControl : ClientModule("EntityControl", Category.MOVEMENT) {
 
     val enforceSaddled by boolean("EnforceSaddled", true)
     val enforceJumpStrength by boolean("EnforceJumpStrength", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag.LagResult
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
@@ -45,7 +45,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  *
  * Allows you to freeze yourself without the server knowing.
  */
-object ModuleFreeze : Module("Freeze", Category.MOVEMENT) {
+object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT) {
 
     private val modes = choices("Mode", Queue, arrayOf(Queue, Cancel, Stationary))
         .apply { tagBy(this) }
@@ -147,7 +147,7 @@ object ModuleFreeze : Module("Freeze", Category.MOVEMENT) {
             get() = modes
 
         fun shouldLag(origin: TransferOrigin): LagResult? {
-            if (!enabled || !isRunning()) {
+            if (!running) {
                 return null
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleInventoryMove.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleInventoryMove.kt
@@ -22,9 +22,9 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.formatAsTime
 import net.ccbluex.liquidbounce.utils.client.notification
@@ -40,7 +40,7 @@ import net.minecraft.item.ItemGroups
  * Allows you to walk while an inventory is opened.
  */
 
-object ModuleInventoryMove : Module("InventoryMove", Category.MOVEMENT) {
+object ModuleInventoryMove : ClientModule("InventoryMove", Category.MOVEMENT) {
 
     private val undetectable by boolean("Undetectable", false)
     private val passthroughSneak by boolean("PassthroughSneak", false)
@@ -54,7 +54,7 @@ object ModuleInventoryMove : Module("InventoryMove", Category.MOVEMENT) {
 
         private val chronometer = Chronometer()
 
-        fun shouldLag() = ModuleInventoryMove.enabled && this.enabled && mc.currentScreen is HandledScreen<*>
+        fun shouldLag() = ModuleInventoryMove.running && this.enabled && mc.currentScreen is HandledScreen<*>
 
         val screenHandler = handler<ScreenEvent> {
             if (it.screen is HandledScreen<*>) {
@@ -65,7 +65,7 @@ object ModuleInventoryMove : Module("InventoryMove", Category.MOVEMENT) {
             }
         }
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (shouldLag() && chronometer.hasElapsed(maximumTime.toLong())) {
                 player.closeHandledScreen()
                 notification("InventoryMove", message("blinkEnd"), NotificationEvent.Severity.INFO)
@@ -79,7 +79,7 @@ object ModuleInventoryMove : Module("InventoryMove", Category.MOVEMENT) {
     }
 
     fun shouldHandleInputs(keyBinding: KeyBinding): Boolean {
-        if (!enabled || mc.currentScreen is ChatScreen || isInCreativeSearchField()) {
+        if (!running || mc.currentScreen is ChatScreen || isInCreativeSearchField()) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoClip.kt
@@ -20,9 +20,9 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -33,7 +33,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  *
  * Allows you to fly through blocks.
  */
-object ModuleNoClip : Module("NoClip", Category.MOVEMENT) {
+object ModuleNoClip : ClientModule("NoClip", Category.MOVEMENT) {
 
     val speed by float("Speed", 0.32f, 0.1f..0.4f)
     private val onlyInVehicle by boolean("OnlyInVehicle", false)
@@ -42,13 +42,13 @@ object ModuleNoClip : Module("NoClip", Category.MOVEMENT) {
     private var noClipSet = false
 
     @Suppress("unused")
-    private val handleGameTick = repeatable {
+    private val handleGameTick = tickHandler {
         if (paused()) {
             if (noClipSet) {
                 disable()
             }
 
-            return@repeatable
+            return@tickHandler
         }
 
         noClipSet = true
@@ -60,7 +60,7 @@ object ModuleNoClip : Module("NoClip", Category.MOVEMENT) {
         player.controllingVehicle?.let {
             it.noClip = true
 
-            if (!ModuleVehicleControl.enabled) {
+            if (!ModuleVehicleControl.running) {
                 it.velocity = it.velocity.strafe(speed = speed)
                 it.velocity.y = when {
                     mc.options.jumpKey.isPressed -> speed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoJumpDelay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoJumpDelay.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoJumpDelay module
@@ -27,4 +27,4 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Removes the delay between jumps.
  */
 
-object ModuleNoJumpDelay : Module("NoJumpDelay", Category.MOVEMENT)
+object ModuleNoJumpDelay : ClientModule("NoJumpDelay", Category.MOVEMENT)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoPush.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoPush.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoPush module
  *
  * Disables pushing from other players.
  */
-object ModuleNoPush : Module("NoPush", Category.MOVEMENT)
+object ModuleNoPush : ClientModule("NoPush", Category.MOVEMENT)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoWeb.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleNoWeb.kt
@@ -21,9 +21,9 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -37,7 +37,7 @@ import net.minecraft.util.math.Direction
  *
  * Disables web slowdown.
  */
-object ModuleNoWeb : Module("NoWeb", Category.MOVEMENT) {
+object ModuleNoWeb : ClientModule("NoWeb", Category.MOVEMENT) {
 
     init {
         enableLock()
@@ -45,7 +45,7 @@ object ModuleNoWeb : Module("NoWeb", Category.MOVEMENT) {
 
     private val modes = choices("Mode", Air, arrayOf(Air, GrimBreak, Intave14)).apply { tagBy(this) }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (ModuleAvoidHazards.enabled && ModuleAvoidHazards.cobWebs) {
             ModuleAvoidHazards.enabled = false
 
@@ -64,7 +64,7 @@ object ModuleNoWeb : Module("NoWeb", Category.MOVEMENT) {
      * @return if we should cancel the slowdown effect
      */
     fun handleEntityCollision(pos: BlockPos): Boolean {
-        if (!enabled) {
+        if (!running) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleParkour.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleParkour.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.moving
 
 /**
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.entity.moving
  *
  * Automatically jumps at the very edge of a block.
  */
-object ModuleParkour : Module("Parkour", Category.MOVEMENT) {
+object ModuleParkour : ClientModule("Parkour", Category.MOVEMENT) {
 
     @Suppress("unused")
     private val simulatedTickHandler = handler<SimulatedTickEvent> { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerSafeWalkEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -36,7 +36,7 @@ import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
  *
  * Prevents you from falling down as if you were sneaking.
  */
-object ModuleSafeWalk : Module("SafeWalk", Category.MOVEMENT) {
+object ModuleSafeWalk : ClientModule("SafeWalk", Category.MOVEMENT) {
 
     @Suppress("UnusedPrivateProperty")
     private val modes = choices("Mode", 1, ::safeWalkChoices) // Default safe mode

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSneak.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSneak.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
 
@@ -34,7 +34,7 @@ import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket
  *
  * Automatically sneaks all the time.
  */
-object ModuleSneak : Module("Sneak", Category.MOVEMENT) {
+object ModuleSneak : ClientModule("Sneak", Category.MOVEMENT) {
 
     var modes = choices("Mode", Vanilla, arrayOf(Legit, Vanilla, Switch)).apply { tagBy(this) }
     var notDuringMove by boolean("NotDuringMove", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSprint.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSprint.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
@@ -35,7 +35,7 @@ import net.minecraft.util.math.MathHelper
  * Sprints automatically.
  */
 
-object ModuleSprint : Module("Sprint", Category.MOVEMENT) {
+object ModuleSprint : ClientModule("Sprint", Category.MOVEMENT) {
 
     enum class SprintMode(override val choiceName: String) : NamedChoice {
         LEGIT("Legit"),
@@ -53,11 +53,11 @@ object ModuleSprint : Module("Sprint", Category.MOVEMENT) {
     // DO NOT USE TREE TO MAKE SURE THAT THE ROTATIONS ARE NOT CHANGED
     private val rotationsConfigurable = RotationsConfigurable(this)
 
-    fun shouldSprintOmnidirectionally() = enabled && sprintMode == SprintMode.OMNIDIRECTIONAL
+    fun shouldSprintOmnidirectionally() = running && sprintMode == SprintMode.OMNIDIRECTIONAL
 
-    fun shouldIgnoreBlindness() = enabled && ignoreBlindness
+    fun shouldIgnoreBlindness() = running && ignoreBlindness
 
-    fun shouldIgnoreHunger() = enabled && ignoreHunger
+    fun shouldIgnoreHunger() = running && ignoreHunger
 
     fun shouldPreventSprint(): Boolean {
         val deltaYaw = player.yaw - (RotationManager.currentRotation ?: return false).yaw
@@ -69,7 +69,7 @@ object ModuleSprint : Module("Sprint", Category.MOVEMENT) {
             && !shouldSprintOmnidirectionally()
             && RotationManager.workingAimPlan?.applyVelocityFix == false && !hasForwardMovement
 
-        return enabled && preventSprint
+        return running && preventSprint
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -32,7 +32,7 @@ import net.minecraft.entity.MovementType
  *
  * Strafe into different directions while you're midair.
  */
-object ModuleStrafe : Module("Strafe", Category.MOVEMENT) {
+object ModuleStrafe : ClientModule("Strafe", Category.MOVEMENT) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTargetStrafe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTargetStrafe.kt
@@ -6,7 +6,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.watchdog.SpeedHypixelLowHop
@@ -26,7 +26,7 @@ import kotlin.math.*
  *
  * TODO: Implement visuals
  */
-object ModuleTargetStrafe : Module("TargetStrafe", Category.MOVEMENT) {
+object ModuleTargetStrafe : ClientModule("TargetStrafe", Category.MOVEMENT) {
 
     // Configuration options
     private val modes = choices<Choice>("Mode", MotionMode, arrayOf(MotionMode)).apply { tagBy(this) }
@@ -132,7 +132,7 @@ object ModuleTargetStrafe : Module("TargetStrafe", Category.MOVEMENT) {
             }
 
             // If speed isn't enabled and requiresSpeed is, we exit early
-            if (requiresSpeed && !ModuleSpeed.enabled) {
+            if (requiresSpeed && !ModuleSpeed.running) {
                 return@handler
             }
 
@@ -182,7 +182,7 @@ object ModuleTargetStrafe : Module("TargetStrafe", Category.MOVEMENT) {
             }
 
             // Perform the strafing movement
-            if (hypixel && ModuleSpeed.enabled) {
+            if (hypixel && ModuleSpeed.running) {
                 val minSpeed = if (player.isOnGround) {
                     0.48
                 } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
@@ -5,7 +5,7 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
 import net.ccbluex.liquidbounce.utils.client.*
 import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
@@ -14,7 +14,7 @@ import java.text.DecimalFormat
 import kotlin.math.abs
 import kotlin.math.floor
 
-object ModuleTeleport : Module("Teleport", Category.EXPLOIT, aliases = arrayOf("tp")) {
+object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arrayOf("tp")) {
 
     private val allFull by boolean("AllFullPacket", false)
     private val paperExploit by boolean("PaperBypass", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleBoost.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleBoost.kt
@@ -20,9 +20,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.util.math.Vec3d
 import kotlin.math.cos
 import kotlin.math.sin
@@ -32,7 +32,7 @@ import kotlin.math.sin
  *
  * Boosts you when leaving a vehicle.
  */
-object ModuleVehicleBoost : Module("VehicleBoost", Category.MOVEMENT) {
+object ModuleVehicleBoost : ClientModule("VehicleBoost", Category.MOVEMENT) {
 
     init {
         enableLock()
@@ -42,7 +42,7 @@ object ModuleVehicleBoost : Module("VehicleBoost", Category.MOVEMENT) {
     private var verticalSpeed by float("VerticalSpeed", 1f, 0.1f..5f)
     private var wasInVehicle = false
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val isInVehicle = player.hasVehicle()
 
         if (wasInVehicle && !isInVehicle) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
@@ -24,9 +24,9 @@ import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.warning
 import net.ccbluex.liquidbounce.utils.entity.boxedDistanceTo
@@ -42,7 +42,7 @@ import net.minecraft.util.math.Vec3d
  *
  * Move with your vehicle however you want.
  */
-object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT, aliases = arrayOf("BoatFly")) {
+object ModuleVehicleControl : ClientModule("VehicleControl", Category.MOVEMENT, aliases = arrayOf("BoatFly")) {
 
     init {
         enableLock()
@@ -74,10 +74,10 @@ object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT, aliase
     }
 
     @Suppress("unused")
-    private val handleVehicleMovement = repeatable {
+    private val handleVehicleMovement = tickHandler {
         val vehicle = player.controllingVehicle ?: run {
             wasInVehicle = false
-            return@repeatable
+            return@tickHandler
         }
 
         // Show explanation message
@@ -139,7 +139,7 @@ object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT, aliase
         private var forceAttempt = false
 
         @Suppress("unused")
-        private val handleRehooking = repeatable {
+        private val handleRehooking = tickHandler {
             if (vehicleId >= 0 && !player.hasVehicle()) {
                 val vehicle = world.getEntityById(vehicleId)
 
@@ -148,7 +148,7 @@ object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT, aliase
                     if (vehicle.boxedDistanceTo(player) > player.entityInteractionRange) {
                         chat(warning(message("vehicleTooFar")))
                         vehicleId = -1
-                        return@repeatable
+                        return@tickHandler
                     }
 
                     // Enter the vehicle again
@@ -168,7 +168,7 @@ object ModuleVehicleControl : Module("VehicleControl", Category.MOVEMENT, aliase
                 forceAttempt = false
 
                 waitTicks(unhookAfter)
-                vehicleId = player.controllingVehicle?.id ?: return@repeatable
+                vehicleId = player.controllingVehicle?.id ?: return@tickHandler
                 network.sendPacket(ClientCommandC2SPacket(player, ClientCommandC2SPacket.Mode.PRESS_SHIFT_KEY))
                 player.stopRiding()
                 waitTicks(hookAfter - 1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/autododge/ModuleAutoDodge.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/autododge/ModuleAutoDodge.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.features.module.modules.render.murdermystery.ModuleMurderMystery
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
@@ -38,7 +38,7 @@ import net.minecraft.entity.projectile.ArrowEntity
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 
-object ModuleAutoDodge : Module("AutoDodge", Category.COMBAT) {
+object ModuleAutoDodge : ClientModule("AutoDodge", Category.COMBAT) {
     private object AllowRotationChange : ToggleableConfigurable(this, "AllowRotationChange", false) {
         val allowJump by boolean("AllowJump", true)
     }
@@ -55,7 +55,7 @@ object ModuleAutoDodge : Module("AutoDodge", Category.COMBAT) {
     @Suppress("unused")
     val tickRep = handler<MovementInputEvent> { event ->
         // We aren't where we are because of blink. So this module shall not cause any disturbance in that case.
-        if (ModuleBlink.enabled) {
+        if (ModuleBlink.running) {
             return@handler
         }
         if (ModuleMurderMystery.disallowsArrowDodge()) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/ModuleElytraFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/ModuleElytraFly.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraStatic
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraVanilla
 
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes
  * Makes you fly faster on Elytra.
  */
 
-object ModuleElytraFly : Module("ElytraFly", Category.MOVEMENT) {
+object ModuleElytraFly : ClientModule("ElytraFly", Category.MOVEMENT) {
 
     val instant by boolean("Instant", true)
     val instantStop by boolean("InstantStop", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraStatic.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraStatic.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.mode
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly.instant
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly.instantStop
@@ -33,27 +33,27 @@ internal object ElytraStatic : Choice("Static") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleElytraFly.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
 
         if (player.vehicle != null) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Find the chest slot
         val chestSlot = player.getEquippedStack(EquipmentSlot.CHEST)
 
         if (player.abilities.creativeMode) {
-            return@repeatable
+            return@tickHandler
         }
 
         // If the player doesn't have an elytra in the chest slot
         if (chestSlot.item != Items.ELYTRA) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (mc.options.sneakKey.isPressed && instantStop) {
             player.stopFallFlying()
-            return@repeatable
+            return@tickHandler
         }
         fun isAnyMovementKeyPressed(): Boolean {
             return mc.options.forwardKey.isPressed || mc.options.backKey.isPressed
@@ -70,7 +70,7 @@ internal object ElytraStatic : Choice("Static") {
                 player.velocity.y = when {
                     mc.options.jumpKey.isPressed -> ModuleElytraFly.Speed.vertical.toDouble()
                     mc.options.sneakKey.isPressed -> -ModuleElytraFly.Speed.vertical.toDouble()
-                    else -> return@repeatable
+                    else -> return@tickHandler
                 }
             }
             // If the player has an elytra and wants to fly instead

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraVanilla.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraVanilla.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.mode
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly.instant
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly.instantStop
@@ -36,27 +36,27 @@ internal object ElytraVanilla : Choice("Vanilla") {
         get() = ModuleElytraFly.modes
 
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
 
         if (player.vehicle != null) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Find the chest slot
         val chestSlot = player.getEquippedStack(EquipmentSlot.CHEST)
 
         if (player.abilities.creativeMode) {
-            return@repeatable
+            return@tickHandler
         }
 
         // If the player doesn't have an elytra in the chest slot
         if (chestSlot.item != Items.ELYTRA) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (mc.options.sneakKey.isPressed && instantStop) {
             player.stopFallFlying()
-            return@repeatable
+            return@tickHandler
         }
 
         // If player is flying
@@ -68,7 +68,7 @@ internal object ElytraVanilla : Choice("Vanilla") {
                 player.velocity.y = when {
                     mc.options.jumpKey.isPressed -> ModuleElytraFly.Speed.vertical.toDouble()
                     mc.options.sneakKey.isPressed -> -ModuleElytraFly.Speed.vertical.toDouble()
-                    else -> return@repeatable
+                    else -> return@tickHandler
                 }
             }
             // If the player has an elytra and wants to fly instead

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerStrideEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.*
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fireball.FlyFireball
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.grim.FlyGrim2859V
@@ -49,7 +49,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  * Allows you to fly.
  */
 
-object ModuleFly : Module("Fly", Category.MOVEMENT, aliases = arrayOf("Glide", "Jetpack")) {
+object ModuleFly : ClientModule("Fly", Category.MOVEMENT, aliases = arrayOf("Glide", "Jetpack")) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleFastUse
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
@@ -62,11 +62,11 @@ internal object FlyEnderpearl : Choice("Enderpearl") {
         canFly = false
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val slot = findHotbarSlot(Items.ENDER_PEARL)
 
         if (player.isDead || player.isSpectator || player.abilities.creativeMode) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (!threwPearl && !canFly) {
@@ -102,7 +102,7 @@ internal object FlyEnderpearl : Choice("Enderpearl") {
                 mc.options.sneakKey.isPressed -> -speed.toDouble()
                 else -> 0.0
             }
-            return@repeatable
+            return@tickHandler
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -29,8 +29,8 @@ import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
@@ -66,7 +66,7 @@ internal object FlyVanilla : Choice("Vanilla") {
         get() = ModuleFly.modes
 
     @Suppress("unused")
-    private val tickHandler = repeatable {
+    private val tickHandler = tickHandler {
         val useSprintSpeed = mc.options.sprintKey.isPressed && SprintSpeed.enabled
         val hSpeed =
             if (useSprintSpeed) SprintSpeed.horizontalSpeed else BaseSpeed.horizontalSpeed
@@ -127,7 +127,7 @@ internal object FlyCreative : Choice("Creative") {
         return true
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         player.abilities.flySpeed =
             if (mc.options.sprintKey.isPressed && SprintSpeed.enabled) SprintSpeed.speed else speed
 
@@ -203,7 +203,7 @@ internal object FlyExplosion : Choice("Explosion") {
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (strafeSince > 0) {
             if (!player.isOnGround) {
                 player.strafe(speed = strafeSince.toDouble())
@@ -243,7 +243,7 @@ internal object FlyJetpack : Choice("Jetpack") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleFly.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.input.jumping) {
             player.velocity.x *= 1.1
             player.velocity.y += 0.15

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/FlyFireball.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/FlyFireball.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fire
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fireball.techniques.FlyFireballCustomTechnique
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fireball.techniques.FlyFireballLegitTechnique
@@ -70,7 +70,7 @@ internal object FlyFireball : Choice("Fireball") {
     }
 
     @Suppress("unused")
-    val handleSilentFireballSelection = repeatable {
+    val handleSilentFireballSelection = tickHandler {
         if (AutoFireball.enabled) {
             val bestMainHandSlot = findFireballSlot()
             if (bestMainHandSlot != null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballLegitTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballLegitTechnique.kt
@@ -26,8 +26,8 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fireball.FlyFireball
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
@@ -80,7 +80,7 @@ object FlyFireballLegitTechnique : Choice("Legit") {
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (FlyFireball.wasTriggered) {
             canMove = !stopMove
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/trigger/FlyFireballInstantTrigger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/trigger/FlyFireballInstantTrigger.kt
@@ -22,7 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fire
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fireball.FlyFireball
 
 object FlyFireballInstantTrigger : Choice("Instant") {
@@ -30,7 +30,7 @@ object FlyFireballInstantTrigger : Choice("Instant") {
     override val parent: ChoiceConfigurable<Choice>
         get() = FlyFireball.trigger
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         FlyFireball.wasTriggered = true
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.fakelag.DelayData
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
@@ -66,7 +66,7 @@ internal object FlyHycraftDamage : Choice("HycraftDamage") {
         release = false
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         waitTicks(1)
         if (ticks > 0) ticks--
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel10thMar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel10thMar.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -52,7 +52,7 @@ internal object FlySentinel10thMar : Choice("Sentinel10thMar") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleFly.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         player.velocity.y = jumpHeight.toDouble()
         player.strafe(speed = jumpSpeed.toDouble())
         spoofOnGround = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModulePingSpoof
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
@@ -82,7 +82,7 @@ internal object FlySentinel20thApr : Choice("Sentinel20thApr") {
         player.zeroXZ()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         boost()
         waitTicks(reboostTicks)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel27thJan.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel27thJan.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -49,9 +49,9 @@ internal object FlySentinel27thJan : Choice("Sentinel27thJan") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleFly.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isOnGround) {
-            return@repeatable
+            return@tickHandler
         }
 
         player.velocity.y = when {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.Timer
@@ -71,9 +71,9 @@ object FlyNcpClip : Choice("NcpClip") {
 
     var shouldLag = false
         private set
-        get() = this.isRunning() && blink && field
+        get() = this.running && blink && field
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val startPos = startPosition
 
         // If fall damage is required, wait for damage to be true
@@ -123,7 +123,7 @@ object FlyNcpClip : Choice("NcpClip") {
 
             // Disable the module if the player is on ground again
             ModuleFly.enabled = false
-            return@repeatable
+            return@tickHandler
         } else if (startPos.distanceTo(player.pos) > maximumDistance) {
             if (shouldLag) {
                 // If we are lagging, we might abuse this to get us back to safety
@@ -136,7 +136,7 @@ object FlyNcpClip : Choice("NcpClip") {
 
             notification("Fly", "You have exceeded the maximum distance.",
                 NotificationEvent.Severity.ERROR)
-            return@repeatable
+            return@tickHandler
         }
 
         // Strafe the player to improve control

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -49,7 +49,7 @@ internal object FlyVerusB3869Flat : Choice("VerusB3896Flat") {
         get() = ModuleFly.modes
 
     val requiresLag
-        get() = this.isRunning()
+        get() = this.running
 
     val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
@@ -71,7 +71,7 @@ internal object FlyVerusB3869Flat : Choice("VerusB3896Flat") {
         event.cancelEvent()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         Timer.requestTimerSpeed(timer, Priority.IMPORTANT_FOR_USAGE_1, ModuleFly)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
@@ -23,9 +23,8 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.veru
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
-import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.enabled
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.client.chat
@@ -45,9 +44,9 @@ internal object FlyVerusB3896Damage : Choice("VerusB3896Damage") {
     override val parent: ChoiceConfigurable<*>
         get() = modes
 
-    var flyTicks = 0
-    var shouldStop = false
-    var gotDamage = false
+    private var flyTicks = 0
+    private var shouldStop = false
+    private var gotDamage = false
 
     override fun enable() {
         network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false))
@@ -57,7 +56,7 @@ internal object FlyVerusB3896Damage : Choice("VerusB3896Damage") {
     }
 
     @Suppress("unused")
-    val failRepeatable = repeatable {
+    val failRepeatable = tickHandler {
         if (!gotDamage) {
             waitTicks(20)
             if (!gotDamage) {
@@ -66,18 +65,18 @@ internal object FlyVerusB3896Damage : Choice("VerusB3896Damage") {
             }
         }
     }
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.hurtTime > 0) {
             gotDamage = true
         }
 
         if (!gotDamage) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (++flyTicks > 20 || shouldStop) {
-            enabled = false
-            return@repeatable
+            ModuleFly.enabled = false
+            return@tickHandler
         }
 
         player.strafe(speed = 9.95)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan277.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan277.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.vulc
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
 
 /**
@@ -37,7 +37,7 @@ internal object FlyVulcan277 : Choice("Vulcan277") {
     override val parent: ChoiceConfigurable<*>
         get() = modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.fallDistance > 0.1) {
             if (player.age % 2 == 0) {
                 player.velocity.y = -0.155

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286.kt
@@ -92,12 +92,12 @@ internal object FlyVulcan286 : Choice("Vulcan286-113") {
         }
     }
 
-    val packetHandler = handler<PacketEvent> {
-        if (it.packet is PlayerPositionLookS2CPacket) {
+    val packetHandler = handler<PacketEvent> { event ->
+        if (event.packet is PlayerPositionLookS2CPacket) {
             flags++
             if (flags == 1) {
-                packet = it.packet
-                it.cancelEvent()
+                packet = event.packet
+                event.cancelEvent()
             } else {
                 ModuleFly.enabled = false
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286Teleport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286Teleport.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -65,7 +65,7 @@ internal object FlyVulcan286Teleport : Choice("Vulcan286-Teleport-18") {
      * After damage, vulcan gives leniency to all sorts of stuff like
      * motion, and teleporting.
      */
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         jumping = true
 
         repeat(3) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
@@ -23,17 +23,17 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.highjump
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * HighJump module
  *
  * Allows you to jump higher.
  */
-object ModuleHighJump : Module("HighJump", Category.MOVEMENT) {
+object ModuleHighJump : ClientModule("HighJump", Category.MOVEMENT) {
 
     init {
         enableLock()
@@ -73,11 +73,11 @@ object ModuleHighJump : Module("HighJump", Category.MOVEMENT) {
         var shouldGlide = false
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (glide && shouldGlide) { // if the variable is true, then glide
                 if (player.isOnGround) {
                     shouldGlide = false
-                    return@repeatable
+                    return@tickHandler
                 }
                 if (player.fallDistance > 0) {
                     if (player.age % 2 == 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
@@ -21,7 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.modes.LiquidWalkNoCheatPlus
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.modes.LiquidWalkVanilla
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.modes.LiquidWalkVerusB3901
@@ -36,7 +36,7 @@ import net.minecraft.block.FluidBlock
  *
  * Allows you to walk on water like jesus. Also known as Jesus module.
  */
-object ModuleLiquidWalk : Module("LiquidWalk", Category.MOVEMENT, aliases = arrayOf("Jesus", "WaterWalk")) {
+object ModuleLiquidWalk : ClientModule("LiquidWalk", Category.MOVEMENT, aliases = arrayOf("Jesus", "WaterWalk")) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkNoCheatPlus.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkNoCheatPlus.kt
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.ModuleLiquidWalk
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.ModuleLiquidWalk.collidesWithAnythingElse
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.ModuleLiquidWalk.standingOnWater
@@ -63,7 +63,7 @@ internal object LiquidWalkNoCheatPlus : Choice("NoCheatPlus") {
         }
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.box.isBlockAtPosition { it is FluidBlock } && !player.input.sneaking) {
             player.velocity.y = 0.08
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkVulcan291.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkVulcan291.kt
@@ -22,7 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.mod
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.liquidwalk.ModuleLiquidWalk
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -41,7 +41,7 @@ internal object LiquidWalkVulcan291 : Choice("Vulcan291") {
         get() = ModuleLiquidWalk.modes
 
     @Suppress("unused")
-    private val tickHandler = repeatable {
+    private val tickHandler = tickHandler {
         // It DOES NOT bypass with Lava - do not use [player.isInFluid].
         if (player.isInsideWaterOrBubbleColumn) {
             // One tick speed-up for extra speed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
@@ -24,13 +24,13 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.modes.VulcanLongJump
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.modes.nocheatplus.NoCheatPlusBoost
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.modes.nocheatplus.NoCheatPlusBow
 import net.ccbluex.liquidbounce.utils.entity.moving
 
-object ModuleLongJump : Module("LongJump", Category.MOVEMENT) {
+object ModuleLongJump : ClientModule("LongJump", Category.MOVEMENT) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/VulcanLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/VulcanLongJump.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.ModuleLongJump
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -68,7 +68,7 @@ internal object VulcanLongJump : Choice("Vulcan289") {
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (started) {
             if (recievedLagback) {
                 player.velocity.y = 1.0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBoost.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBoost.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.ModuleLongJump
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.movement.zeroXZ
@@ -41,7 +41,7 @@ internal object NoCheatPlusBoost : Choice("NoCheatPlusBoost") {
 
     val ncpBoost by float("NCPBoost", 4.25f, 1f..10f)
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (ModuleLongJump.canBoost) {
             player.velocity.x *= ncpBoost.toDouble()
             player.velocity.z *= ncpBoost.toDouble()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBow.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBow.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.ModuleLongJump
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
@@ -65,7 +65,7 @@ internal object NoCheatPlusBow : Choice("NoCheatPlusBow") {
         }
     }
 
-    val tickJumpHandler = repeatable {
+    val tickJumpHandler = tickHandler {
         if (arrowBoost <= arrowsToShoot) {
             mc.options.useKey.isPressed = true
             RotationManager.aimAt(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/ModuleNoSlow.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/ModuleNoSlow.kt
@@ -18,10 +18,10 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.noslow
 
-import net.ccbluex.liquidbounce.event.*
-import net.ccbluex.liquidbounce.event.events.*
+import net.ccbluex.liquidbounce.event.events.PlayerUseMultiplier
+import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.blocking.NoSlowBlock
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.bow.NoSlowBow
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.consume.NoSlowConsume
@@ -39,7 +39,7 @@ import net.minecraft.util.UseAction
  *
  * Cancels slowness effects caused by blocks and using items.
  */
-object ModuleNoSlow : Module("NoSlow", Category.MOVEMENT) {
+object ModuleNoSlow : ClientModule("NoSlow", Category.MOVEMENT) {
 
     init {
         tree(NoSlowBlock)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlock.kt
@@ -49,14 +49,15 @@ internal object NoSlowBlock : ToggleableConfigurable(ModuleNoSlow, "Blocking", t
         )
     }
 
-    override fun isRunning(): Boolean {
-        if (!super.isRunning() || !inGame) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            if (!super.running || !inGame) {
+                return false
+            }
 
-        // Check if we are using a block item
-        return (player.isUsingItem && player.activeItem.useAction == UseAction.BLOCK) || isBlocking
-    }
+            // Check if we are using a block item
+            return (player.isUsingItem && player.activeItem.useAction == UseAction.BLOCK) || isBlocking
+        }
 
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlockingBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlockingBlink.kt
@@ -13,7 +13,7 @@ internal object NoSlowBlockingBlink : Choice("Blink") {
         get() = modes
 
     fun shouldLag(packet: Packet<*>?): FakeLag.LagResult? {
-        if (!isActive || !isRunning() || !player.isBlocking) {
+        if (!isSelected || !running || !player.isBlocking) {
             return null
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/bow/NoSlowBow.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/bow/NoSlowBow.kt
@@ -43,18 +43,19 @@ internal object NoSlowBow : ToggleableConfigurable(ModuleNoSlow, "Bow", true) {
         )
     }
 
-    override fun isRunning(): Boolean {
-        if (!super.isRunning() || !inGame) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            if (!super.running || !inGame) {
+                return false
+            }
 
-        // Check if we are using a block item
-        return player.isUsingItem && player.activeItem.useAction in arrayOf(
-            UseAction.BOW,
-            UseAction.CROSSBOW,
-            UseAction.SPEAR
-        )
-    }
+            // Check if we are using a block item
+            return player.isUsingItem && player.activeItem.useAction in arrayOf(
+                UseAction.BOW,
+                UseAction.CROSSBOW,
+                UseAction.SPEAR
+            )
+        }
 
     @Suppress("unused")
     private val noBlockInteract = tree(NoSlowNoBlockInteract(this) { action ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/consume/NoSlowConsume.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/consume/NoSlowConsume.kt
@@ -52,13 +52,14 @@ object NoSlowConsume : ToggleableConfigurable(ModuleNoSlow, "Consume", true) {
         )
     }
 
-    override fun isRunning(): Boolean {
-        if (!super.isRunning() || !inGame) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            if (!super.running || !inGame) {
+                return false
+            }
 
-        // Check if we are using a consume item
-        return player.isUsingItem && player.activeItem.isConsumable
-    }
+            // Check if we are using a consume item
+            return player.isUsingItem && player.activeItem.isConsumable
+        }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowNoBlockInteract.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowNoBlockInteract.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.shared
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.block.getState
@@ -33,7 +33,7 @@ import net.minecraft.util.UseAction
  * Confirmed to be working on 25th of May 2024
  */
 internal class NoSlowNoBlockInteract(
-    parent: EventHandler? = null,
+    parent: EventListener? = null,
     actionFilter: (UseAction) -> Boolean = { true }
 ) : ToggleableConfigurable(parent, "NoBlockInteract", true) {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowNoBlockInteract.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowNoBlockInteract.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.shared
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.block.getState
@@ -33,7 +33,7 @@ import net.minecraft.util.UseAction
  * Confirmed to be working on 25th of May 2024
  */
 internal class NoSlowNoBlockInteract(
-    parent: Listenable? = null,
+    parent: EventHandler? = null,
     actionFilter: (UseAction) -> Boolean = { true }
 ) : ToggleableConfigurable(parent, "NoBlockInteract", true) {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/sneaking/NoSlowSneaking.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/sneaking/NoSlowSneaking.kt
@@ -45,5 +45,6 @@ internal object NoSlowSneaking : ToggleableConfigurable(ModuleNoSlow, "Sneaking"
         event.multiplier = max(event.multiplier, minMultiplier)
     }
 
-    override fun isRunning() = super.isRunning() && inGame && player.isSneaking
+    override val running: Boolean
+        get() = super.running && inGame && player.isSneaking
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleCriticals
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
@@ -53,7 +53,7 @@ import net.ccbluex.liquidbounce.utils.combat.CombatManager
  *
  * Allows you to move faster.
  */
-object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
+object ModuleSpeed : ClientModule("Speed", Category.MOVEMENT) {
 
     init {
         enableLock()
@@ -105,21 +105,22 @@ object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
         val modes = choices(this, "Mode", { it.choices[0] },
             ModuleSpeed::initializeSpeeds)
 
-        override fun isRunning(): Boolean {
-            // We cannot use our parent super.handleEvents() here, because it has been turned false
-            // when [OnlyInCombat] is enabled
-            if (!ModuleSpeed.enabled || !enabled || !inGame || !passesRequirements()) {
-                return false
-            }
+        override val running: Boolean
+            get() {
+                // We cannot use our parent super.handleEvents() here, because it has been turned false
+                // when [OnlyInCombat] is enabled
+                if (!ModuleSpeed.running || !enabled || !inGame || !passesRequirements()) {
+                    return false
+                }
 
-            // Only On Potion Effect has a higher priority
-            if (OnlyOnPotionEffect.isRunning()) {
-                return false
-            }
+                // Only On Potion Effect has a higher priority
+                if (OnlyOnPotionEffect.running) {
+                    return false
+                }
 
-            return CombatManager.isInCombat ||
-                (ModuleKillAura.enabled && ModuleKillAura.targetTracker.lockedOnTarget != null)
-        }
+                return CombatManager.isInCombat ||
+                    (ModuleKillAura.running && ModuleKillAura.targetTracker.lockedOnTarget != null)
+            }
 
     }
 
@@ -135,15 +136,16 @@ object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
         val modes = choices(this, "Mode", { it.choices[0] },
             ModuleSpeed::initializeSpeeds)
 
-        override fun isRunning(): Boolean {
-            // We cannot use our parent super.handleEvents() here, because it has been turned false
-            // when [OnlyOnPotionEffect] is enabled
-            if (!ModuleSpeed.enabled || !enabled || !inGame || !passesRequirements()) {
-                return false
-            }
+        override val running: Boolean
+            get() {
+                // We cannot use our parent super.handleEvents() here, because it has been turned false
+                // when [OnlyOnPotionEffect] is enabled
+                if (!ModuleSpeed.running || !enabled || !inGame || !passesRequirements()) {
+                    return false
+                }
 
-            return potionEffects.activeChoice.checkPotionEffects()
-        }
+                return potionEffects.activeChoice.checkPotionEffects()
+            }
 
     }
 
@@ -152,36 +154,37 @@ object ModuleSpeed : Module("Speed", Category.MOVEMENT) {
         tree(OnlyOnPotionEffect)
     }
 
-    override fun isRunning(): Boolean {
-        // Early return if the module is not ready to be used - prevents accessing player when it's null below
-        // in case it was forgotten to be checked
-        if (!super.isRunning()) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            // Early return if the module is not ready to be used - prevents accessing player when it's null below
+            // in case it was forgotten to be checked
+            if (!super.running) {
+                return false
+            }
 
-        if (!passesRequirements()) {
-            return false
-        }
+            if (!passesRequirements()) {
+                return false
+            }
 
-        // We do not want to handle events if the OnlyInCombat is enabled
-        if (OnlyInCombat.enabled && OnlyInCombat.isRunning()) {
-            return false
-        }
+            // We do not want to handle events if the OnlyInCombat is enabled
+            if (OnlyInCombat.enabled && OnlyInCombat.running) {
+                return false
+            }
 
-        // We do not want to handle events if the OnlyOnPotionEffect is enabled
-        if (OnlyOnPotionEffect.enabled && OnlyOnPotionEffect.potionEffects.activeChoice.checkPotionEffects()) {
-            return false
-        }
+            // We do not want to handle events if the OnlyOnPotionEffect is enabled
+            if (OnlyOnPotionEffect.enabled && OnlyOnPotionEffect.potionEffects.activeChoice.checkPotionEffects()) {
+                return false
+            }
 
-        return true
-    }
+            return true
+        }
 
     private fun passesRequirements(): Boolean {
         if (!inGame) {
             return false
         }
 
-        if (notDuringScaffold && ModuleScaffold.enabled || ModuleFly.enabled) {
+        if (notDuringScaffold && ModuleScaffold.running || ModuleFly.running) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
@@ -56,7 +56,7 @@ import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket
  */
 class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom") {
 
-    private class HorizontalModification(parent: EventHandler?) : ToggleableConfigurable(parent,
+    private class HorizontalModification(parent: EventListener?) : ToggleableConfigurable(parent,
         "HorizontalModification", true) {
 
         private val horizontalAcceleration by float("HorizontalAcceleration", 0f, -0.1f..0.2f)
@@ -89,7 +89,7 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
 
     }
 
-    private class VerticalModification(parent: EventHandler?) : ToggleableConfigurable(parent,
+    private class VerticalModification(parent: EventListener?) : ToggleableConfigurable(parent,
         "VerticalModification", true) {
 
         private val jumpHeight by float("JumpHeight", 0.42f, 0.0f..3f)
@@ -114,7 +114,7 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
 
     }
 
-    private class Strafe(parent: EventHandler?) : ToggleableConfigurable(parent, "Strafe", true) {
+    private class Strafe(parent: EventListener?) : ToggleableConfigurable(parent, "Strafe", true) {
 
         private val strength by float("Strength", 1f, 0.1f..1f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleCriticals
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.SpeedAntiCornerBump
@@ -56,7 +56,7 @@ import net.minecraft.network.packet.s2c.play.EntityVelocityUpdateS2CPacket
  */
 class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom") {
 
-    private class HorizontalModification(parent: Listenable?) : ToggleableConfigurable(parent,
+    private class HorizontalModification(parent: EventHandler?) : ToggleableConfigurable(parent,
         "HorizontalModification", true) {
 
         private val horizontalAcceleration by float("HorizontalAcceleration", 0f, -0.1f..0.2f)
@@ -67,9 +67,9 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
          */
         private val ticksToBoostOff by int("TicksToBoostOff", 0, 0..20, "ticks")
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (!player.moving) {
-                return@repeatable
+                return@tickHandler
             }
 
             if (horizontalAcceleration != 0f) {
@@ -89,7 +89,7 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
 
     }
 
-    private class VerticalModification(parent: Listenable?) : ToggleableConfigurable(parent,
+    private class VerticalModification(parent: EventHandler?) : ToggleableConfigurable(parent,
         "VerticalModification", true) {
 
         private val jumpHeight by float("JumpHeight", 0.42f, 0.0f..3f)
@@ -97,9 +97,9 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
         private val pullDown by float("Pulldown", 0f, 0f..1f)
         private val pullDownDuringFall by float("PullDownDuringFall", 0f, 0f..1f)
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (!player.moving) {
-                return@repeatable
+                return@tickHandler
             }
 
             val pullDown = if (player.velocity.y <= 0.0) pullDownDuringFall else pullDown
@@ -114,7 +114,7 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
 
     }
 
-    private class Strafe(parent: Listenable?) : ToggleableConfigurable(parent, "Strafe", true) {
+    private class Strafe(parent: EventHandler?) : ToggleableConfigurable(parent, "Strafe", true) {
 
         private val strength by float("Strength", 1f, 0.1f..1f)
 
@@ -127,14 +127,14 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
         private var ticksTimeout = 0
 
         @Suppress("unused")
-        private val strafeHandler = repeatable {
+        private val strafeHandler = tickHandler {
             if (ticksTimeout > 0) {
                 ticksTimeout--
-                return@repeatable
+                return@tickHandler
             }
 
             if (!player.moving) {
-                return@repeatable
+                return@tickHandler
             }
 
             when {
@@ -183,9 +183,9 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : Choice("Custom")
         tree(Strafe(this))
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!player.moving) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (timerSpeed != 1f) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedGeneric.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.utils.entity.downwards
 import net.ccbluex.liquidbounce.utils.entity.moving
@@ -31,7 +31,7 @@ import net.ccbluex.liquidbounce.utils.entity.upwards
 
 class SpeedSpeedYPort(override val parent: ChoiceConfigurable<*>) : Choice("YPort") {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isOnGround && player.moving) {
             player.strafe(speed = 0.4)
             player.upwards(0.42f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/blocksmc/SpeedBlocksMC.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/blocksmc/SpeedBlocksMC.kt
@@ -26,8 +26,8 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -65,7 +65,7 @@ class SpeedBlocksMC(override val parent: ChoiceConfigurable<*>) : Choice("Blocks
         player.strafe(speed = 0.0)
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
 
         if (player.isOnGround) {
             airTicks = 0
@@ -74,7 +74,7 @@ class SpeedBlocksMC(override val parent: ChoiceConfigurable<*>) : Choice("Blocks
             airTicks++
 
             if (!canSpeed) {
-                return@repeatable
+                return@tickHandler
             }
             if (fullStrafe) {
                 if (player.moving) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexGround.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexGround.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.hy
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.minecraft.entity.effect.StatusEffects
 
 /**
@@ -38,24 +38,24 @@ class SpeedHylexGround(override val parent: ChoiceConfigurable<*>) : Choice("Hyl
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!player.isOnGround) {
             groundTicks = 0
-            return@repeatable
+            return@tickHandler
         }
 
         groundTicks++
 
         if (groundTicks <= 5) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (player.hurtTime >= 1) {
-            return@repeatable
+            return@tickHandler
         }
 
         if ((player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0) >= 1) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (!(mc.options.leftKey.isPressed || mc.options.rightKey.isPressed)) {
@@ -64,7 +64,7 @@ class SpeedHylexGround(override val parent: ChoiceConfigurable<*>) : Choice("Hyl
                 1.0,
                 1.2174
             )
-            return@repeatable
+            return@tickHandler
         }
 
         player.velocity = player.velocity.multiply(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexLowHop.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.hy
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
@@ -35,7 +35,7 @@ import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
 class SpeedHylexLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("HylexLowHop", parent) {
 
     var airTicks = 0
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isOnGround) {
             airTicks = 0
             if (player.moving && player.sqrtSpeed < 0.32) {
@@ -46,7 +46,7 @@ class SpeedHylexLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBa
                     1.1
                 )
             }
-            return@repeatable
+            return@tickHandler
         }
         airTicks++
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
@@ -22,7 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.in
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
@@ -51,7 +51,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         private const val BOOST_CONSTANT = 0.003
     }
 
-    private inner class Strafe(parent: EventHandler) : ToggleableConfigurable(parent, "Strafe", true) {
+    private inner class Strafe(parent: EventListener) : ToggleableConfigurable(parent, "Strafe", true) {
 
         private val strength by float("Strength", 0.29f, 0.01f..0.29f)
 
@@ -66,7 +66,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         }
     }
 
-    private inner class AirBoost(parent: EventHandler) : ToggleableConfigurable(parent, "AirBoost", true) {
+    private inner class AirBoost(parent: EventListener) : ToggleableConfigurable(parent, "AirBoost", true) {
 
         private val initialBoostMultiplier by float(
             "InitialBoostMultiplier", 1f,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
@@ -22,12 +22,12 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.in
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
@@ -51,7 +51,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         private const val BOOST_CONSTANT = 0.003
     }
 
-    private inner class Strafe(parent: Listenable) : ToggleableConfigurable(parent, "Strafe", true) {
+    private inner class Strafe(parent: EventHandler) : ToggleableConfigurable(parent, "Strafe", true) {
 
         private val strength by float("Strength", 0.29f, 0.01f..0.29f)
 
@@ -66,7 +66,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         }
     }
 
-    private inner class AirBoost(parent: Listenable) : ToggleableConfigurable(parent, "AirBoost", true) {
+    private inner class AirBoost(parent: EventHandler) : ToggleableConfigurable(parent, "AirBoost", true) {
 
         private val initialBoostMultiplier by float(
             "InitialBoostMultiplier", 1f,
@@ -74,7 +74,7 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         )
 
         @Suppress("unused")
-        private val tickHandler = repeatable {
+        private val tickHandler = tickHandler {
             if (player.velocity.y > 0.003 && player.isSprinting) {
                 player.velocity.x *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())
                 player.velocity.z *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
@@ -22,10 +22,10 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.nc
 
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.client.Timer
@@ -42,7 +42,7 @@ import net.minecraft.entity.effect.StatusEffects
  */
 class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP", parent) {
 
-    private inner class PullDown(parent: Listenable?) : ToggleableConfigurable(parent, "PullDown", true) {
+    private inner class PullDown(parent: EventHandler?) : ToggleableConfigurable(parent, "PullDown", true) {
 
         private val motionMultiplier by float("MotionMultiplier", 1f, 0.01f..10f)
         private val onTick by int("OnTick", 5, 1..9)
@@ -51,10 +51,10 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
         private var ticksInAir = 0
 
         @Suppress("unused")
-        private val repeatable = repeatable {
+        private val repeatable = tickHandler {
             if (player.isOnGround) {
                 ticksInAir = 0
-                return@repeatable
+                return@tickHandler
             } else {
                 ticksInAir++
                 if (ticksInAir == onTick) {
@@ -73,11 +73,11 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
         tree(PullDown(this))
     }
 
-    private inner class Boost(parent: Listenable?) : ToggleableConfigurable(parent, "Boost", true) {
+    private inner class Boost(parent: EventHandler?) : ToggleableConfigurable(parent, "Boost", true) {
         private val initialBoostMultiplier by float("InitialBoostMultiplier", 1f, 0.01f..10f)
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (player.moving) {
                 player.velocity.x *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())
                 player.velocity.z *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())
@@ -102,7 +102,7 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         val speedMultiplier = player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0
 
         if (player.moving) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
@@ -22,7 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.nc
 
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
@@ -42,7 +42,7 @@ import net.minecraft.entity.effect.StatusEffects
  */
 class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP", parent) {
 
-    private inner class PullDown(parent: EventHandler?) : ToggleableConfigurable(parent, "PullDown", true) {
+    private inner class PullDown(parent: EventListener?) : ToggleableConfigurable(parent, "PullDown", true) {
 
         private val motionMultiplier by float("MotionMultiplier", 1f, 0.01f..10f)
         private val onTick by int("OnTick", 5, 1..9)
@@ -73,7 +73,7 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
         tree(PullDown(this))
     }
 
-    private inner class Boost(parent: EventHandler?) : ToggleableConfigurable(parent, "Boost", true) {
+    private inner class Boost(parent: EventListener?) : ToggleableConfigurable(parent, "Boost", true) {
         private val initialBoostMultiplier by float("InitialBoostMultiplier", 1f, 0.01f..10f)
 
         @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModulePingSpoof
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
@@ -68,9 +68,9 @@ class SpeedSentinelDamage(override val parent: ChoiceConfigurable<*>) : Choice("
         super.enable()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!player.moving) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (externalDamageAdjust != 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/spartan/SpeedSpartan524.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/spartan/SpeedSpartan524.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerPostTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.moving
@@ -42,9 +42,9 @@ import net.ccbluex.liquidbounce.utils.movement.zeroXZ
  */
 class SpeedSpartan524(override val parent: ChoiceConfigurable<*>) : Choice("Spartan524") {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!player.moving) {
-            return@repeatable
+            return@tickHandler
         }
 
         Timer.requestTimerSpeed(1.1f, Priority.IMPORTANT_FOR_USAGE_1, ModuleSpeed)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
@@ -61,7 +61,7 @@ class SpeedVerusB3882(override val parent: ChoiceConfigurable<*>) : Choice("Veru
         }
     }
 
-    val timerRepeatable = repeatable {
+    val timerRepeatable = tickHandler {
         Timer.requestTimerSpeed(2.0F, Priority.IMPORTANT_FOR_USAGE_1, ModuleSpeed)
         waitTicks(101)
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
@@ -24,8 +24,8 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.entity.downwards
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -53,7 +53,7 @@ class SpeedVulcan288(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase
         waitTicks(1)
         player.strafe(speed = if (hasSpeed) 0.595 else 0.28)
     }
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val hasSpeed = (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0) != 0
         if (!player.isOnGround) {
             if (abs(player.fallDistance) > 0 && hasSpeed) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcanGround286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcanGround286.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -39,7 +39,7 @@ import net.minecraft.util.shape.VoxelShapes
  */
 class SpeedVulcanGround286(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("VulcanGround286", parent) {
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.moving && collidesBottomVertical()) {
             val speedEffect = player.getStatusEffect(StatusEffects.SPEED)
             val isAffectedBySpeed = speedEffect != null && speedEffect.amplifier > 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
@@ -26,8 +26,8 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
@@ -70,11 +70,11 @@ class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : Choice("Hyp
 
     private var wasFlagged = false
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.isOnGround) {
             // Strafe when on ground
             player.strafe()
-            return@repeatable
+            return@tickHandler
         } else {
             // Not much speed boost, but still a little bit - if someone wants to improve this, feel free to do so
             val horizontalMod = if (horizontalAcceleration) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelLowHop.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
@@ -47,14 +47,14 @@ class SpeedHypixelLowHop(override val parent: ChoiceConfigurable<*>) : Choice("H
 
     private var airTicks = 0
     @Suppress("unused")
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         shouldStrafe = false
 
         if (player.isOnGround) {
             player.strafe()
             shouldStrafe = true
             airTicks = 0
-            return@repeatable
+            return@tickHandler
         } else {
             airTicks++
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
@@ -19,10 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.spider
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
-import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.*
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.SpiderVanilla
+import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.SpiderVulcan288
 
-object ModuleSpider : Module("Spider", Category.MOVEMENT, aliases = arrayOf("WallClimb")) {
+object ModuleSpider : ClientModule("Spider", Category.MOVEMENT, aliases = arrayOf("WallClimb")) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVanilla.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVanilla.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.ModuleSpider
 
 internal object SpiderVanilla : Choice("Vanilla") {
@@ -30,7 +30,7 @@ internal object SpiderVanilla : Choice("Vanilla") {
     override val parent: ChoiceConfigurable<Choice>
         get() = ModuleSpider.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.horizontalCollision) {
             player.velocity.y = motion.toDouble()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVulcan288.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVulcan288.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.ModuleSpider
 
 /**
@@ -42,7 +42,7 @@ internal object SpiderVulcan288 : Choice("Vulcan288") {
 
     private var requiresStop = false
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.horizontalCollision) {
             if (!player.isClimbing) {
                 requiresStop = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleReverseStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleReverseStep.kt
@@ -24,9 +24,9 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.getBlock
 import net.ccbluex.liquidbounce.utils.entity.FallingPlayer
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
@@ -41,7 +41,7 @@ import net.minecraft.util.shape.VoxelShapes
  * Allows you to step down blocks faster.
  */
 
-object ModuleReverseStep : Module("ReverseStep", Category.MOVEMENT) {
+object ModuleReverseStep : ClientModule("ReverseStep", Category.MOVEMENT) {
 
     private var modes = choices("Mode", Instant, arrayOf(Instant, Strict, Accelerator)).apply { tagBy(this) }
     private val maximumFallDistance by float("MaximumFallDistance", 1f, 1f..50f)
@@ -68,7 +68,7 @@ object ModuleReverseStep : Module("ReverseStep", Category.MOVEMENT) {
         initiatedJump = true
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.velocity.y > 0.0) {
             initiatedJump = true
         } else if (player.isOnGround) {
@@ -83,10 +83,10 @@ object ModuleReverseStep : Module("ReverseStep", Category.MOVEMENT) {
         private val ticks by int("Ticks", 20, 1..40, "ticks")
         private val simulateFalling by boolean("SimulateFalling", false)
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (!initiatedJump && !player.isOnGround && !unwantedBlocksBelow) {
                 if (isFallingTooFar()) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 val simInput = SimulatedPlayer.SimulatedPlayerInput.fromClientPlayer(DirectionalInput.NONE)
@@ -128,10 +128,10 @@ object ModuleReverseStep : Module("ReverseStep", Category.MOVEMENT) {
 
         private val factor by float("Factor", 1.0F, 0.1F..5.0F)
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (!initiatedJump && !player.isOnGround && player.velocity.y < 0.0 && !unwantedBlocksBelow) {
                 if (isFallingTooFar()) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 player.velocity = player.velocity.multiply(0.0, factor.toDouble(), 0.0)
@@ -147,10 +147,10 @@ object ModuleReverseStep : Module("ReverseStep", Category.MOVEMENT) {
 
         private val motion by float("Motion", 1.0F, 0.1F..5.0F)
 
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (!initiatedJump && !player.isOnGround && !unwantedBlocksBelow) {
                 if (isFallingTooFar()) {
-                    return@repeatable
+                    return@tickHandler
                 }
 
                 player.velocity.y = -motion.toDouble()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
@@ -26,10 +26,10 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerStepEvent
 import net.ccbluex.liquidbounce.event.events.PlayerStepSuccessEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
@@ -45,7 +45,7 @@ import net.minecraft.stat.Stats
  * Allows you to step up blocks.
  */
 
-object ModuleStep : Module("Step", Category.MOVEMENT) {
+object ModuleStep : ClientModule("Step", Category.MOVEMENT) {
 
     var modes = choices("Mode", Instant, arrayOf(
         Instant,
@@ -105,7 +105,7 @@ object ModuleStep : Module("Step", Category.MOVEMENT) {
         private var ticksWait = 0
 
         @Suppress("unused")
-        private val tickHandler = repeatable {
+        private val tickHandler = tickHandler {
             if (ticksWait > 0) {
                 ticksWait--
             }
@@ -246,7 +246,8 @@ object ModuleStep : Module("Step", Category.MOVEMENT) {
             super.disable()
         }
 
-        override fun isRunning() = super.isRunning() && !ModuleSpeed.enabled
+        override val running: Boolean
+        get() = super.running && !ModuleSpeed.running
 
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
@@ -21,7 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.fastclimb.FastClimb
 import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.icespeed.IceSpeed
 
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.ic
  *
  * Move faster on specific surfaces.
  */
-object ModuleTerrainSpeed : Module("TerrainSpeed", Category.MOVEMENT) {
+object ModuleTerrainSpeed : ClientModule("TerrainSpeed", Category.MOVEMENT) {
 
     init {
         enableLock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiAFK.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiAFK.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiAFK.CustomMode.Rotate.angle
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiAFK.CustomMode.Rotate.ignoreOpenInventory
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiAFK.CustomMode.Rotate.rotationsConfigurable
@@ -46,7 +46,7 @@ import kotlin.random.Random
  * Prevents you from being kicked for AFK.
  */
 
-object ModuleAntiAFK : Module("AntiAFK", Category.PLAYER) {
+object ModuleAntiAFK : ClientModule("AntiAFK", Category.PLAYER) {
 
     private val modes = choices(
         "Mode", RandomMode, arrayOf(
@@ -60,7 +60,7 @@ object ModuleAntiAFK : Module("AntiAFK", Category.PLAYER) {
             get() = modes
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             waitTicks(10)
             player.yaw += 180f
         }
@@ -82,7 +82,7 @@ object ModuleAntiAFK : Module("AntiAFK", Category.PLAYER) {
         var randomDirection = DirectionalInput.NONE
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             when (Random.nextInt(0, 6)) {
                 0 -> {
                     EventScheduler.schedule<MovementInputEvent>(ModuleScaffold) {
@@ -155,7 +155,7 @@ object ModuleAntiAFK : Module("AntiAFK", Category.PLAYER) {
         val move by boolean("Move", true)
 
         @Suppress("unused")
-        val swingRepeatable = repeatable {
+        val swingRepeatable = tickHandler {
             if (Swing.enabled && !player.handSwinging) {
                 waitTicks(Swing.delay)
                 player.swingHand(Hand.MAIN_HAND)
@@ -163,7 +163,7 @@ object ModuleAntiAFK : Module("AntiAFK", Category.PLAYER) {
         }
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (move) {
                 mc.options.forwardKey.isPressed = true
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiExploit.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.notification
 
 /**
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.utils.client.notification
  *
  * Prevents exploits
  */
-object ModuleAntiExploit : Module("AntiExploit", Category.PLAYER) {
+object ModuleAntiExploit : ClientModule("AntiExploit", Category.PLAYER) {
 
     val limitExplosionStrength by boolean("LimitExplosionStrength", true)
     val limitExplosionRange by boolean("LimitExplosionRange", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoBreak.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoBreak.kt
@@ -18,9 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player
 
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.hit.HitResult
@@ -30,17 +30,17 @@ import net.minecraft.util.hit.HitResult
  *
  * Automatically breaks blocks.
  */
-object ModuleAutoBreak : Module("AutoBreak", Category.PLAYER) {
+object ModuleAutoBreak : ClientModule("AutoBreak", Category.PLAYER) {
 
     private var wasBreaking = false
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val crosshairTarget = mc.crosshairTarget
 
         if (crosshairTarget is BlockHitResult && crosshairTarget.type == HitResult.Type.BLOCK) {
-            val blockState = crosshairTarget.blockPos.getState() ?: return@repeatable
+            val blockState = crosshairTarget.blockPos.getState() ?: return@tickHandler
             if (blockState.isAir) {
-                return@repeatable
+                return@tickHandler
             }
 
             // Start breaking

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoFish.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoFish.kt
@@ -21,9 +21,9 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.item.FishingRodItem
 import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket
@@ -37,7 +37,7 @@ import net.minecraft.util.Hand
  * Automatically catches fish when using a rod.
  */
 
-object ModuleAutoFish : Module("AutoFish", Category.PLAYER) {
+object ModuleAutoFish : ClientModule("AutoFish", Category.PLAYER) {
 
     private val reelDelay by intRange("ReelDelay", 5..8, 0..20, "ticks")
 
@@ -55,7 +55,7 @@ object ModuleAutoFish : Module("AutoFish", Category.PLAYER) {
         caughtFish = false
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (caughtFish) {
             for (hand in arrayOf(Hand.MAIN_HAND, Hand.OFF_HAND)) {
                 if (player.getEquippedStack(hand.equipmentSlot).item !is FishingRodItem) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoRespawn.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoRespawn.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.client.gui.screen.DeathScreen
 
 /**
@@ -29,7 +29,7 @@ import net.minecraft.client.gui.screen.DeathScreen
  *
  * Automatically respawns the player after dying.
  */
-object ModuleAutoRespawn : Module("AutoRespawn", Category.PLAYER) {
+object ModuleAutoRespawn : ClientModule("AutoRespawn", Category.PLAYER) {
 
     // There is a delay until the button is clickable on the death screen (20 ticks)
     private val delay by int("Delay", 0, 0..20, "ticks")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWalk.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * AutoWalk module
  *
  * Automatically makes you walk.
  */
-object ModuleAutoWalk : Module("AutoWalk", Category.PLAYER) {
+object ModuleAutoWalk : ClientModule("AutoWalk", Category.PLAYER) {
 
     @Suppress("unused")
     val moveInputHandler = handler<MovementInputEvent>(priority = 1000) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
@@ -25,12 +25,12 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMovementTickEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag.findAvoidingArrowPosition
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag.getInflictedHit
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.minecraft.client.network.OtherClientPlayerEntity
@@ -44,7 +44,7 @@ import java.util.*
  * Makes it look as if you were teleporting to other players.
  */
 
-object ModuleBlink : Module("Blink", Category.PLAYER) {
+object ModuleBlink : ClientModule("Blink", Category.PLAYER) {
 
     private val dummy by boolean("Dummy", false)
     private val ambush by boolean("Ambush", false)
@@ -104,12 +104,13 @@ object ModuleBlink : Module("Blink", Category.PLAYER) {
         }
     }
 
-    val repeatable = repeatable {
+    @Suppress("unused")
+    private val tickTask = tickHandler {
         if (evadeArrows) {
-            val (playerPosition, _, _) = FakeLag.firstPosition() ?: return@repeatable
+            val (playerPosition, _, _) = FakeLag.firstPosition() ?: return@tickHandler
 
             if (getInflictedHit(playerPosition) == null) {
-                return@repeatable
+                return@tickHandler
             }
 
             val evadingPacket = findAvoidingArrowPosition()
@@ -132,7 +133,8 @@ object ModuleBlink : Module("Blink", Category.PLAYER) {
         }
     }
 
-    val playerMoveHandler = handler<PlayerMovementTickEvent> {
+    @Suppress("unused")
+    private val playerMoveHandler = handler<PlayerMovementTickEvent> {
         if (AutoResetOption.enabled && FakeLag.positions.count() > AutoResetOption.resetAfter) {
             when (AutoResetOption.action) {
                 ResetAction.RESET -> FakeLag.cancel()
@@ -143,8 +145,9 @@ object ModuleBlink : Module("Blink", Category.PLAYER) {
             }
 
             notification("Blink", "Auto reset", NotificationEvent.Severity.INFO)
-            if (autoDisable)
+            if (autoDisable) {
                 enabled = false
+            }
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ScaffoldBlockItemSelection.isValidBlock
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -32,7 +32,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
  *
  * Legit trick to build faster.
  */
-object ModuleEagle : Module("Eagle", Category.PLAYER, aliases = arrayOf("FastBridge", "BridgeAssistant")) {
+object ModuleEagle : ClientModule("Eagle", Category.PLAYER, aliases = arrayOf("FastBridge", "BridgeAssistant")) {
 
     private val edgeDistance by float("EagleEdgeDistance", 0.4f, 0.01f..1.3f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastExp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastExp.kt
@@ -19,9 +19,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.OffHandSlot
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
@@ -44,7 +44,7 @@ import net.minecraft.item.Items
  *
  * Automatically repairs your armor.
  */
-object ModuleFastExp : Module(
+object ModuleFastExp : ClientModule(
     "FastExp",
     Category.PLAYER,
     bindAction = InputBind.BindAction.HOLD,
@@ -65,10 +65,10 @@ object ModuleFastExp : Module(
     private val slotResetDelay by intRange("SlotResetDelay", 0..0, 0..40, "ticks")
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         val slot = getSlot()
         if (slot == null || player.isDead || InventoryManager.isInventoryOpenServerSide || isRepaired(slot)) {
-            return@repeatable
+            return@tickHandler
         }
 
         CombatManager.pauseCombatForAtLeast(combatPauseTime)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
@@ -22,9 +22,9 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.moving
@@ -41,7 +41,7 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
  * Allows you to use items faster.
  */
 
-object ModuleFastUse : Module("FastUse", Category.PLAYER) {
+object ModuleFastUse : ClientModule("FastUse", Category.PLAYER) {
 
     private val modes = choices("Mode", Immediate, arrayOf(Immediate, ItemUseTime)).apply { tagBy(this) }
 
@@ -107,7 +107,7 @@ object ModuleFastUse : Module("FastUse", Category.PLAYER) {
         val speed by int("Speed", 20, 1..35, "packets")
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (accelerateNow) {
                 Timer.requestTimerSpeed(
                     timer, Priority.IMPORTANT_FOR_USAGE_1, ModuleFastUse,
@@ -133,7 +133,7 @@ object ModuleFastUse : Module("FastUse", Category.PLAYER) {
         val speed by int("Speed", 20, 1..35, "packets")
 
         @Suppress("unused")
-        val repeatable = repeatable {
+        val repeatable = tickHandler {
             if (accelerateNow && player.itemUseTime >= consumeTime) {
                 repeat(speed) {
                     network.sendPacket(packetType.generatePacket())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleNoRotateSet.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleNoRotateSet.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 
 /**
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
  *
  * Prevents the server from rotating your head.
  */
-object ModuleNoRotateSet : Module("NoRotateSet", Category.PLAYER) {
+object ModuleNoRotateSet : ClientModule("NoRotateSet", Category.PLAYER) {
     val mode = choices(
         "Mode", SilentAccept, arrayOf(
             SilentAccept, ResetRotation

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleReach.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleReach.kt
@@ -19,8 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
-import kotlin.math.max
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * Reach module
@@ -28,7 +27,7 @@ import kotlin.math.max
  * Increases your reach.
  */
 
-object ModuleReach : Module("Reach", Category.PLAYER) {
+object ModuleReach : ClientModule("Reach", Category.PLAYER) {
 
     val combatReach by float("CombatReach", 4.2f, 3f..8f).apply { tagBy(this) }
     val blockReach by float("BlockReach", 5f, 4.5f..8f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleSmartEat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleSmartEat.kt
@@ -22,9 +22,9 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.events.PlayerInteractedItem
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.render.renderEnvironmentForGUI
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
@@ -48,7 +48,7 @@ import kotlin.math.absoluteValue
  * Makes it easier to eat
  */
 
-object ModuleSmartEat : Module("SmartEat", Category.PLAYER) {
+object ModuleSmartEat : ClientModule("SmartEat", Category.PLAYER) {
     private val HOTBAR_OFFHAND_LEFT_TEXTURE = Identifier.of("hud/hotbar_offhand_left")
 
     private val swapBackDelay by int("SwapBackDelay", 5, 1..20)
@@ -160,13 +160,13 @@ object ModuleSmartEat : Module("SmartEat", Category.PLAYER) {
             )
         }
 
-        val tickHandler = repeatable {
+        val tickHandler = tickHandler {
             val useAction = player.activeItem.useAction
 
             if (useAction != UseAction.EAT && useAction != UseAction.DRINK)
-                return@repeatable
+                return@tickHandler
             if (!SilentHotbar.isSlotModifiedBy(this@SilentOffhand))
-                return@repeatable
+                return@tickHandler
 
             // if we are already eating, we want to keep the silent slot
             SilentHotbar.selectSlotSilently(this@SilentOffhand, SilentHotbar.serversideSlot, swapBackDelay)
@@ -180,7 +180,7 @@ object ModuleSmartEat : Module("SmartEat", Category.PLAYER) {
     private object AutoEat : ToggleableConfigurable(this, "AutoEat", true) {
         private val minHunger by int("MinHunger", 15, 0..20)
 
-        private val tickHandler = repeatable {
+        private val tickHandler = tickHandler {
 
             if (player.hungerManager.foodLevel < minHunger) {
                 waitUntil {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
@@ -23,9 +23,9 @@ package net.ccbluex.liquidbounce.features.module.modules.player.antivoid
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidBlinkMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidFlagMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidGhostBlockMode
@@ -39,7 +39,7 @@ import net.minecraft.util.shape.VoxelShapes
  * AntiVoid module protects the player from falling into the void by simulating
  * future movements and taking action if necessary.
  */
-object ModuleAntiVoid : Module("AntiVoid", Category.PLAYER) {
+object ModuleAntiVoid : ClientModule("AntiVoid", Category.PLAYER) {
 
     val mode = choices("Mode", AntiVoidGhostBlockMode, arrayOf(
         AntiVoidGhostBlockMode,
@@ -124,9 +124,9 @@ object ModuleAntiVoid : Module("AntiVoid", Category.PLAYER) {
      * Executes periodically to check if an anti-void action is required, and triggers it if necessary.
      */
     @Suppress("unused")
-    private val antiVoidListener = repeatable {
+    private val antiVoidListener = tickHandler {
         if (mode.activeChoice.isExempt || !isLikelyFalling) {
-            return@repeatable
+            return@tickHandler
         }
 
         val boundingBox = player.boundingBox.withMinY(voidThreshold.toDouble())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidBlinkMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidBlinkMode.kt
@@ -39,11 +39,11 @@ object AntiVoidBlinkMode : AntiVoidMode("Blink") {
 
     // Cases in which the AntiVoid protection should not be active.
     override val isExempt
-        get() = super.isExempt || ModuleScaffold.enabled
+        get() = super.isExempt || ModuleScaffold.running
 
     // Whether artificial lag is needed to prevent falling into the void.
     val requiresLag
-        get() = AntiVoidBlinkMode.isRunning() && ModuleAntiVoid.isLikelyFalling
+        get() = AntiVoidBlinkMode.running && ModuleAntiVoid.isLikelyFalling
             && !isExempt && isWorth()
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidMode.kt
@@ -32,7 +32,7 @@ abstract class AntiVoidMode(name: String) : Choice(name) {
 
     // Cases in which the AntiVoid protection should not be active.
     open val isExempt: Boolean
-        get() = player.isDead || ModuleFly.enabled
+        get() = player.isDead || ModuleFly.running
 
     /**
      * Attempt to safely move the player to a safe location.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
@@ -24,15 +24,15 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autobuff
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.*
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
 
-object ModuleAutoBuff : Module("AutoBuff", Category.PLAYER, aliases = arrayOf("AutoPot", "AutoGapple", "AutoSoup")) {
+object ModuleAutoBuff : ClientModule("AutoBuff", Category.PLAYER, aliases = arrayOf("AutoPot", "AutoGapple", "AutoSoup")) {
 
     /**
      * All buff features
@@ -88,14 +88,14 @@ object ModuleAutoBuff : Module("AutoBuff", Category.PLAYER, aliases = arrayOf("A
     private val activeFeatures
         get() = features.filter { it.enabled }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (notDuringCombat && CombatManager.isInCombat) {
-            return@repeatable
+            return@tickHandler
         }
 
         for (feature in activeFeatures) {
             if (feature.runIfPossible(this)) {
-                return@repeatable
+                return@tickHandler
             }
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/ModuleAutoQueue.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/ModuleAutoQueue.kt
@@ -19,12 +19,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.modes.AutoQueueGommeDuels
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.modes.AutoQueueHypixelSW
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.modes.AutoQueuePaper
 
-object ModuleAutoQueue : Module("AutoQueue", Category.PLAYER) {
+object ModuleAutoQueue : ClientModule("AutoQueue", Category.PLAYER) {
     val modes = choices("Mode", AutoQueuePaper, arrayOf(
         AutoQueuePaper,
         AutoQueueHypixelSW,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueueGommeDuels.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueueGommeDuels.kt
@@ -25,8 +25,8 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
-import net.ccbluex.liquidbounce.event.repeatable
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue.modes
 import net.ccbluex.liquidbounce.utils.client.*
@@ -56,13 +56,13 @@ object AutoQueueGommeDuels : Choice("GommeDuels") {
         super.enable()
     }
 
-    val repeatable = repeatable {
-        val inGameHud = mc.inGameHud ?: return@repeatable
+    val repeatable = tickHandler {
+        val inGameHud = mc.inGameHud ?: return@tickHandler
         val playerListHeader = inGameHud.playerListHud.header
 
         if (playerListHeader == null) {
             inMatch = false
-            return@repeatable
+            return@tickHandler
         }
 
         // Check if we are on GommeHD.net
@@ -72,7 +72,7 @@ object AutoQueueGommeDuels : Choice("GommeDuels") {
 
             notification("AutoPlay", "Not on GommeHD.net", NotificationEvent.Severity.ERROR)
             waitTicks(20)
-            return@repeatable
+            return@tickHandler
         }
 
         // Check in which situation we are
@@ -165,7 +165,7 @@ object AutoQueueGommeDuels : Choice("GommeDuels") {
                 PlayerInteractItemC2SPacket(Hand.MAIN_HAND, sequence, player.yaw, player.pitch)
             }
             waitTicks(20)
-        } else if (!ModuleKillAura.enabled && controlKillAura) {
+        } else if (!ModuleKillAura.running && controlKillAura) {
             ModuleKillAura.enabled = true
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueueHypixelSW.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueueHypixelSW.kt
@@ -24,7 +24,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.modes
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue.modes
 import net.ccbluex.liquidbounce.utils.item.findHotbarSlot
 import net.minecraft.item.Items
@@ -39,10 +39,10 @@ object AutoQueueHypixelSW : Choice("HypixelSW") {
     private val hasPaper
         get() = (findHotbarSlot { it.item == Items.PAPER } ?: -1) != -1
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         // Check if we have paper in our hotbar
         if (!hasPaper) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Send join command

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueuePaper.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/modes/AutoQueuePaper.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue.modes
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
@@ -39,10 +39,10 @@ object AutoQueuePaper : Choice("Paper") {
     override val parent: ChoiceConfigurable<Choice>
         get() = modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         val paper = (findHotbarSlot { it.item == Items.PAPER } ?: -1)
         if (paper == -1) {
-            return@repeatable
+            return@tickHandler
         }
 
         SilentHotbar.selectSlotSilently(ModuleAutoQueue, paper)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopInventoryManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopInventoryManager.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player.autoshop
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.player
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.sumValues
 import net.minecraft.item.PotionItem
 import net.minecraft.registry.Registries
 
-class AutoShopInventoryManager : Listenable {
+class AutoShopInventoryManager : EventHandler {
 
     private val prevInventoryItems = mutableMapOf<String, Int>()
     private val currentInventoryItems = mutableMapOf<String, Int>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopInventoryManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/AutoShopInventoryManager.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player.autoshop
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.player
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.sumValues
 import net.minecraft.item.PotionItem
 import net.minecraft.registry.Registries
 
-class AutoShopInventoryManager : EventHandler {
+class AutoShopInventoryManager : EventListener {
 
     private val prevInventoryItems = mutableMapOf<String, Int>()
     private val currentInventoryItems = mutableMapOf<String, Int>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features.FeatureChestAura
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.*
 import net.ccbluex.liquidbounce.utils.inventory.*
@@ -39,7 +39,7 @@ import kotlin.math.ceil
  * Automatically steals all items from a chest.
  */
 
-object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
+object ModuleChestStealer : ClientModule("ChestStealer", Category.PLAYER) {
 
     val inventoryConstrains = tree(InventoryConstraints())
     val autoClose by boolean("AutoClose", true)
@@ -195,7 +195,7 @@ object ModuleChestStealer : Module("ChestStealer", Category.PLAYER) {
      * Either asks [ModuleInventoryCleaner] what to do or just takes everything.
      */
     private fun createCleanupPlan(screen: GenericContainerScreen): InventoryCleanupPlan {
-        val cleanupPlan = if (!ModuleInventoryCleaner.enabled) {
+        val cleanupPlan = if (!ModuleInventoryCleaner.running) {
             val usefulItems = findItemsInContainer(screen)
 
             InventoryCleanupPlan(usefulItems.toMutableSet(), mutableListOf(), hashMapOf())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/features/FeatureChestAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/features/FeatureChestAura.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.fea
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.ModuleChestStealer
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
@@ -143,13 +143,13 @@ object FeatureChestAura : ToggleableConfigurable(ModuleChestStealer, "Aura", tru
 
     // Task that repeats to interact with the target block
     @Suppress("unused")
-    private val interactionRepeatableTask = repeatable { event ->
+    private val interactionRepeatableTask = tickHandler { event ->
         if (mc.currentScreen is GenericContainerScreen) {
             // Do not proceed if a screen is open which implies player might be in a GUI
-            return@repeatable
+            return@tickHandler
         }
 
-        val targetBlockPos = currentTargetBlock ?: return@repeatable
+        val targetBlockPos = currentTargetBlock ?: return@tickHandler
         val currentPlayerRotation = RotationManager.serverRotation
 
         // Trace a ray from the player to the target block position
@@ -157,12 +157,12 @@ object FeatureChestAura : ToggleableConfigurable(ModuleChestStealer, "Aura", tru
             interactionRange.toDouble(),
             currentPlayerRotation,
             targetBlockPos,
-            targetBlockPos.getState() ?: return@repeatable
+            targetBlockPos.getState() ?: return@tickHandler
         )
 
         // Verify if the block is hit and is the correct target
         if (rayTraceResult?.type != HitResult.Type.BLOCK || rayTraceResult.blockPos != targetBlockPos) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Attempt to interact with the block

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.invcleaner
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.ItemFacet
 import net.ccbluex.liquidbounce.features.module.modules.player.offhand.ModuleOffhand
 import net.ccbluex.liquidbounce.utils.inventory.ClickInventoryAction
@@ -35,7 +35,7 @@ import net.minecraft.screen.slot.SlotActionType
  *
  * Automatically throws away useless items and sorts them.
  */
-object ModuleInventoryCleaner : Module("InventoryCleaner", Category.PLAYER) {
+object ModuleInventoryCleaner : ClientModule("InventoryCleaner", Category.PLAYER) {
 
     private val inventoryConstraints = tree(PlayerInventoryConstraints())
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.nofall
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes.*
 import net.minecraft.entity.EntityPose
 
@@ -29,7 +29,7 @@ import net.minecraft.entity.EntityPose
  * Protects you from taking fall damage.
  */
 
-object ModuleNoFall : Module("NoFall", Category.PLAYER) {
+object ModuleNoFall : ClientModule("NoFall", Category.PLAYER) {
 
     internal val modes = choices(
         "Mode", NoFallSpoofGround, arrayOf(
@@ -52,27 +52,28 @@ object ModuleNoFall : Module("NoFall", Category.PLAYER) {
 
     private var duringFallFlying by boolean("DuringFallFlying", false)
 
-    override fun isRunning(): Boolean {
-        if (!super.isRunning()) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            if (!super.running) {
+                return false
+            }
 
-        // In creative mode, we don't need to reduce fall damage
-        if (player.isCreative || player.isSpectator) {
-            return false
-        }
+            // In creative mode, we don't need to reduce fall damage
+            if (player.isCreative || player.isSpectator) {
+                return false
+            }
 
-        // Check if we are invulnerable or flying
-        if (player.abilities.invulnerable || player.abilities.flying) {
-            return false
-        }
+            // Check if we are invulnerable or flying
+            if (player.abilities.invulnerable || player.abilities.flying) {
+                return false
+            }
 
-        // With Elytra - we don't want to reduce fall damage.
-        if (!duringFallFlying && player.isFallFlying && player.isInPose(EntityPose.FALL_FLYING)) {
-            return false
-        }
+            // With Elytra - we don't want to reduce fall damage.
+            if (!duringFallFlying && player.isFallFlying && player.isInPose(EntityPose.FALL_FLYING)) {
+                return false
+            }
 
-        return true
-    }
+            return true
+        }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallBlink.kt
@@ -142,6 +142,6 @@ internal object NoFallBlink : Choice("Blink") {
         super.disable()
     }
 
-    fun shouldLag() = isRunning() && blinkFall
+    fun shouldLag() = running && blinkFall
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.Timer
@@ -38,7 +38,7 @@ internal object NoFallHypixelPacket : Choice("HypixelPacket") {
         return (!player.isFallingToVoid() && !void || void)
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.fallDistance - player.velocity.y >= 3.3 && voidCheck()) {
             Timer.requestTimerSpeed(0.5f, Priority.IMPORTANT_FOR_PLAYER_LIFE, ModuleNoFall)
             network.sendPacket(MovePacketType.ON_GROUND_ONLY.generatePacket().apply {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallMLG.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallMLG.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
@@ -86,13 +86,13 @@ internal object NoFallMLG : Choice("MLG") {
         )
     }
 
-    val tickHandler = repeatable {
-        val target = currentTarget ?: return@repeatable
+    val tickHandler = tickHandler {
+        val target = currentTarget ?: return@tickHandler
 
-        val rayTraceResult = raycast() ?: return@repeatable
+        val rayTraceResult = raycast() ?: return@tickHandler
 
         if (target.doesCorrespondTo(rayTraceResult)) {
-            return@repeatable
+            return@tickHandler
         }
 
         SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot.hotbarSlotForServer, 1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallPacket.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 
@@ -32,7 +32,7 @@ internal object NoFallPacket : Choice("Packet") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleNoFall.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (always || player.fallDistance > 2f && player.age > 20) {
             network.sendPacket(packetType.generatePacket().apply {
                 onGround = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallRettungsplatform.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallRettungsplatform.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.block.getBlock
@@ -52,16 +52,16 @@ internal object NoFallRettungsplatform : Choice("Rettungsplatform") {
     private val itemToPlatform
         get() = Hotbar.findClosestItem(Items.BLAZE_ROD, Items.MAGMA_CREAM)
 
-    val repatable = repeatable {
+    val repatable = tickHandler {
         if (player.fallDistance > 2f) {
-            val itemToPlatform = itemToPlatform ?: return@repeatable
+            val itemToPlatform = itemToPlatform ?: return@tickHandler
 
             // Are we actually going to fall into the void?
             // todo: check if the fall damage is actually high enough to kill us
             val collision = FallingPlayer.fromPlayer(player).findCollision(90)?.pos
             ModuleDebug.debugParameter(ModuleNoFall, "Collision", collision?.getBlock().toString())
             if (collision != null && collision.getState()?.isAir == false) {
-                return@repeatable
+                return@tickHandler
             }
 
             useHotbarSlotOrOffhand(itemToPlatform)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
@@ -35,7 +35,7 @@ internal object NoFallSpartan524Flag : Choice("Spartan524Flag") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleNoFall.modes
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (player.fallDistance > 2f) {
             network.sendPacket(PlayerMoveC2SPacket.OnGroundOnly(true))
             waitTicks(1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/ModuleOffhand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/ModuleOffhand.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura.ModuleCrystalAura
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
@@ -56,7 +56,7 @@ import org.lwjgl.glfw.GLFW
  *
  * Manages your offhand.
  */
-object ModuleOffhand : Module("Offhand", Category.PLAYER, aliases = arrayOf("AutoTotem")) {
+object ModuleOffhand : ClientModule("Offhand", Category.PLAYER, aliases = arrayOf("AutoTotem")) {
 
     private val inventoryConstraints = tree(PlayerInventoryConstraints())
     private var switchMode = enumChoice("SwitchMode", SwitchMode.AUTOMATIC)
@@ -224,7 +224,7 @@ object ModuleOffhand : Module("Offhand", Category.PLAYER, aliases = arrayOf("Aut
         return actions
     }
 
-    fun isOperating() = enabled && activeMode != Mode.NONE
+    fun isOperating() = running && activeMode != Mode.NONE
 
     private enum class Mode(val modeName: String, private val item: Item, private val fallBackItem: Item? = null) {
         TOTEM("Totem", Items.TOTEM_OF_UNDYING) {
@@ -262,7 +262,7 @@ object ModuleOffhand : Module("Offhand", Category.PLAYER, aliases = arrayOf("Aut
             }
 
             override fun shouldEquip(): Boolean {
-                val killAura = Strength.onlyWhileKa && !ModuleKillAura.enabled
+                val killAura = Strength.onlyWhileKa && !ModuleKillAura.running
                 if (!Strength.enabled || killAura || player.hasStatusEffect(StatusEffects.STRENGTH)) {
                     return false
                 }
@@ -286,7 +286,7 @@ object ModuleOffhand : Module("Offhand", Category.PLAYER, aliases = arrayOf("Aut
 
                 if (player.mainHandStack.item is SwordItem && Gapple.WhileHoldingSword.enabled) {
                     return if (Gapple.WhileHoldingSword.onlyWhileKa) {
-                        ModuleKillAura.enabled
+                        ModuleKillAura.running
                     } else {
                         true
                     }
@@ -298,7 +298,7 @@ object ModuleOffhand : Module("Offhand", Category.PLAYER, aliases = arrayOf("Aut
             override fun canCycleTo() = Gapple.enabled
         },
         CRYSTAL("Crystal", Items.END_CRYSTAL) {
-            override fun canCycleTo() = Crystal.enabled && (!Crystal.onlyWhileCa || ModuleCrystalAura.enabled)
+            override fun canCycleTo() = Crystal.enabled && (!Crystal.onlyWhileCa || ModuleCrystalAura.running)
         },
         BACK("Back", Items.AIR) {
             override fun getSlot(): ItemSlot? {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/Totem.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/Totem.kt
@@ -92,7 +92,7 @@ class Totem : ToggleableConfigurable(ModuleOffhand, "Totem", true) {
             val ignoreElytra by boolean("IgnoreElytra", false)
 
             fun getFallDamage(): Float {
-                if (ModuleNoFall.enabled || !FallDamage.enabled || player.fallDistance <= 3f) {
+                if (ModuleNoFall.running || !FallDamage.enabled || player.fallDistance <= 3f) {
                     return 0f
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAnimations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAnimations.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerStrideEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleAnimations.PushdownAnimation.applySwingOffset
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.Arm
@@ -40,7 +40,7 @@ import net.minecraft.util.math.RotationAxis
  * Please credit from where you got the animation from and make sure they are willing to contribute.
  * If they are not willing to contribute, please do not add the animation to this module.
  */
-object ModuleAnimations : Module("Animations", Category.RENDER) {
+object ModuleAnimations : ClientModule("Animations", Category.RENDER) {
 
     init {
         tree(MainHand)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAntiBlind.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAntiBlind.kt
@@ -19,14 +19,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * AntiBlind module
  *
  * Protects you from potentially annoying screen effects that block your view.
  */
-object ModuleAntiBlind : Module("AntiBlind", Category.RENDER) {
+object ModuleAntiBlind : ClientModule("AntiBlind", Category.RENDER) {
     val antiBlind by boolean("DisableBlindingEffect", true)
     val antiDarkness by boolean("DisableDarknessEffect", true)
     val antiNausea by boolean("DisableNauseaEffect", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAttackEffects.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAttackEffects.kt
@@ -22,14 +22,14 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.block.Blocks
 import net.minecraft.client.sound.PositionedSoundInstance
 import net.minecraft.entity.LivingEntity
 import net.minecraft.particle.ParticleTypes
 import net.minecraft.sound.SoundEvents
 
-object ModuleAttackEffects : Module("AttackEffects", Category.RENDER) {
+object ModuleAttackEffects : ClientModule("AttackEffects", Category.RENDER) {
 
     enum class Particle(override val choiceName: String) : NamedChoice {
         NONE("None"),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAutoF5.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleAutoF5.kt
@@ -24,7 +24,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.event.events.PerspectiveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
 import net.minecraft.client.gui.screen.ingame.InventoryScreen
 import net.minecraft.client.option.Perspective
@@ -32,7 +32,7 @@ import net.minecraft.client.option.Perspective
 /**
  * Automatically goes into F5 mode when opening the inventory
  */
-object ModuleAutoF5 : Module("AutoF5", Category.RENDER) {
+object ModuleAutoF5 : ClientModule("AutoF5", Category.RENDER) {
 
     @Suppress("unused")
     private val perspectiveHandler = handler<PerspectiveEvent> { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBedPlates.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBedPlates.kt
@@ -23,7 +23,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.FontManager
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForGUI
@@ -46,7 +46,7 @@ import kotlin.math.sqrt
 private const val ITEM_SIZE: Int = 16
 private const val BACKGROUND_PADDING: Int = 2
 
-object ModuleBedPlates : Module("BedPlates", Category.RENDER) {
+object ModuleBedPlates : ClientModule("BedPlates", Category.RENDER) {
     private val ROMAN_NUMERALS = arrayOf("", "I", "II", "III", "IV", "V")
 
     private val maxLayers by int("MaxLayers", 5, 1..5)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.DrawOutlinesEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
@@ -42,14 +42,14 @@ import net.minecraft.util.math.BlockPos
  * Allows you to see selected blocks through walls.
  */
 
-object ModuleBlockESP : Module("BlockESP", Category.RENDER) {
+object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
 
     private val modes = choices("Mode", Glow, arrayOf(Box, Glow, Outline))
     private val targets by blocks(
         "Targets",
         findBlocksEndingWith("_BED", "DRAGON_EGG").toHashSet()
     ).onChange {
-        if (enabled) {
+        if (running) {
             disable()
             enable()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockOutline.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockOutline.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 
 /**
@@ -29,6 +29,6 @@ import net.ccbluex.liquidbounce.render.engine.Color4b
  *
  * TODO: Implement Block Side Box and GUI Information Panel
  */
-object ModuleBlockOutline : Module("BlockOutline", Category.RENDER, aliases = arrayOf("BlockOverlay")) {
+object ModuleBlockOutline : ClientModule("BlockOutline", Category.RENDER, aliases = arrayOf("BlockOverlay")) {
     val outlineColor by color("Outline", Color4b(68, 117, 255, 102))
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.utils.rainbow
@@ -45,7 +45,7 @@ import java.util.*
  *
  * Leaves traces behind players.
  */
-object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER, aliases = arrayOf("PlayerTrails")) {
+object ModuleBreadcrumbs : ClientModule("Breadcrumbs", Category.RENDER, aliases = arrayOf("PlayerTrails")) {
 
     private val onlyOwn by boolean("OnlyOwn", true)
     private val color by color("Color", Color4b(70, 119, 255, 120))
@@ -142,7 +142,7 @@ object ModuleBreadcrumbs : Module("Breadcrumbs", Category.RENDER, aliases = arra
     }
 
     @Suppress("unused")
-    val worldChangeHandler = handler<WorldChangeEvent>(ignoreCondition = true) {
+    val worldChangeHandler = handler<WorldChangeEvent>(ignoreNotRunning = true) {
         clear()
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCameraClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCameraClip.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * CameraClip module
@@ -27,6 +27,6 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Allows you to see through walls in third person view.
  */
 
-object ModuleCameraClip : Module("CameraClip", Category.RENDER) {
+object ModuleCameraClip : ClientModule("CameraClip", Category.RENDER) {
     val distance by float("CameraDistance", 4f, 1f..16f)
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleChams.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleChams.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
-object ModuleChams: Module("Chams", Category.RENDER)
+object ModuleChams: ClientModule("Chams", Category.RENDER)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.integration.VirtualScreenType
 import net.ccbluex.liquidbounce.integration.VrScreen
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.ITab
@@ -44,7 +44,7 @@ import org.lwjgl.glfw.GLFW
  */
 
 object ModuleClickGui :
-    Module("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY_RIGHT_SHIFT, disableActivation = true) {
+    ClientModule("ClickGUI", Category.RENDER, bind = GLFW.GLFW_KEY_RIGHT_SHIFT, disableActivation = true) {
 
     @Suppress("UnusedPrivateProperty")
     private val scale by float("Scale", 1f, 0.5f..2f).onChanged {
@@ -149,7 +149,7 @@ object ModuleClickGui :
     @Suppress("unused")
     private val gameRenderHandler = handler<GameRenderEvent>(
         priority = EventPriorityConvention.OBJECTION_AGAINST_EVERYTHING,
-        ignoreCondition = true
+        ignoreNotRunning = true
     ) {
         // A hack to prevent the clickgui from being drawn
         if (mc.currentScreen !is ClickScreen) {
@@ -159,7 +159,7 @@ object ModuleClickGui :
 
     @Suppress("unused")
     private val browserReadyHandler = handler<BrowserReadyEvent>(
-        ignoreCondition = true
+        ignoreNotRunning = true
     ) {
         createView()
     }
@@ -167,7 +167,7 @@ object ModuleClickGui :
     @Suppress("unused")
     private val worldChangeHandler = sequenceHandler<WorldChangeEvent>(
         priority = EventPriorityConvention.OBJECTION_AGAINST_EVERYTHING,
-        ignoreCondition = true
+        ignoreNotRunning = true
     ) { event ->
         if (event.world == null) {
             return@sequenceHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityType
 import net.minecraft.entity.mob.MobEntity
@@ -37,7 +37,7 @@ import net.minecraft.util.math.BlockPos
  * The idea behind this module originates from the video
  * "2b2t's WAR Against Chicken Lag" https://www.youtube.com/watch?v=Qqmz76Z5az0
  */
-object ModuleCombineMobs : Module("CombineMobs", Category.RENDER) {
+object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
 
     private val trackedEntitySinceRender = mutableMapOf<EntityType<*>, MutableList<BlockPos>>()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCustomAmbience.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCustomAmbience.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 
 /**
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.render.engine.Color4b
  *
  * Override the ambience of the game
  */
-object ModuleCustomAmbience : Module("CustomAmbience", Category.RENDER) {
+object ModuleCustomAmbience : ClientModule("CustomAmbience", Category.RENDER) {
 
     val weather = enumChoice("Weather", WeatherType.SUNNY)
     private val time = enumChoice("Time", TimeType.NOON)
@@ -66,7 +66,7 @@ object ModuleCustomAmbience : Module("CustomAmbience", Category.RENDER) {
 
     @JvmStatic
     fun getTime(original: Long): Long {
-        return if (enabled) {
+        return if (running) {
             when (time.get()) {
                 TimeType.NO_CHANGE -> original
                 TimeType.DAWN -> 23041L

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDamageParticles.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDamageParticles.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.event.events.DisconnectEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.FontManager
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForGUI
@@ -41,7 +41,7 @@ import kotlin.math.abs
  *
  * Show health changes of entities
  */
-object ModuleDamageParticles : Module("DamageParticles", Category.RENDER) {
+object ModuleDamageParticles : ClientModule("DamageParticles", Category.RENDER) {
 
     private val scale by float("Scale", 1.5F, 0.25F..4F)
     private val ttl by float("TimeToLive", 1.5F, 0.5F..5.0F, "s")
@@ -79,7 +79,7 @@ object ModuleDamageParticles : Module("DamageParticles", Category.RENDER) {
     }
 
     @Suppress("unused")
-    private val tickHandler = repeatable {
+    private val tickHandler = tickHandler {
         val entities = world.entities.filterIsInstanceTo(hashSetOf<LivingEntity>())
         entities.remove(player)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
@@ -161,7 +161,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
         debuggedOwners.onEach { (owner, parameter) ->
             val ownerName = when (owner) {
                 is ClientModule -> owner.name
-                is EventHandler -> "${owner.parent()?.javaClass?.simpleName}::${owner.javaClass.simpleName}"
+                is EventListener -> "${owner.parent()?.javaClass?.simpleName}::${owner.javaClass.simpleName}"
                 else -> owner.javaClass.simpleName
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -19,14 +19,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
@@ -51,7 +51,7 @@ import java.awt.Color
  * Allows you to see server-sided rotations.
  */
 
-object ModuleDebug : Module("Debug", Category.RENDER) {
+object ModuleDebug : ClientModule("Debug", Category.RENDER) {
 
     private val parameters by boolean("Parameters", true)
     private val geometry by boolean("Geometry", true)
@@ -64,7 +64,7 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
         val tickRep = handler<MovementInputEvent> { _ ->
             // We aren't actually where we are because of blink.
             // So this module shall not cause any disturbance in that case.
-            if (ModuleBlink.enabled) {
+            if (ModuleBlink.running) {
                 return@handler
             }
 
@@ -105,9 +105,9 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
         }
     }
 
-    val repeatable = repeatable {
-        if (!ModuleSpeed.enabled) {
-            return@repeatable
+    val repeatable = tickHandler {
+        if (!ModuleSpeed.running) {
+            return@tickHandler
         }
 
         val pos0 = Vec3d(77.0, 75.0, -52.0)
@@ -160,8 +160,8 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
 
         debuggedOwners.onEach { (owner, parameter) ->
             val ownerName = when (owner) {
-                is Module -> owner.name
-                is Listenable -> "${owner.parent()?.javaClass?.simpleName}::${owner.javaClass.simpleName}"
+                is ClientModule -> owner.name
+                is EventHandler -> "${owner.parent()?.javaClass?.simpleName}::${owner.javaClass.simpleName}"
                 else -> owner.javaClass.simpleName
             }
 
@@ -204,7 +204,7 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
     }
 
     inline fun debugGeometry(owner: Any, name: String, lazyGeometry: () -> DebuggedGeometry) {
-        if (!enabled) {
+        if (!running) {
             return
         }
 
@@ -213,7 +213,7 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
 
     fun debugGeometry(owner: Any, name: String, geometry: DebuggedGeometry) {
         // Do not take any new debugging while the module is off
-        if (!enabled) {
+        if (!running) {
             return
         }
 
@@ -227,7 +227,7 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
     private val debugParameters = hashMapOf<DebuggedParameter, Any>()
 
     inline fun debugParameter(owner: Any, name: String, lazyValue: () -> Any) {
-        if (!enabled) {
+        if (!running) {
             return
         }
 
@@ -235,7 +235,7 @@ object ModuleDebug : Module("Debug", Category.RENDER) {
     }
 
     fun debugParameter(owner: Any, name: String, value: Any) {
-        if (!enabled) {
+        if (!running) {
             return
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleESP.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.combat.EntityTaggingManager
@@ -39,7 +39,7 @@ import net.minecraft.util.math.Box
  * Allows you to see targets through walls.
  */
 
-object ModuleESP : Module("ESP", Category.RENDER) {
+object ModuleESP : ClientModule("ESP", Category.RENDER) {
 
     override val baseKey: String
         get() = "liquidbounce.module.esp"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeCam.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeCam.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.entity.eyes
 import net.ccbluex.liquidbounce.utils.entity.getMovementDirectionOfInput
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -40,7 +40,7 @@ import net.minecraft.util.math.Vec3i
  *
  * Allows you to move out of your body.
  */
-object ModuleFreeCam : Module("FreeCam", Category.RENDER, disableOnQuit = true) {
+object ModuleFreeCam : ClientModule("FreeCam", Category.RENDER, disableOnQuit = true) {
 
     private val speed by float("Speed", 1f, 0.1f..2f)
 
@@ -111,7 +111,7 @@ object ModuleFreeCam : Module("FreeCam", Category.RENDER, disableOnQuit = true) 
     fun applyCameraPosition(entity: Entity, tickDelta: Float) {
         val camera = mc.gameRenderer.camera
 
-        if (!enabled || entity != player) {
+        if (!running || entity != player) {
             return
         }
 
@@ -119,7 +119,7 @@ object ModuleFreeCam : Module("FreeCam", Category.RENDER, disableOnQuit = true) 
     }
 
     fun renderPlayerFromAllPerspectives(entity: LivingEntity): Boolean {
-        if (!enabled || entity != player) {
+        if (!running || entity != player) {
             return entity.isSleeping
         }
 
@@ -130,16 +130,16 @@ object ModuleFreeCam : Module("FreeCam", Category.RENDER, disableOnQuit = true) 
      * Modify the raycast position
      */
     fun modifyRaycast(original: Vec3d, entity: Entity, tickDelta: Float): Vec3d {
-        if (!enabled || entity != mc.player || !allowCameraInteract) {
+        if (!running || entity != mc.player || !allowCameraInteract) {
             return original
         }
 
         return pos?.interpolate(tickDelta) ?: original
     }
 
-    fun shouldDisableCrosshair() = enabled && !allowCameraInteract
+    fun shouldDisableCrosshair() = running && !allowCameraInteract
 
-    fun shouldDisableRotations() = enabled && !allowRotationChange
+    fun shouldDisableRotations() = running && !allowRotationChange
 
     private fun updatePosition(velocity: Vec3d) {
         pos = (pos ?: PositionPair(player.eyes, player.eyes)).apply { this += velocity }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeLook.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFreeLook.kt
@@ -23,11 +23,11 @@ import net.ccbluex.liquidbounce.event.events.MouseRotationEvent
 import net.ccbluex.liquidbounce.event.events.PerspectiveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.input.InputBind
 import net.minecraft.client.option.Perspective.THIRD_PERSON_BACK
 
-object ModuleFreeLook : Module(
+object ModuleFreeLook : ClientModule(
     "FreeLook", Category.RENDER, disableOnQuit = true, bindAction = InputBind.BindAction.HOLD
 ) {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFullBright.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleFullBright.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerPostTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.entity.effect.StatusEffectInstance
 import net.minecraft.entity.effect.StatusEffects
 
@@ -32,7 +32,7 @@ import net.minecraft.entity.effect.StatusEffects
  *
  * Allows you to see in the dark.
  */
-object ModuleFullBright : Module("FullBright", Category.RENDER) {
+object ModuleFullBright : ClientModule("FullBright", Category.RENDER) {
 
     private val modes = choices(
         "Mode", FullBrightGamma, arrayOf(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHoleESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHoleESP.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.events.PlayerPostTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.block.ChunkScanner
@@ -59,7 +59,7 @@ typealias State = Byte
  * Detects and displays safe spots for Crystal PvP.
  */
 
-object ModuleHoleESP : Module("HoleESP", Category.RENDER) {
+object ModuleHoleESP : ClientModule("HoleESP", Category.RENDER) {
 
     private val modes = choices("Mode", GlowingPlane, arrayOf(BoxChoice, GlowingPlane))
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHud.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHud.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.events.SpaceSeperatedNamesChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isHidingNow
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.integration.VirtualScreenType
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.ITab
 import net.ccbluex.liquidbounce.integration.theme.ThemeManager
@@ -45,7 +45,7 @@ import net.minecraft.client.gui.screen.DisconnectedScreen
  * The client in-game dashboard.
  */
 
-object ModuleHud : Module("HUD", Category.RENDER, state = true, hide = true) {
+object ModuleHud : ClientModule("HUD", Category.RENDER, state = true, hide = true) {
 
     private var browserTab: ITab? = null
 
@@ -68,8 +68,8 @@ object ModuleHud : Module("HUD", Category.RENDER, state = true, hide = true) {
         tree(Configurable("Custom", customComponents as MutableList<Value<*>>))
     }
 
-    val screenHandler = handler<ScreenEvent>(ignoreCondition = true) {
-        if (!enabled || !inGame || it.screen is DisconnectedScreen || isHidingNow) {
+    val screenHandler = handler<ScreenEvent>(ignoreNotRunning = true) {
+        if (!running || !inGame || it.screen is DisconnectedScreen || isHidingNow) {
             browserTab?.closeTab()
             browserTab = null
         } else if (browserTab == null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
@@ -38,7 +38,7 @@ import net.minecraft.util.math.Box
  * Allows you to see dropped items through walls.
  */
 
-object ModuleItemESP : Module("ItemESP", Category.RENDER) {
+object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
 
     override val baseKey: String
         get() = "liquidbounce.module.itemEsp"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemTags.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemTags.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.FontManager
 import net.ccbluex.liquidbounce.render.GUIRenderEnvironment
 import net.ccbluex.liquidbounce.render.engine.Color4b
@@ -46,7 +46,7 @@ private const val BACKGROUND_PADDING: Int = 2
  *
  * Show the names and quantities of items in several boxes.
  */
-object ModuleItemTags : Module("ItemTags", Category.RENDER) {
+object ModuleItemTags : ClientModule("ItemTags", Category.RENDER) {
 
     override val baseKey: String
         get() = "liquidbounce.module.itemTags"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleJumpEffect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleJumpEffect.kt
@@ -22,9 +22,9 @@ import it.unimi.dsi.fastutil.objects.ObjectLongMutablePair
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.drawGradientCircle
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
@@ -33,7 +33,7 @@ import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.math.Easing
 import net.minecraft.util.math.Vec3d
 
-object ModuleJumpEffect : Module("JumpEffect", Category.RENDER) {
+object ModuleJumpEffect : ClientModule("JumpEffect", Category.RENDER) {
 
     private val endRadius by floatRange("EndRadius", 0.15F..0.8F, 0F..3F)
 
@@ -48,7 +48,7 @@ object ModuleJumpEffect : Module("JumpEffect", Category.RENDER) {
 
     private val circles = ArrayDeque<ObjectLongMutablePair<Vec3d>>()
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         with(circles.iterator()) {
             while (hasNext()) {
                 val pair = next()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleMobOwners.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleMobOwners.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.config.gson.util.decode
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.io.HttpClient
 import net.minecraft.entity.Entity
 import net.minecraft.entity.passive.HorseEntity
@@ -39,14 +39,14 @@ import java.util.concurrent.ConcurrentHashMap
  * Shows you from which player a tamable entity or projectile belongs to.
  */
 
-object ModuleMobOwners : Module("MobOwners", Category.RENDER) {
+object ModuleMobOwners : ClientModule("MobOwners", Category.RENDER) {
 
     private val projectiles by boolean("Projectiles", false)
 
     private val uuidNameCache = ConcurrentHashMap<UUID, OrderedText>()
 
     fun getOwnerInfoText(entity: Entity): OrderedText? {
-        if (!this.enabled) {
+        if (!this.running) {
             return null
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoBob.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoBob.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoBob module
@@ -27,4 +27,4 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Disables the view bobbing effect.
  */
 
-object ModuleNoBob : Module("NoBob", Category.RENDER)
+object ModuleNoBob : ClientModule("NoBob", Category.RENDER)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoFov.kt
@@ -21,14 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoFOV module
  *
  * Changes FOV value.
  */
-object ModuleNoFov : Module("NoFOV", Category.RENDER) {
+object ModuleNoFov : ClientModule("NoFOV", Category.RENDER) {
 
     val mode = choices("Mode", ConstantFov, arrayOf(ConstantFov, Custom))
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoHurtCam.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoHurtCam.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoHurtCam module
@@ -27,4 +27,4 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Disables the hurt cam effect when getting hurt.
  */
 
-object ModuleNoHurtCam : Module("NoHurtCam", Category.RENDER)
+object ModuleNoHurtCam : ClientModule("NoHurtCam", Category.RENDER)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoSignRender.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoSignRender.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoSignRender module
@@ -27,4 +27,4 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Prevents the sign text from being rendered.
  */
 
-object ModuleNoSignRender : Module("NoSignRender", Category.RENDER)
+object ModuleNoSignRender : ClientModule("NoSignRender", Category.RENDER)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoSwing.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleNoSwing.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoSwing module
@@ -28,11 +28,11 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Disables the swing effect.
  */
 
-object ModuleNoSwing : Module("NoSwing", Category.RENDER) {
+object ModuleNoSwing : ClientModule("NoSwing", Category.RENDER) {
     private val mode by enumChoice("Mode", Mode.HIDE_BOTH)
 
-    fun shouldHideForServer() = this.enabled && mode.hideServerSide
-    fun shouldHideForClient() = this.enabled && mode.hideClientSide
+    fun shouldHideForServer() = this.running && mode.hideServerSide
+    fun shouldHideForClient() = this.running && mode.hideClientSide
 
     private enum class Mode(
         override val choiceName: String,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProphuntESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProphuntESP.kt
@@ -6,9 +6,9 @@ import net.ccbluex.liquidbounce.event.events.DrawOutlinesEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.utils.interpolateHue
@@ -24,7 +24,7 @@ import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 import java.util.concurrent.PriorityBlockingQueue
 
-object ModuleProphuntESP : Module("ProphuntESP", Category.RENDER,
+object ModuleProphuntESP : ClientModule("ProphuntESP", Category.RENDER,
     aliases = arrayOf("BlockUpdateDetector", "FallingBlockESP")) {
 
     private val modes = choices(
@@ -75,7 +75,7 @@ object ModuleProphuntESP : Module("ProphuntESP", Category.RENDER,
     private val renderTicks by float("RenderTicks", 60f, 0f..600f)
 
     @Suppress("unused")
-    private val gameHandler = repeatable {
+    private val gameHandler = tickHandler {
         while (trackedBlocks.isNotEmpty() && trackedBlocks.peek().expirationTime <= world.time) {
             trackedBlocks.poll()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleQuickPerspectiveSwap.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleQuickPerspectiveSwap.kt
@@ -19,10 +19,10 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.input.InputBind
 
-object ModuleQuickPerspectiveSwap : Module(
+object ModuleQuickPerspectiveSwap : ClientModule(
     "QuickPerspectiveSwap", Category.RENDER, disableOnQuit = true, bindAction = InputBind.BindAction.HOLD
 ) {
     val rearView by boolean("RearView", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.`fun`.ModuleDerp
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.drawSolidBox
@@ -42,7 +42,7 @@ import net.minecraft.util.math.Box
  * Allows you to see server-sided rotations.
  */
 
-object ModuleRotations : Module("Rotations", Category.RENDER) {
+object ModuleRotations : ClientModule("Rotations", Category.RENDER) {
 
     /**
      * Body part to modify the rotation of.
@@ -125,9 +125,9 @@ object ModuleRotations : Module("Rotations", Category.RENDER) {
      * Should we even send a rotation if we use freeCam?
      */
     fun shouldSendCustomRotation(): Boolean {
-        val special = arrayOf(ModuleDerp).any { it.enabled }
+        val special = arrayOf(ModuleDerp).any { it.running }
 
-        return enabled && (RotationManager.currentRotation != null || special)
+        return running && (RotationManager.currentRotation != null || special)
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSilentHotbar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSilentHotbar.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.item.MixinHeldItemRenderer
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 
@@ -30,6 +30,6 @@ import net.ccbluex.liquidbounce.utils.client.SilentHotbar
  *
  * Handled in [MixinHeldItemRenderer].
  */
-object ModuleSilentHotbar : Module("SilentHotbar", Category.RENDER) {
+object ModuleSilentHotbar : ClientModule("SilentHotbar", Category.RENDER) {
     val noCooldownProgress by boolean("NoCooldownProgress", true)
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.DrawOutlinesEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.ModuleChestStealer
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features.FeatureChestAura
 import net.ccbluex.liquidbounce.render.*
@@ -53,7 +53,7 @@ import java.awt.Color
  * Allows you to see chests, dispensers, etc. through walls.
  */
 
-object ModuleStorageESP : Module("StorageESP", Category.RENDER, aliases = arrayOf("ChestESP")) {
+object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = arrayOf("ChestESP")) {
 
     private val modes = choices("Mode", Glow, arrayOf(BoxMode, Glow))
 
@@ -261,12 +261,13 @@ object ModuleStorageESP : Module("StorageESP", Category.RENDER, aliases = arrayO
         }
     }
 
-    override fun isRunning(): Boolean {
-        if (requiresChestStealer && !ModuleChestStealer.enabled) {
-            return false
-        }
+    override val running: Boolean
+        get() {
+            if (requiresChestStealer && !ModuleChestStealer.running) {
+                return false
+            }
 
-        return super.isRunning()
-    }
+            return super.running
+        }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTNTTimer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTNTTimer.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -40,7 +40,7 @@ import kotlin.math.sin
  *
  * Highlight the active TNTs.
  */
-object ModuleTNTTimer : Module("TNTTimer", Category.RENDER) {
+object ModuleTNTTimer : ClientModule("TNTTimer", Category.RENDER) {
 
     override val baseKey: String
         get() = "liquidbounce.module.tntTimer"

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -43,7 +43,7 @@ import java.awt.Color
  * Draws a line to every entity a certain radius.
  */
 
-object ModuleTracers : Module("Tracers", Category.RENDER) {
+object ModuleTracers : ClientModule("Tracers", Category.RENDER) {
 
     private val modes = choices("ColorMode", 0) {
         arrayOf(
@@ -66,7 +66,7 @@ object ModuleTracers : Module("Tracers", Category.RENDER) {
     val renderHandler = handler<WorldRenderEvent> { event ->
         val matrixStack = event.matrixStack
 
-        val useDistanceColor = DistanceColor.isActive
+        val useDistanceColor = DistanceColor.isSelected
 
         val viewDistance = 16.0F * MathHelper.SQUARE_ROOT_OF_TWO *
             (if (DistanceColor.useViewDistance) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrueSight.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTrueSight.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * TrueSight module
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.features.module.Module
  * Allows you to see invisible objects and entities.
  */
 
-object ModuleTrueSight : Module("TrueSight", Category.RENDER) {
+object ModuleTrueSight : ClientModule("TrueSight", Category.RENDER) {
     val barriers by boolean("Barriers", true)
     val entities by boolean("Entities", true)
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks.*
@@ -33,7 +33,7 @@ import net.minecraft.util.math.Direction
  * Allows you to see ores through walls.
  */
 
-object ModuleXRay : Module("XRay", Category.RENDER) {
+object ModuleXRay : ClientModule("XRay", Category.RENDER) {
 
     // Lighting of blocks through walls
     val fullBright by boolean("FullBright", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleZoom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleZoom.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.MouseScrollInHotbarEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.client.MixinMouse
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.input.InputBind
@@ -38,7 +38,7 @@ import kotlin.math.round
  *
  * The mouse is slowed down with the help of mixins in [MixinMouse].
  */
-object ModuleZoom : Module("Zoom", Category.RENDER, bindAction = InputBind.BindAction.HOLD) {
+object ModuleZoom : ClientModule("Zoom", Category.RENDER, bindAction = InputBind.BindAction.HOLD) {
 
     val zoom by int("Zoom", 30, 10..150)
 
@@ -98,7 +98,7 @@ object ModuleZoom : Module("Zoom", Category.RENDER, bindAction = InputBind.BindA
 
     private fun getDefaultFov(): Int {
         val fov = mc.options.fov.value
-        return if (ModuleNoFov.enabled) ModuleNoFov.getFov(fov) else fov
+        return if (ModuleNoFov.running) ModuleNoFov.getFov(fov) else fov
     }
 
     private fun reset() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.client.network.AbstractClientPlayerEntity
@@ -38,7 +38,7 @@ import net.minecraft.network.packet.s2c.play.PlayerRespawnS2CPacket
 import net.minecraft.sound.SoundEvent
 import net.minecraft.util.Identifier
 
-object ModuleMurderMystery : Module("MurderMystery", Category.RENDER) {
+object ModuleMurderMystery : ClientModule("MurderMystery", Category.RENDER) {
     var playHurt = false
     var playBow = false
 
@@ -157,7 +157,7 @@ object ModuleMurderMystery : Module("MurderMystery", Category.RENDER) {
     }
 
     fun disallowsArrowDodge(): Boolean {
-        if (!enabled) {
+        if (!running) {
             return false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryAssassinationMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryAssassinationMode.kt
@@ -4,7 +4,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.math.levenshtein
 import net.minecraft.client.network.AbstractClientPlayerEntity
@@ -61,7 +61,7 @@ object MurderMysteryAssassinationMode : Choice("Assassination"), MurderMysteryMo
     }
 
     val repeatable =
-        repeatable {
+        tickHandler {
             assassinModeBs(player, world)
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryGenericMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryGenericMode.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render.murdermystery
 
 import net.ccbluex.liquidbounce.config.types.Choice
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.minecraft.client.network.AbstractClientPlayerEntity
 import net.minecraft.item.BowItem
@@ -18,7 +18,7 @@ abstract class MurderMysteryGenericMode(name: String) : Choice(name), MurderMyst
     protected var currentPlayerType = MurderMysteryMode.PlayerType.NEUTRAL
 
     val repeatable =
-        repeatable {
+        tickHandler {
             currentPlayerType = player.handItems.firstNotNullOfOrNull {
                 when {
                     it.item is BowItem || it.item == Items.ARROW -> MurderMysteryMode.PlayerType.DETECTIVE_LIKE

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryInfectionMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/MurderMysteryInfectionMode.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render.murdermystery
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.minecraft.client.network.AbstractClientPlayerEntity
 import net.minecraft.item.BowItem
@@ -14,7 +14,7 @@ object MurderMysteryInfectionMode : MurderMysteryGenericMode("Infection") {
         get() = ModuleMurderMystery.modes
 
     val rep =
-        repeatable {
+        tickHandler {
             world.players
                 .filterIsInstance<AbstractClientPlayerEntity>()
                 .filter {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleESP
 import net.ccbluex.liquidbounce.render.FontManager
 import net.ccbluex.liquidbounce.render.RenderEnvironment
@@ -40,7 +40,7 @@ import net.minecraft.entity.Entity
  * Makes player name tags more visible and adds useful information.
  */
 
-object ModuleNametags : Module("Nametags", Category.RENDER) {
+object ModuleNametags : ClientModule("Nametags", Category.RENDER) {
 
     /**
      * Contains the list of toggleable options for the [NametagTextFormatter]

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render.trajectories
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.client.toRadians
@@ -42,7 +42,7 @@ import kotlin.math.sin
  * Allows you to see where projectile items will land.
  */
 
-object ModuleTrajectories : Module("Trajectories", Category.RENDER) {
+object ModuleTrajectories : ClientModule("Trajectories", Category.RENDER) {
     private val maxSimulatedTicks by int("MaxSimulatedTicks", 240, 1..1000, "ticks")
     private val alwaysShowBow by boolean("AlwaysShowBow", false)
     private val otherPlayers by boolean("OtherPlayers", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair
 import net.ccbluex.liquidbounce.event.events.BlockBreakingProgressEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.item.isNothing
 import net.minecraft.block.BlockState
@@ -35,7 +35,7 @@ import net.minecraft.util.math.BlockPos
  *
  * Automatically chooses the best tool in your inventory to mine a block.
  */
-object ModuleAutoTool : Module("AutoTool", Category.WORLD) {
+object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
 
     // Ignore items with low durability
     private val ignoreDurability by boolean("IgnoreDurability", false)
@@ -72,7 +72,7 @@ object ModuleAutoTool : Module("AutoTool", Category.WORLD) {
     }
 
     fun getTool(inventory: PlayerInventory, blockState: BlockState?): IntObjectImmutablePair<ItemStack>? {
-        if (search || !enabled) {
+        if (search || !running) {
             val (hotbarSlot, stack) =
                 (0..8).map {
                     it to inventory.getStack(it)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleBedDefender.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleBedDefender.kt
@@ -21,13 +21,14 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.world.fucker.isSelfBedChoices
 import net.ccbluex.liquidbounce.render.engine.Color4b
-import net.ccbluex.liquidbounce.utils.block.*
 import net.ccbluex.liquidbounce.utils.block.placer.BlockPlacer
+import net.ccbluex.liquidbounce.utils.block.searchBedLayer
+import net.ccbluex.liquidbounce.utils.block.searchBlocksInCuboid
 import net.ccbluex.liquidbounce.utils.entity.eyes
 import net.ccbluex.liquidbounce.utils.entity.getNearestPoint
 import net.ccbluex.liquidbounce.utils.inventory.HOTBAR_SLOTS
@@ -42,7 +43,7 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen
 import net.minecraft.item.BlockItem
 import net.minecraft.util.math.Box
 
-object ModuleBedDefender : Module("BedDefender", category = Category.WORLD) {
+object ModuleBedDefender : ClientModule("BedDefender", category = Category.WORLD) {
 
     private val maxLayers by int("MaxLayers", 1, 1..5)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleExtinguish.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleExtinguish.kt
@@ -3,9 +3,9 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
@@ -26,7 +26,7 @@ import net.minecraft.item.Items
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3i
 
-object ModuleExtinguish: Module("Extinguish", Category.WORLD) {
+object ModuleExtinguish: ClientModule("Extinguish", Category.WORLD) {
 
     private val cooldown by float("Cooldown", 1.0F, 0.0F..20.0F, "s")
     private val notDuringCombat by boolean("NotDuringCombat", true)
@@ -89,13 +89,13 @@ object ModuleExtinguish: Module("Extinguish", Category.WORLD) {
         return planExtinguishing()
     }
 
-    val repeatable = repeatable {
-        val target = currentTarget ?: return@repeatable
+    val repeatable = tickHandler {
+        val target = currentTarget ?: return@tickHandler
 
-        val rayTraceResult = raycast() ?: return@repeatable
+        val rayTraceResult = raycast() ?: return@tickHandler
 
         if (!target.doesCorrespondTo(rayTraceResult)) {
-            return@repeatable
+            return@tickHandler
         }
 
         SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot.hotbarSlotForServer, 1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFastBreak.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFastBreak.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NoneChoice
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket
 
 /**
@@ -33,13 +33,13 @@ import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket
  *
  * Allows you to break blocks faster.
  */
-object ModuleFastBreak : Module("FastBreak", Category.WORLD) {
+object ModuleFastBreak : ClientModule("FastBreak", Category.WORLD) {
 
     private val breakDamage by float("BreakDamage", 0.8f, 0.1f..1f)
 
     private val modeChoice = choices("Mode", 0) { arrayOf(NoneChoice(it), AbortAnother) }.apply(::tagBy)
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         interaction.blockBreakingCooldown = 0
 
         if (interaction.currentBreakingProgress > breakDamage) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFastPlace.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleFastPlace.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 import net.ccbluex.liquidbounce.event.events.UseCooldownEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.minecraft.item.BlockItem
 
 /**
@@ -29,7 +29,7 @@ import net.minecraft.item.BlockItem
  *
  * Allows you to place blocks faster.
  */
-object ModuleFastPlace : Module("FastPlace", Category.WORLD) {
+object ModuleFastPlace : ClientModule("FastPlace", Category.WORLD) {
 
     private val cooldown by int("Cooldown", 0, 0..4, "ticks").apply { tagBy(this) }
     private val onlyBlock by boolean("OnlyBlock", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleLiquidPlace.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleLiquidPlace.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.world
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * LiquidPlace module
  *
  * Allows you to place blocks on liquids
  */
-object ModuleLiquidPlace : Module("LiquidPlace", Category.WORLD)
+object ModuleLiquidPlace : ClientModule("LiquidPlace", Category.WORLD)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleNoSlowBreak.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleNoSlowBreak.kt
@@ -19,14 +19,14 @@
 package net.ccbluex.liquidbounce.features.module.modules.world
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 
 /**
  * NoSlowBreak module
  *
  * Automatically adjusts breaking speed when in negatively affecting situations.
  */
-object ModuleNoSlowBreak : Module("NoSlowBreak", Category.WORLD) {
+object ModuleNoSlowBreak : ClientModule("NoSlowBreak", Category.WORLD) {
     val miningFatigue by boolean("MiningFatigue", true)
     val onAir by boolean("OnAir", true)
     val water by boolean("Water", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
@@ -20,9 +20,9 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 import net.ccbluex.liquidbounce.utils.aiming.facingEnemy
@@ -44,7 +44,7 @@ import net.minecraft.util.math.MathHelper
  *
  * Shoots back incoming projectiles around you.
  */
-object ModuleProjectilePuncher : Module("ProjectilePuncher", Category.WORLD, aliases = arrayOf("AntiFireball")) {
+object ModuleProjectilePuncher : ClientModule("ProjectilePuncher", Category.WORLD, aliases = arrayOf("AntiFireball")) {
 
     private val clickScheduler = tree(ClickScheduler(ModuleProjectilePuncher, false))
 
@@ -70,8 +70,8 @@ object ModuleProjectilePuncher : Module("ProjectilePuncher", Category.WORLD, ali
         updateTarget()
     }
 
-    val repeatable = repeatable {
-        val target = target ?: return@repeatable
+    val repeatable = tickHandler {
+        val target = target ?: return@tickHandler
 
         if (target.squaredBoxedDistanceTo(player) > range * range ||
             !facingEnemy(
@@ -80,7 +80,7 @@ object ModuleProjectilePuncher : Module("ProjectilePuncher", Category.WORLD, ali
                 range = range.toDouble(),
                 wallsRange = 0.0
             )) {
-            return@repeatable
+            return@tickHandler
         }
 
         clickScheduler.clicks {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleSurround.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleSurround.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.commands.client.CommandCenter
 import net.ccbluex.liquidbounce.features.command.commands.client.CommandCenter.CenterHandlerState
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.*
 import net.ccbluex.liquidbounce.utils.block.placer.BlockPlacer
 import net.ccbluex.liquidbounce.utils.block.placer.CrystalDestroyFeature
@@ -60,7 +60,7 @@ import kotlin.math.ceil
  *
  * Builds safe holes.
  */
-object ModuleSurround : Module("Surround", Category.WORLD, disableOnQuit = true) {
+object ModuleSurround : ClientModule("Surround", Category.WORLD, disableOnQuit = true) {
 
     /**
      * The blocks the surround normal utilizes.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autobuild/ModuleAutoBuild.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autobuild/ModuleAutoBuild.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.autobuild
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.block.placer.BlockPlacer
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -31,7 +31,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
  *
  * Builds structures.
  */
-object ModuleAutoBuild : Module("AutoBuild", Category.WORLD, aliases = arrayOf("Platform", "AutoPortal")) {
+object ModuleAutoBuild : ClientModule("AutoBuild", Category.WORLD, aliases = arrayOf("Platform", "AutoPortal")) {
 
     private val mode = choices("Mode", PortalMode, arrayOf(PortalMode, PlatformMode)).apply { tagBy(this) }
     val placer = tree(BlockPlacer("Placing", this, Priority.NORMAL, { mode.activeChoice.getSlot() }))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autobuild/PlatformMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autobuild/PlatformMode.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.autobuild
 
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.world.autobuild.ModuleAutoBuild.placer
 import net.ccbluex.liquidbounce.utils.block.getState
@@ -43,7 +43,7 @@ object PlatformMode : ModuleAutoBuild.AutoBuildMode("Platform") {
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (disableOnYChange && player.pos.y != startY) {
             ModuleAutoBuild.enabled = false
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/ModuleNuker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/ModuleNuker.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.nuker
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.area.FloorNukerArea
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.area.SphereNukerArea
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.mode.InstantNukerMode
@@ -33,7 +33,7 @@ import net.minecraft.util.math.BlockPos
  *
  * Destroys blocks around you.
  */
-object ModuleNuker : Module("Nuker", Category.WORLD, disableOnQuit = true) {
+object ModuleNuker : ClientModule("Nuker", Category.WORLD, disableOnQuit = true) {
 
     val mode =
         choices("Mode", LegitNukerMode, arrayOf(LegitNukerMode, InstantNukerMode))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.nuker.mode
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.ModuleNuker.areaMode
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.ModuleNuker.ignoreOpenInventory
@@ -44,20 +44,20 @@ object InstantNukerMode : Choice("Instant") {
     private val doNotStop by boolean("DoNotStop", false)
 
     @Suppress("unused")
-    private val tickHandler = repeatable {
-        if (ModuleBlink.enabled) {
-            return@repeatable
+    private val tickHandler = tickHandler {
+        if (ModuleBlink.running) {
+            return@tickHandler
         }
 
         if (!ignoreOpenInventory && mc.currentScreen is HandledScreen<*>) {
-            return@repeatable
+            return@tickHandler
         }
 
         val targets = areaMode.activeChoice.lookupTargets(range, count = bps.random())
 
         if (targets.isEmpty()) {
             wasTarget = null
-            return@repeatable
+            return@tickHandler
         }
 
         for ((pos, _) in targets) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
@@ -25,9 +25,9 @@ import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleAutoTool
 import net.ccbluex.liquidbounce.features.module.modules.world.packetmine.mode.CivMineMode
 import net.ccbluex.liquidbounce.features.module.modules.world.packetmine.mode.ImmediateMineMode
@@ -69,7 +69,7 @@ import kotlin.math.max
  * @author ccetl
  */
 @Suppress("TooManyFunctions")
-object ModulePacketMine : Module("PacketMine", Category.WORLD) {
+object ModulePacketMine : ClientModule("PacketMine", Category.WORLD) {
 
     val mode = choices<MineMode>(
         this,
@@ -144,16 +144,16 @@ object ModulePacketMine : Module("PacketMine", Category.WORLD) {
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
-        val blockPos = targetPos ?: return@repeatable
+    private val repeatable = tickHandler {
+        val blockPos = targetPos ?: return@tickHandler
         val state = blockPos.getState()!!
         val invalid = mode.activeChoice.isInvalid(blockPos, state)
         if (invalid || blockPos.getCenterDistanceSquaredEyes() > keepRange.sq()) {
             targetPos = null
-            return@repeatable
+            return@tickHandler
         }
 
-        val rotation = handleRotating(blockPos, state) ?: return@repeatable
+        val rotation = handleRotating(blockPos, state) ?: return@tickHandler
         handleBreaking(blockPos, state, rotation)
     }
 
@@ -268,7 +268,7 @@ object ModulePacketMine : Module("PacketMine", Category.WORLD) {
         }
 
         val shouldSwitch = switchMode.shouldSwitch()
-        if (shouldSwitch && ModuleAutoTool.enabled) {
+        if (shouldSwitch && ModuleAutoTool.running) {
             ModuleAutoTool.switchToBreakBlock(pos)
         } else if (shouldSwitch) {
             SilentHotbar.selectSlotSilently(this, slot.firstInt(), 1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/CivMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/CivMineMode.kt
@@ -73,7 +73,7 @@ object CivMineMode : MineMode("Civ", stopOnStateChange = false) {
         val oldSlot = player.inventory.selectedSlot
         val state = world.getBlockState(blockPos)
         var shouldSwitch = switch && state.isToolRequired
-        if (shouldSwitch && ModuleAutoTool.enabled) {
+        if (shouldSwitch && ModuleAutoTool.running) {
             ModuleAutoTool.switchToBreakBlock(blockPos)
             shouldSwitch = false
         } else if (shouldSwitch) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
@@ -27,9 +27,9 @@ import net.ccbluex.liquidbounce.event.events.BlockCountChangeEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleSafeWalk
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes.NoFallBlink
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
@@ -91,7 +91,7 @@ import kotlin.math.abs
  * Places blocks under you.
  */
 @Suppress("TooManyFunctions")
-object ModuleScaffold : Module("Scaffold", Category.WORLD) {
+object ModuleScaffold : ClientModule("Scaffold", Category.WORLD) {
 
     private var delay by intRange("Delay", 0..0, 0..40, "ticks")
     private val minDist by float("MinDist", 0.0f, 0.0f..0.25f)
@@ -401,14 +401,14 @@ object ModuleScaffold : Module("Scaffold", Category.WORLD) {
     }
 
     @Suppress("unused")
-    val timerHandler = repeatable {
+    val timerHandler = tickHandler {
         if (timer != 1f) {
             Timer.requestTimerSpeed(timer, Priority.IMPORTANT_FOR_USAGE_1, this@ModuleScaffold)
         }
     }
 
     @Suppress("unused")
-    val tickHandler = repeatable {
+    val tickHandler = tickHandler {
         updateRenderCount(blockCount)
 
         if (player.isOnGround) {
@@ -453,14 +453,14 @@ object ModuleScaffold : Module("Scaffold", Category.WORLD) {
         }
 
         if (target == null || currentCrosshairTarget == null) {
-            return@repeatable
+            return@tickHandler
         }
 
         // Does the crosshair target meet the requirements?
         if (!target.doesCrosshairTargetFullFillRequirements(currentCrosshairTarget) ||
             !isValidCrosshairTarget(currentCrosshairTarget)
         ) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (!ScaffoldAutoBlockFeature.alwaysHoldBlock) {
@@ -468,7 +468,7 @@ object ModuleScaffold : Module("Scaffold", Category.WORLD) {
         }
 
         if (!hasBlockInMainHand && !hasBlockInOffHand) {
-            return@repeatable
+            return@tickHandler
         }
 
         val handToInteractWith = if (hasBlockInMainHand) Hand.MAIN_HAND else Hand.OFF_HAND
@@ -568,7 +568,7 @@ object ModuleScaffold : Module("Scaffold", Category.WORLD) {
     }
 
     internal fun getTargetedPosition(blockPos: BlockPos): BlockPos {
-        if (ScaffoldDownFeature.isRunning() && ScaffoldDownFeature.shouldGoDown) {
+        if (ScaffoldDownFeature.running && ScaffoldDownFeature.shouldGoDown) {
             return blockPos.add(0, -2, 0)
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldBlinkFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldBlinkFeature.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.scaffold.features
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -33,13 +33,13 @@ object ScaffoldBlinkFeature : ToggleableConfigurable(ModuleScaffold, "Blink", fa
     private val pulseTimer = Chronometer()
 
     val shouldBlink
-        get() = isRunning() && (!player.isOnGround || !pulseTimer.hasElapsed(pulseTime))
+        get() = this.running && (!player.isOnGround || !pulseTimer.hasElapsed(pulseTime))
 
     fun onBlockPlacement() {
         pulseTime = time.random().toLong()
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (fallCancel && player.fallDistance > 0.5f) {
             FakeLag.cancel()
             onBlockPlacement()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldHeadHitterFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldHeadHitterFeature.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.scaffold.features
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.utils.entity.moving
 
@@ -27,7 +27,7 @@ object ScaffoldHeadHitterFeature : ToggleableConfigurable(ModuleScaffold, "HeadH
     fun canHeadHit() =
         !world.getBlockState(player.blockPos.add(0, 2, 0)).isAir && player.isOnGround
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (canHeadHit() && player.moving) {
             player.jump()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldSlowFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldSlowFeature.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.scaffold.features
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 
 object ScaffoldSlowFeature : ToggleableConfigurable(ModuleScaffold, "Slow", false) {
@@ -27,7 +27,7 @@ object ScaffoldSlowFeature : ToggleableConfigurable(ModuleScaffold, "Slow", fals
     private val onlyOnGround by boolean("OnlyOnGround", false)
 
     @Suppress("unused")
-    val stateUpdateHandler = repeatable {
+    val stateUpdateHandler = tickHandler {
         if (onlyOnGround) {
             if (player.isOnGround) {
                 player.velocity.x *= slowSpeed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldGodBridgeTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldGodBridgeTechnique.kt
@@ -64,7 +64,7 @@ object ScaffoldGodBridgeTechnique : ScaffoldTechnique("GodBridge"), ScaffoldLedg
         target: BlockPlacementTarget?,
         rotation: Rotation
     ): LedgeState {
-        if (!isActive) {
+        if (!isSelected) {
             return LedgeState.NO_LEDGE
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerMotion.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerMotion.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.isBlockBelow
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.towerMode
@@ -49,14 +49,14 @@ object ScaffoldTowerMotion : Choice("Motion") {
         jumpOffPosition = player.y
     }
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!mc.options.jumpKey.isPressed || ModuleScaffold.blockCount <= 0 || !isBlockBelow) {
             jumpOffPosition = Double.NaN
-            return@repeatable
+            return@tickHandler
         }
 
         if (jumpOffPosition.isNaN()) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (player.y > jumpOffPosition + triggerHeight) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerVulcan.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerVulcan.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.isBlockBelow
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.towerMode
@@ -34,9 +34,9 @@ object ScaffoldTowerVulcan : Choice("Vulcan") {
     override val parent: ChoiceConfigurable<Choice>
         get() = towerMode
 
-    val repeatable = repeatable {
+    val repeatable = tickHandler {
         if (!mc.options.jumpKey.isPressed || ModuleScaffold.blockCount <= 0 || !isBlockBelow) {
-            return@repeatable
+            return@tickHandler
         }
 
         if(player.age % 2 == 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/ModuleAutoTrap.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/ModuleAutoTrap.kt
@@ -20,39 +20,25 @@ package net.ccbluex.liquidbounce.features.module.modules.world.traps
 
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
-import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeInfo
-import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeIntent
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.traps.IgnitionTrapPlanner
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 import net.ccbluex.liquidbounce.utils.aiming.raycast
 import net.ccbluex.liquidbounce.utils.block.doPlacement
-import net.ccbluex.liquidbounce.utils.block.getState
-import net.ccbluex.liquidbounce.utils.block.targetfinding.BlockPlacementTargetFindingOptions
-import net.ccbluex.liquidbounce.utils.block.targetfinding.CenterTargetPositionFactory
-import net.ccbluex.liquidbounce.utils.block.targetfinding.findBestBlockPlacementTarget
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
-import net.ccbluex.liquidbounce.utils.combat.TargetTracker
-import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
-import net.ccbluex.liquidbounce.utils.entity.boxedDistanceTo
-import net.ccbluex.liquidbounce.utils.inventory.Hotbar
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
-import net.minecraft.block.Blocks
-import net.minecraft.item.Items
 import net.minecraft.util.Hand
-import net.minecraft.util.hit.HitResult
-import net.minecraft.util.math.Vec3i
 
 /**
  * Ignite module
  *
  * Automatically sets targets around you on fire.
  */
-object ModuleAutoTrap : Module("AutoTrap", Category.WORLD, aliases = arrayOf("Ignite")) {
+object ModuleAutoTrap : ClientModule("AutoTrap", Category.WORLD, aliases = arrayOf("Ignite")) {
 
     val range by floatRange("Range", 3.0f..4.5f, 2f..6f)
     private val delay by int("Delay", 20, 0..400, "ticks")
@@ -94,12 +80,12 @@ object ModuleAutoTrap : Module("AutoTrap", Category.WORLD, aliases = arrayOf("Ig
     }
 
     @Suppress("unused")
-    private val placementHandler = repeatable {
-        val plan = currentPlan ?: return@repeatable
-        val raycast = raycast() ?: return@repeatable
+    private val placementHandler = tickHandler {
+        val plan = currentPlan ?: return@tickHandler
+        val raycast = raycast() ?: return@tickHandler
 
         if (!plan.validate(raycast)) {
-            return@repeatable
+            return@tickHandler
         }
 
         CombatManager.pauseCombatForAtLeast(1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/IgnitionTrapPlanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/IgnitionTrapPlanner.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.traps.traps
 
 import it.unimi.dsi.fastutil.doubles.DoubleObjectImmutablePair
 import it.unimi.dsi.fastutil.doubles.DoubleObjectPair
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeInfo
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeIntent
@@ -10,11 +10,7 @@ import net.ccbluex.liquidbounce.features.module.modules.world.traps.IntentTiming
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.ModuleAutoTrap
 import net.ccbluex.liquidbounce.utils.block.collidingRegion
 import net.ccbluex.liquidbounce.utils.block.getState
-import net.ccbluex.liquidbounce.utils.block.targetfinding.BlockPlacementTarget
-import net.ccbluex.liquidbounce.utils.block.targetfinding.BlockPlacementTargetFindingOptions
-import net.ccbluex.liquidbounce.utils.block.targetfinding.NearestRotationTargetPositionFactory
-import net.ccbluex.liquidbounce.utils.block.targetfinding.PositionFactoryConfiguration
-import net.ccbluex.liquidbounce.utils.block.targetfinding.findBestBlockPlacementTarget
+import net.ccbluex.liquidbounce.utils.block.targetfinding.*
 import net.ccbluex.liquidbounce.utils.combat.TargetTracker
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.boxedDistanceTo
@@ -33,7 +29,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 
-class IgnitionTrapPlanner(parent: Listenable) : TrapPlanner<IgnitionTrapPlanner.IgnitionIntentData>(
+class IgnitionTrapPlanner(parent: EventHandler) : TrapPlanner<IgnitionTrapPlanner.IgnitionIntentData>(
     parent,
     "Ignite",
     true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/IgnitionTrapPlanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/IgnitionTrapPlanner.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.traps.traps
 
 import it.unimi.dsi.fastutil.doubles.DoubleObjectImmutablePair
 import it.unimi.dsi.fastutil.doubles.DoubleObjectPair
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeInfo
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeIntent
@@ -29,7 +29,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 
-class IgnitionTrapPlanner(parent: EventHandler) : TrapPlanner<IgnitionTrapPlanner.IgnitionIntentData>(
+class IgnitionTrapPlanner(parent: EventListener) : TrapPlanner<IgnitionTrapPlanner.IgnitionIntentData>(
     parent,
     "Ignite",
     true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/TrapPlanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/TrapPlanner.kt
@@ -1,12 +1,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.traps.traps
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeIntent
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockIntentProvider
 
 abstract class TrapPlanner<T>(
-    parent: Listenable,
+    parent: EventHandler,
     name: String,
     enabled: Boolean
 ): ToggleableConfigurable(parent, name, enabled), BlockIntentProvider<T> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/TrapPlanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/traps/TrapPlanner.kt
@@ -1,12 +1,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.traps.traps
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockChangeIntent
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.BlockIntentProvider
 
 abstract class TrapPlanner<T>(
-    parent: EventHandler,
+    parent: EventListener,
     name: String,
     enabled: Boolean
 ): ToggleableConfigurable(parent, name, enabled), BlockIntentProvider<T> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationHandler.kt
@@ -21,23 +21,23 @@ package net.ccbluex.liquidbounce.integration
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.LiquidBounce
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.HideAppearance
+import net.ccbluex.liquidbounce.integration.browser.BrowserManager
+import net.ccbluex.liquidbounce.integration.theme.Theme
+import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.liquidbounce.mcef.progress.MCEFProgressMenu
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.client.mc
-import net.ccbluex.liquidbounce.integration.browser.BrowserManager
-import net.ccbluex.liquidbounce.integration.theme.Theme
-import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.screen.TitleScreen
 import org.lwjgl.glfw.GLFW
 
-object IntegrationHandler : Listenable {
+object IntegrationHandler : EventHandler {
 
     /**
      * This tab is always open and initialized. We keep this tab open to make it possible to draw on the screen,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.integration
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.LiquidBounce
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
@@ -37,7 +37,7 @@ import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.screen.TitleScreen
 import org.lwjgl.glfw.GLFW
 
-object IntegrationHandler : EventHandler {
+object IntegrationListener : EventListener {
 
     /**
      * This tab is always open and initialized. We keep this tab open to make it possible to draw on the screen,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
@@ -67,34 +67,34 @@ enum class VirtualScreenType(
     MULTIPLAYER(
         "multiplayer",
         recognizer = { it is MultiplayerScreen || it is MultiplayerWarningScreen },
-        open = { mc.setScreen(MultiplayerScreen(IntegrationHandler.parent)) }
+        open = { mc.setScreen(MultiplayerScreen(IntegrationListener.parent)) }
     ),
 
     MULTIPLAYER_REALMS(
         "multiplayer_realms",
         recognizer = { it is RealmsMainScreen },
-        open = { mc.setScreen(RealmsMainScreen(IntegrationHandler.parent)) }
+        open = { mc.setScreen(RealmsMainScreen(IntegrationListener.parent)) }
     ),
 
     SINGLEPLAYER(
         "singleplayer",
         recognizer = { it is SelectWorldScreen },
         open = {
-            mc.setScreen(SelectWorldScreen(IntegrationHandler.parent))
+            mc.setScreen(SelectWorldScreen(IntegrationListener.parent))
         }
     ),
 
     CREATE_WORLD(
         "create_world",
         recognizer = { it is CreateWorldScreen },
-        open = { CreateWorldScreen.create(mc, IntegrationHandler.parent) }
+        open = { CreateWorldScreen.create(mc, IntegrationListener.parent) }
     ),
 
     OPTIONS(
         "options",
         recognizer = { it is OptionsScreen },
         open = {
-            mc.setScreen(OptionsScreen(IntegrationHandler.parent, mc.options))
+            mc.setScreen(OptionsScreen(IntegrationListener.parent, mc.options))
         }
     ),
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/VrScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/VrScreen.kt
@@ -32,11 +32,11 @@ class VrScreen(
     val originalScreen: Screen? = null) : Screen("VS-${screenType.routeName.uppercase()}".asText()) {
 
     override fun init() {
-        IntegrationHandler.virtualOpen(theme, screenType)
+        IntegrationListener.virtualOpen(theme, screenType)
     }
 
     override fun close() {
-        IntegrationHandler.virtualClose()
+        IntegrationListener.virtualClose()
         mc.mouse.lockCursor()
         super.close()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserDrawer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserDrawer.kt
@@ -20,19 +20,19 @@ package net.ccbluex.liquidbounce.integration.browser
 
 import com.mojang.blaze3d.platform.GlStateManager
 import com.mojang.blaze3d.systems.RenderSystem
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
-import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
 import net.minecraft.client.render.BufferRenderer.drawWithGlobalProgram
 import net.minecraft.client.render.GameRenderer
 import net.minecraft.client.render.Tessellator
 import net.minecraft.client.render.VertexFormat
 import net.minecraft.client.render.VertexFormats
 
-class BrowserDrawer(val browser: () -> IBrowser?) : Listenable {
+class BrowserDrawer(val browser: () -> IBrowser?) : EventHandler {
 
     private val tabs
         get() = browser()?.getTabs() ?: emptyList()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserDrawer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserDrawer.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.integration.browser
 
 import com.mojang.blaze3d.platform.GlStateManager
 import com.mojang.blaze3d.systems.RenderSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
@@ -32,7 +32,7 @@ import net.minecraft.client.render.Tessellator
 import net.minecraft.client.render.VertexFormat
 import net.minecraft.client.render.VertexFormats
 
-class BrowserDrawer(val browser: () -> IBrowser?) : EventHandler {
+class BrowserDrawer(val browser: () -> IBrowser?) : EventListener {
 
     private val tabs
         get() = browser()?.getTabs() ?: emptyList()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserInput.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserInput.kt
@@ -18,15 +18,15 @@
  */
 package net.ccbluex.liquidbounce.integration.browser
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.InputAware
+import net.ccbluex.liquidbounce.utils.client.mc
 import org.lwjgl.glfw.GLFW
 
-class BrowserInput(val browser: () -> IBrowser?) : Listenable {
+class BrowserInput(val browser: () -> IBrowser?) : EventHandler {
 
     private val tabs
         get() = browser()?.getTabs() ?: emptyList()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserInput.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/BrowserInput.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.integration.browser
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.integration.browser.supports.IBrowser
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.integration.browser.supports.tab.InputAware
 import net.ccbluex.liquidbounce.utils.client.mc
 import org.lwjgl.glfw.GLFW
 
-class BrowserInput(val browser: () -> IBrowser?) : EventHandler {
+class BrowserInput(val browser: () -> IBrowser?) : EventListener {
 
     private val tabs
         get() = browser()?.getTabs() ?: emptyList()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/supports/JcefBrowser.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/supports/JcefBrowser.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.integration.browser.supports
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.integration.browser.BrowserType
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.JcefTab
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.TabPosition
@@ -49,7 +49,7 @@ private const val CACHE_CLEANUP_THRESHOLD = 1000 * 60 * 60 * 24 * 7 // 7 days
  * @author 1zuna <marco@ccbluex.net>
  */
 @Suppress("TooManyFunctions")
-class JcefBrowser : IBrowser, EventHandler {
+class JcefBrowser : IBrowser, EventListener {
 
     private val mcefFolder = ConfigSystem.rootFolder.resolve("mcef")
     private val librariesFolder = mcefFolder.resolve("libraries")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/supports/JcefBrowser.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/browser/supports/JcefBrowser.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.integration.browser.supports
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.integration.browser.BrowserType
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.JcefTab
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.TabPosition
@@ -49,7 +49,7 @@ private const val CACHE_CLEANUP_THRESHOLD = 1000 * 60 * 60 * 24 * 7 // 7 days
  * @author 1zuna <marco@ccbluex.net>
  */
 @Suppress("TooManyFunctions")
-class JcefBrowser : IBrowser, Listenable {
+class JcefBrowser : IBrowser, EventHandler {
 
     private val mcefFolder = ConfigSystem.rootFolder.resolve("mcef")
     private val librariesFolder = mcefFolder.resolve("libraries")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/ClientInteropServer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/ClientInteropServer.kt
@@ -22,7 +22,7 @@ package net.ccbluex.liquidbounce.integration.interop
 import com.google.gson.JsonObject
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.config.ConfigSystem
-import net.ccbluex.liquidbounce.integration.interop.protocol.event.SocketEventHandler
+import net.ccbluex.liquidbounce.integration.interop.protocol.event.SocketEventListener
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.registerInteropFunctions
 import net.ccbluex.liquidbounce.utils.client.ErrorHandler
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -41,7 +41,7 @@ import kotlin.concurrent.thread
 object ClientInteropServer {
 
     internal var httpServer = HttpServer()
-    private var socketEventHandler = SocketEventHandler()
+    private var socketEventHandler = SocketEventListener()
 
     private const val DEFAULT_PORT = 15000
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/event/SocketEventHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/event/SocketEventHandler.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer.httpServ
 import net.ccbluex.liquidbounce.utils.client.logger
 import kotlin.reflect.KClass
 
-class SocketEventHandler : Listenable {
+class SocketEventHandler : EventHandler {
 
     private val events = ALL_EVENT_CLASSES
         .filter { it.java.isAnnotationPresent(WebSocketEvent::class.java) }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/event/SocketEventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/event/SocketEventListener.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer.httpServ
 import net.ccbluex.liquidbounce.utils.client.logger
 import kotlin.reflect.KClass
 
-class SocketEventHandler : EventHandler {
+class SocketEventListener : EventListener {
 
     private val events = ALL_EVENT_CLASSES
         .filter { it.java.isAnnotationPresent(WebSocketEvent::class.java) }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
@@ -45,7 +45,7 @@ fun getModules(requestObject: RequestObject): FullHttpResponse {
             addProperty("name", module.name)
             addProperty("category", module.category.readableName)
             add("keyBind", interopGson.toJsonTree(module.bind))
-            addProperty("enabled", module.enabled)
+            addProperty("enabled", module.running)
             addProperty("description", module.description)
             addProperty("tag", module.tag)
             addProperty("hidden", module.hidden)
@@ -102,7 +102,7 @@ data class ModuleRequest(val name: String) {
     fun acceptToggle(method: HttpMethod): FullHttpResponse {
         val module = ModuleManager[name] ?: return httpForbidden("$name not found")
 
-        val supposedNew = method == HttpMethod.PUT || (method == HttpMethod.POST && !module.enabled)
+        val supposedNew = method == HttpMethod.PUT || (method == HttpMethod.POST && !module.running)
 
         if (module.enabled == supposedNew) {
             return httpForbidden("$name already ${if (supposedNew) "enabled" else "disabled"}")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
@@ -23,7 +23,7 @@ package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client
 
 import com.google.gson.JsonObject
 import io.netty.handler.codec.http.FullHttpResponse
-import net.ccbluex.liquidbounce.integration.IntegrationHandler
+import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.integration.VirtualScreenType
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.netty.http.model.RequestObject
@@ -35,7 +35,7 @@ import net.minecraft.client.gui.screen.SplashOverlay
 @Suppress("UNUSED_PARAMETER")
 fun getVirtualScreenInfo(requestObject: RequestObject): FullHttpResponse {
     return httpOk(JsonObject().apply {
-        addProperty("name", IntegrationHandler.momentaryVirtualScreen?.type?.routeName)
+        addProperty("name", IntegrationListener.momentaryVirtualScreen?.type?.routeName)
         addProperty("showingSplash", mc.overlay is SplashOverlay)
     })
 }
@@ -45,12 +45,12 @@ fun postVirtualScreen(requestObject: RequestObject): FullHttpResponse {
     val body = requestObject.asJson<JsonObject>()
     val name = body["name"]?.asString ?: return httpForbidden("No name")
 
-    val virtualScreen = IntegrationHandler.momentaryVirtualScreen
+    val virtualScreen = IntegrationListener.momentaryVirtualScreen
     if ((virtualScreen?.type?.routeName ?: "none") != name) {
         return httpForbidden("Wrong virtual screen")
     }
 
-    IntegrationHandler.acknowledgement.confirm()
+    IntegrationListener.acknowledgement.confirm()
     return httpOk(JsonObject())
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
@@ -28,7 +28,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.config.gson.interopGson
 import net.ccbluex.liquidbounce.config.gson.serializer.minecraft.ResourcePolicy
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.ActiveServerList.pingThemAll
@@ -176,7 +176,7 @@ fun postOrderServers(requestObject: RequestObject): FullHttpResponse {
     return httpOk(JsonObject())
 }
 
-object ActiveServerList : Listenable {
+object ActiveServerList : EventHandler {
 
     internal var serverList = ServerList(mc).apply { loadFile() }
 
@@ -231,7 +231,7 @@ object ActiveServerList : Listenable {
         serverListPinger.tick()
     }
 
-    override fun isRunning() = true
+    override val running = true
 
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
@@ -28,7 +28,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.config.gson.interopGson
 import net.ccbluex.liquidbounce.config.gson.serializer.minecraft.ResourcePolicy
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.ActiveServerList.pingThemAll
@@ -176,7 +176,7 @@ fun postOrderServers(requestObject: RequestObject): FullHttpResponse {
     return httpOk(JsonObject())
 }
 
-object ActiveServerList : EventHandler {
+object ActiveServerList : EventListener {
 
     internal var serverList = ServerList(mc).apply { loadFile() }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.config.gson.util.decode
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleClickGui
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleHud
-import net.ccbluex.liquidbounce.integration.IntegrationHandler
+import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.integration.VirtualScreenType
 import net.ccbluex.liquidbounce.integration.browser.BrowserManager
 import net.ccbluex.liquidbounce.integration.browser.supports.tab.ITab
@@ -79,7 +79,7 @@ object ThemeManager : Configurable("theme") {
             ComponentOverlay.insertComponents()
 
             // Update integration browser
-            IntegrationHandler.updateIntegrationBrowser()
+            IntegrationListener.updateIntegrationBrowser()
             ModuleHud.refresh()
             ModuleClickGui.restartView()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/ComponentOverlay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/ComponentOverlay.kt
@@ -21,8 +21,8 @@
 
 package net.ccbluex.liquidbounce.integration.theme.component
 
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.ComponentsUpdate
 import net.ccbluex.liquidbounce.features.misc.HideAppearance
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleHud
@@ -36,15 +36,15 @@ val customComponents: MutableList<Component> = mutableListOf(
     TextComponent("hello! :)", enabled = false)
 )
 
-object ComponentOverlay : Listenable {
+object ComponentOverlay : EventHandler {
 
     @JvmStatic
-    fun isTweakEnabled(tweak: FeatureTweak) = isRunning() && !HideAppearance.isHidingNow &&
+    fun isTweakEnabled(tweak: FeatureTweak) = this.running && !HideAppearance.isHidingNow &&
         components.filterIsInstance<IntegratedComponent>().any { it.enabled && it.tweaks.contains(tweak) }
 
     @JvmStatic
     fun getComponentWithTweak(tweak: FeatureTweak): IntegratedComponent? {
-        if (!isRunning() || HideAppearance.isHidingNow) {
+        if (!running || HideAppearance.isHidingNow) {
             return null
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/ComponentOverlay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/ComponentOverlay.kt
@@ -21,7 +21,7 @@
 
 package net.ccbluex.liquidbounce.integration.theme.component
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.ComponentsUpdate
 import net.ccbluex.liquidbounce.features.misc.HideAppearance
@@ -36,7 +36,7 @@ val customComponents: MutableList<Component> = mutableListOf(
     TextComponent("hello! :)", enabled = false)
 )
 
-object ComponentOverlay : EventHandler {
+object ComponentOverlay : EventListener {
 
     @JvmStatic
     fun isTweakEnabled(tweak: FeatureTweak) = this.running && !HideAppearance.isHidingNow &&

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.render.engine.font
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.render.FontManager
@@ -15,7 +15,7 @@ private val BASIC_CHARS = '\u0000'..'\u0200'
 class FontGlyphPageManager(
     baseFonts: Set<FontManager.FontFace>,
     additionalFonts: Set<FontManager.FontFace> = emptySet()
-): EventHandler {
+): EventListener {
 
     private var staticPage: List<StaticGlyphPage> = StaticGlyphPage.createGlyphPages(baseFonts.flatMap { loadedFont ->
         loadedFont.styles.filterNotNull().flatMap { font -> BASIC_CHARS.map { ch -> FontGlyph(ch, font) } }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.render.engine.font
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.render.FontManager
@@ -15,7 +15,7 @@ private val BASIC_CHARS = '\u0000'..'\u0200'
 class FontGlyphPageManager(
     baseFonts: Set<FontManager.FontFace>,
     additionalFonts: Set<FontManager.FontFace> = emptySet()
-): Listenable {
+): EventHandler {
 
     private var staticPage: List<StaticGlyphPage> = StaticGlyphPage.createGlyphPages(baseFonts.flatMap { loadedFont ->
         loadedFont.styles.filterNotNull().flatMap { font -> BASIC_CHARS.map { ch -> FontGlyph(ch, font) } }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.render.ui
 
 import com.mojang.blaze3d.systems.RenderSystem
 import com.mojang.blaze3d.systems.VertexSorter
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.ResourceReloadEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -39,7 +39,7 @@ private class Atlas(
 /**
  *
  */
-object ItemImageAtlas: Listenable {
+object ItemImageAtlas: EventHandler {
 
     private var atlas: Atlas? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.render.ui
 
 import com.mojang.blaze3d.systems.RenderSystem
 import com.mojang.blaze3d.systems.VertexSorter
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.ResourceReloadEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -39,7 +39,7 @@ private class Atlas(
 /**
  *
  */
-object ItemImageAtlas: EventHandler {
+object ItemImageAtlas: EventListener {
 
     private var atlas: Atlas? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/PolyglotScript.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/PolyglotScript.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandManager
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.script.bindings.api.ScriptContextProvider
 import net.ccbluex.liquidbounce.script.bindings.features.ScriptChoice
@@ -77,7 +77,7 @@ class PolyglotScript(val language: String, val file: File) {
     /**
      * Tracks client modifications made by the script
      */
-    private val registeredModules = mutableListOf<Module>()
+    private val registeredModules = mutableListOf<ClientModule>()
     private val registeredCommands = mutableListOf<Command>()
     private val registeredChoices = mutableListOf<Choice>()
 
@@ -132,7 +132,7 @@ class PolyglotScript(val language: String, val file: File) {
      * @see ScriptModule
      */
     @Suppress("unused")
-    fun registerModule(moduleObject: Map<String, Any>, callback: (Module) -> Unit) {
+    fun registerModule(moduleObject: Map<String, Any>, callback: (ClientModule) -> Unit) {
         val module = ScriptModule(this, moduleObject)
         registeredModules += module
         callback(module)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptRotationUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptRotationUtil.kt
@@ -18,9 +18,9 @@
  */
 package net.ccbluex.liquidbounce.script.bindings.api
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
@@ -88,10 +88,10 @@ object ScriptRotationUtil {
         RotationManager.aimAt(
             rotation,
             configurable = RotationsConfigurable(
-                object : Listenable { }
+                object : EventHandler { }
             ).also {
                 it.fixVelocity = fixVelocity
-            }, priority = Priority.NORMAL, provider = Module("ScriptAPI", Category.MISC)
+            }, priority = Priority.NORMAL, provider = ClientModule("ScriptAPI", Category.MISC)
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptRotationUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptRotationUtil.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.script.bindings.api
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
@@ -88,7 +88,7 @@ object ScriptRotationUtil {
         RotationManager.aimAt(
             rotation,
             configurable = RotationsConfigurable(
-                object : EventHandler { }
+                object : EventListener { }
             ).also {
                 it.fixVelocity = fixVelocity
             }, priority = Priority.NORMAL, provider = ClientModule("ScriptAPI", Category.MISC)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
@@ -21,12 +21,12 @@ package net.ccbluex.liquidbounce.script.bindings.features
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.script.PolyglotScript
 import net.ccbluex.liquidbounce.utils.client.*
 import kotlin.reflect.KClass
 
-class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) : Module(
+class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) : ClientModule(
     name = moduleObject["name"] as String,
     category = Category.fromReadableName(moduleObject["category"] as String)!!
 ) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/FailFocus.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/FailFocus.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
@@ -12,7 +12,7 @@ import kotlin.random.Random
 /**
  * The fail focus acts as fail rate, it will purposely miss the target on a certain rate.
  */
-class FailFocus(owner: Listenable? = null)
+class FailFocus(owner: EventHandler? = null)
     : ToggleableConfigurable(owner, "Fail", false) {
 
     // Configuration properties

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/FailFocus.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/FailFocus.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
@@ -12,7 +12,7 @@ import kotlin.random.Random
 /**
  * The fail focus acts as fail rate, it will purposely miss the target on a certain rate.
  */
-class FailFocus(owner: EventHandler? = null)
+class FailFocus(owner: EventListener? = null)
     : ToggleableConfigurable(owner, "Fail", false) {
 
     // Configuration properties

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PointTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PointTracker.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.aiming
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.combat.ClickScheduler.Companion.RNG
 import net.ccbluex.liquidbounce.utils.entity.*
@@ -41,7 +41,7 @@ class PointTracker(
     lowestPointDefault: PreferredBoxPart = PreferredBoxPart.BODY,
     timeEnemyOffsetDefault: Float = 0.4f,
     timeEnemyOffsetScale: ClosedFloatingPointRange<Float> = -1f..1f
-) : Configurable("PointTracker"), Listenable {
+) : Configurable("PointTracker"), EventHandler {
 
     companion object {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PointTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PointTracker.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.aiming
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.combat.ClickScheduler.Companion.RNG
 import net.ccbluex.liquidbounce.utils.entity.*
@@ -41,7 +41,7 @@ class PointTracker(
     lowestPointDefault: PreferredBoxPart = PreferredBoxPart.BODY,
     timeEnemyOffsetDefault: Float = 0.4f,
     timeEnemyOffsetScale: ClosedFloatingPointRange<Float> = -1f..1f
-) : Configurable("PointTracker"), EventHandler {
+) : Configurable("PointTracker"), EventListener {
 
     companion object {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PostRotationExecutor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PostRotationExecutor.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.aiming
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
@@ -30,7 +30,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 /**
  * Executes code right after the client sent the normal movement packet or at the start of the next tick.
  */
-object PostRotationExecutor : EventHandler {
+object PostRotationExecutor : EventListener {
 
     /**
      * This should be used by actions that depend on the rotation sent in the tick movement packet.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PostRotationExecutor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/PostRotationExecutor.kt
@@ -18,36 +18,36 @@
  */
 package net.ccbluex.liquidbounce.utils.aiming
 
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventState
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 
 /**
  * Executes code right after the client sent the normal movement packet or at the start of the next tick.
  */
-object PostRotationExecutor : Listenable {
+object PostRotationExecutor : EventHandler {
 
     /**
      * This should be used by actions that depend on the rotation sent in the tick movement packet.
      */
-    private var priorityAction: Pair<Module, () -> Unit>? = null
+    private var priorityAction: Pair<ClientModule, () -> Unit>? = null
 
     private var priorityActionPostMove = false
 
     /**
      * All other actions that should be executed on post-move.
      */
-    private val postMoveTasks = ArrayDeque<Pair<Module, () -> Unit>>()
+    private val postMoveTasks = ArrayDeque<Pair<ClientModule, () -> Unit>>()
 
     /**
      * All other actions that should be executed on tick.
      */
-    private val normalTasks = ArrayDeque<Pair<Module, () -> Unit>>()
+    private val normalTasks = ArrayDeque<Pair<ClientModule, () -> Unit>>()
 
     @Suppress("unused")
     val worldChangeHandler = handler<WorldChangeEvent> {
@@ -80,7 +80,7 @@ object PostRotationExecutor : Listenable {
         }
 
         priorityAction?.let { action ->
-            if (action.first.enabled) {
+            if (action.first.running) {
                 action.second.invoke()
             }
         }
@@ -90,7 +90,7 @@ object PostRotationExecutor : Listenable {
         // execute all other actions
         while (postMoveTasks.isNotEmpty()) {
             val next = postMoveTasks.removeFirst()
-            if (next.first.enabled) {
+            if (next.first.running) {
                 next.second.invoke()
             }
         }
@@ -106,7 +106,7 @@ object PostRotationExecutor : Listenable {
         if (!priorityActionPostMove) {
             // execute the priority action
             priorityAction?.let { action ->
-                if (action.first.enabled) {
+                if (action.first.running) {
                     action.second.invoke()
                 }
             }
@@ -117,7 +117,7 @@ object PostRotationExecutor : Listenable {
         // if we reach this point, the post-move queue should be empty, if not it gets cleared here
         while (postMoveTasks.isNotEmpty()) {
             val next = postMoveTasks.removeFirst()
-            if (next.first.enabled) {
+            if (next.first.running) {
                 next.second.invoke()
             }
         }
@@ -125,13 +125,13 @@ object PostRotationExecutor : Listenable {
         // execute all other actions
         while (normalTasks.isNotEmpty()) {
             val next = normalTasks.removeFirst()
-            if (next.first.enabled) {
+            if (next.first.running) {
                 next.second.invoke()
             }
         }
     }
 
-    fun addTask(module: Module, postMove: Boolean, task: () -> Unit, priority: Boolean = false) {
+    fun addTask(module: ClientModule, postMove: Boolean, task: () -> Unit, priority: Boolean = false) {
         if (priority) {
             priorityAction = module to task
             priorityActionPostMove = postMove

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationModes.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationModes.kt
@@ -20,8 +20,8 @@ package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
-import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.client.RestrictedSingleUseAction
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -29,7 +29,7 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 abstract class RotationMode(
     name: String,
     private val configurable: ChoiceConfigurable<RotationMode>,
-    val module: Module,
+    val module: ClientModule,
 ) : Choice(name), MinecraftShortcuts {
 
     /**
@@ -49,7 +49,7 @@ abstract class RotationMode(
 
 class NormalRotationMode(
     configurable: ChoiceConfigurable<RotationMode>,
-    module: Module,
+    module: ClientModule,
     val priority: Priority = Priority.IMPORTANT_FOR_USAGE_2
 ) : RotationMode("Normal", configurable, module) {
 
@@ -71,7 +71,7 @@ class NormalRotationMode(
 
 }
 
-class NoRotationMode(configurable: ChoiceConfigurable<RotationMode>, module: Module)
+class NoRotationMode(configurable: ChoiceConfigurable<RotationMode>, module: ClientModule)
     : RotationMode("None", configurable, module) {
 
     val send by boolean("SendRotationPacket", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationsUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationsUtil.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -57,7 +57,7 @@ import kotlin.math.sqrt
  * Configurable to configure the dynamic rotation engine
  */
 open class RotationsConfigurable(
-    owner: EventHandler,
+    owner: EventListener,
     fixVelocity: Boolean = true,
     changeLook: Boolean = false,
     combatSpecific: Boolean = false
@@ -133,7 +133,7 @@ open class RotationsConfigurable(
 /**
  * A rotation manager
  */
-object RotationManager : EventHandler {
+object RotationManager : EventListener {
 
     /**
      * Our final target rotation. This rotation is only used to define our current rotation.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationsUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationsUtil.kt
@@ -19,15 +19,15 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.Configurable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerVelocityStrafe
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.fakelag.FakeLag
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleBacktrack
 import net.ccbluex.liquidbounce.utils.aiming.anglesmooth.*
 import net.ccbluex.liquidbounce.utils.client.RestrictedSingleUseAction
@@ -57,7 +57,7 @@ import kotlin.math.sqrt
  * Configurable to configure the dynamic rotation engine
  */
 open class RotationsConfigurable(
-    owner: Listenable,
+    owner: EventHandler,
     fixVelocity: Boolean = true,
     changeLook: Boolean = false,
     combatSpecific: Boolean = false
@@ -133,7 +133,7 @@ open class RotationsConfigurable(
 /**
  * A rotation manager
  */
-object RotationManager : Listenable {
+object RotationManager : EventHandler {
 
     /**
      * Our final target rotation. This rotation is only used to define our current rotation.
@@ -195,7 +195,7 @@ object RotationManager : Listenable {
         considerInventory: Boolean = true,
         configurable: RotationsConfigurable,
         priority: Priority,
-        provider: Module
+        provider: ClientModule
     ) {
         val (rotation, vec) = vecRotation
         aimAt(configurable.toAimPlan(rotation, vec, entity, considerInventory = considerInventory), priority, provider)
@@ -206,7 +206,7 @@ object RotationManager : Listenable {
         considerInventory: Boolean = true,
         configurable: RotationsConfigurable,
         priority: Priority,
-        provider: Module,
+        provider: ClientModule,
         whenReached: RestrictedSingleUseAction? = null
     ) {
         aimAt(configurable.toAimPlan(
@@ -214,7 +214,7 @@ object RotationManager : Listenable {
         ), priority, provider)
     }
 
-    fun aimAt(plan: AimPlan, priority: Priority, provider: Module) {
+    fun aimAt(plan: AimPlan, priority: Priority, provider: ClientModule) {
         if (!allowedToUpdate()) {
             return
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/ShortStop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/ShortStop.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -9,7 +9,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 /**
  * The short stop mechanism temporarily halts aiming at the target based on a specified rate.
  */
-class ShortStop(owner: EventHandler? = null)
+class ShortStop(owner: EventListener? = null)
     : ToggleableConfigurable(owner, "ShortStop", false) {
 
     private val stopRate by int("Rate", 3, 1..25, "%")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/ShortStop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/ShortStop.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -9,7 +9,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 /**
  * The short stop mechanism temporarily halts aiming at the target based on a specified rate.
  */
-class ShortStop(owner: Listenable? = null)
+class ShortStop(owner: EventHandler? = null)
     : ToggleableConfigurable(owner, "ShortStop", false) {
 
     private val stopRate by int("Rate", 3, 1..25, "%")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/SlowStart.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/SlowStart.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -13,7 +13,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
  * enhances aiming by providing smooth adjustments, particularly for fast-moving targets,
  * avoiding abrupt or unnatural flicks.
  */
-class SlowStart(owner: EventHandler? = null)
+class SlowStart(owner: EventListener? = null)
     : ToggleableConfigurable(owner, "SlowStart", false) {
 
     // Configuration properties

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/SlowStart.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/SlowStart.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.aiming
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -13,7 +13,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
  * enhances aiming by providing smooth adjustments, particularly for fast-moving targets,
  * avoiding abrupt or unnatural flicks.
  */
-class SlowStart(owner: Listenable? = null)
+class SlowStart(owner: EventHandler? = null)
     : ToggleableConfigurable(owner, "SlowStart", false) {
 
     // Configuration properties

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -36,7 +36,7 @@ import net.minecraft.world.chunk.WorldChunk
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.cancellation.CancellationException
 
-object ChunkScanner : Listenable {
+object ChunkScanner : EventHandler {
 
     private val subscribers = CopyOnWriteArrayList<BlockChangeSubscriber>()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/ChunkScanner.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -36,7 +36,7 @@ import net.minecraft.world.chunk.WorldChunk
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.cancellation.CancellationException
 
-object ChunkScanner : EventHandler {
+object ChunkScanner : EventListener {
 
     private val subscribers = CopyOnWriteArrayList<BlockChangeSubscriber>()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacer.kt
@@ -20,11 +20,11 @@ package net.ccbluex.liquidbounce.utils.block.placer
 
 import it.unimi.dsi.fastutil.objects.Object2BooleanLinkedOpenHashMap
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.render.FULL_BOX
@@ -57,11 +57,11 @@ import kotlin.math.max
 
 class BlockPlacer(
     name: String,
-    val module: Module,
+    val module: ClientModule,
     val priority: Priority,
     val slotFinder: (BlockPos?) -> HotbarItemSlot?,
     allowSupportPlacements: Boolean = true
-) : Configurable(name), Listenable {
+) : Configurable(name), EventHandler {
 
     val range by float("Range", 4.5f, 1f..6f)
     val wallRange by float("WallRange", 4.5f, 0f..6f)
@@ -442,6 +442,6 @@ class BlockPlacer(
         inaccessible.clear()
     }
 
-    override fun parent(): Listenable = module
+    override fun parent(): EventHandler = module
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacer.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.utils.block.placer
 
 import it.unimi.dsi.fastutil.objects.Object2BooleanLinkedOpenHashMap
 import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.SimulatedTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -61,7 +61,7 @@ class BlockPlacer(
     val priority: Priority,
     val slotFinder: (BlockPos?) -> HotbarItemSlot?,
     allowSupportPlacements: Boolean = true
-) : Configurable(name), EventHandler {
+) : Configurable(name), EventListener {
 
     val range by float("Range", 4.5f, 1f..6f)
     val wallRange by float("WallRange", 4.5f, 0f..6f)
@@ -442,6 +442,6 @@ class BlockPlacer(
         inaccessible.clear()
     }
 
-    override fun parent(): EventHandler = module
+    override fun parent(): EventListener = module
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/CrystalDestroyFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/CrystalDestroyFeature.kt
@@ -19,11 +19,11 @@
 package net.ccbluex.liquidbounce.utils.block.placer
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.*
 import net.ccbluex.liquidbounce.utils.aiming.NoRotationMode
 import net.ccbluex.liquidbounce.utils.aiming.NormalRotationMode
@@ -34,8 +34,8 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.entity.decoration.EndCrystalEntity
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket
 
-class CrystalDestroyFeature(listenable: Listenable, private val module: Module) :
-    ToggleableConfigurable(listenable, "DestroyCrystals", true) {
+class CrystalDestroyFeature(eventHandler: EventHandler, private val module: ClientModule) :
+    ToggleableConfigurable(eventHandler, "DestroyCrystals", true) {
 
     private val range by float("Range", 4.5f, 1f..6f)
     private val wallRange by float("WallRange", 4.5f, 0f..6f)
@@ -62,16 +62,16 @@ class CrystalDestroyFeature(listenable: Listenable, private val module: Module) 
             }
         }
 
-    val repeatable = repeatable {
-        val target = currentTarget ?: return@repeatable
+    val repeatable = tickHandler {
+        val target = currentTarget ?: return@tickHandler
 
         if (!chronometer.hasElapsed(delay.toLong())) {
-            return@repeatable
+            return@tickHandler
         }
 
         if (wouldKill(target)) {
             currentTarget = null
-            return@repeatable
+            return@tickHandler
         }
 
         // find the best spot (and skip if no spot was found)
@@ -81,7 +81,7 @@ class CrystalDestroyFeature(listenable: Listenable, private val module: Module) 
                 target.boundingBox,
                 range = range.toDouble(),
                 wallsRange = wallRange.toDouble(),
-            ) ?: return@repeatable
+            ) ?: return@tickHandler
 
         rotationMode.activeChoice.rotate(rotation, isFinished = {
             facingEnemy(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/CrystalDestroyFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/CrystalDestroyFeature.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.block.placer
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
@@ -34,8 +34,8 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.entity.decoration.EndCrystalEntity
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket
 
-class CrystalDestroyFeature(eventHandler: EventHandler, private val module: ClientModule) :
-    ToggleableConfigurable(eventHandler, "DestroyCrystals", true) {
+class CrystalDestroyFeature(eventListener: EventListener, private val module: ClientModule) :
+    ToggleableConfigurable(eventListener, "DestroyCrystals", true) {
 
     private val range by float("Range", 4.5f, 1f..6f)
     private val wallRange by float("WallRange", 4.5f, 0f..6f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ClientUtils.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.features.command.Command
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.interfaces.ClientTextColorAdditions
 import net.minecraft.client.MinecraftClient
 import net.minecraft.text.MutableText
@@ -133,11 +133,11 @@ fun chat(vararg texts: Text, metadata: MessageMetadata = defaultMessageMetadata)
     chatHud.addMessage(literalText, metadata.id, metadata.count)
 }
 
-fun chat(text: Text, module: Module) = chat(text, metadata = MessageMetadata(id = "${module.name}#info"))
+fun chat(text: Text, module: ClientModule) = chat(text, metadata = MessageMetadata(id = "${module.name}#info"))
 
 fun chat(text: Text, command: Command) = chat(text, metadata = MessageMetadata(id = "${command.name}#info"))
 
-fun chat(text: String, module: Module) = chat(text.asText(), module)
+fun chat(text: String, module: ClientModule) = chat(text.asText(), module)
 
 fun chat(text: String, command: Command) = chat(text.asText(), command)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/EventScheduler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/EventScheduler.kt
@@ -20,14 +20,14 @@ package net.ccbluex.liquidbounce.utils.client
 
 import net.ccbluex.liquidbounce.event.ALL_EVENT_CLASSES
 import net.ccbluex.liquidbounce.event.Event
-import net.ccbluex.liquidbounce.event.Listenable
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Useful for sending actions to other events.
  */
-object EventScheduler : Listenable {
+object EventScheduler : EventHandler {
 
     /**
      * Maps the event class to the scheduled tasks that currently wait for it.
@@ -47,7 +47,7 @@ object EventScheduler : Listenable {
      * or the event does not exist.
      */
     inline fun <reified T : Event> schedule(
-        module: Module,
+        module: ClientModule,
         uniqueId: Int? = null,
         noinline action: (T) -> Unit
     ): Boolean {
@@ -58,7 +58,7 @@ object EventScheduler : Listenable {
      * @see schedule
      */
     fun schedule(
-        module: Module,
+        module: ClientModule,
         eventClass: Class<out Event>,
         uniqueId: Int?,
         action: (Event) -> Unit
@@ -79,7 +79,7 @@ object EventScheduler : Listenable {
     }
 
 
-    fun clear(module: Module) {
+    fun clear(module: ClientModule) {
         for (value in eventActionsMap.values) {
             value.removeIf { it.module == module }
         }
@@ -104,7 +104,7 @@ object EventScheduler : Listenable {
     // An event here that detects world change then clears the list
 
     data class ScheduleInfo(
-        val module: Module,
+        val module: ClientModule,
         val id: Int?,
         val action: (Event) -> Unit,
         var discarded: Boolean = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/EventScheduler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/EventScheduler.kt
@@ -20,14 +20,14 @@ package net.ccbluex.liquidbounce.utils.client
 
 import net.ccbluex.liquidbounce.event.ALL_EVENT_CLASSES
 import net.ccbluex.liquidbounce.event.Event
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Useful for sending actions to other events.
  */
-object EventScheduler : EventHandler {
+object EventScheduler : EventListener {
 
     /**
      * Maps the event class to the scheduled tasks that currently wait for it.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/InteractionTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/InteractionTracker.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.blocking.NoSlowBlock.player
@@ -10,7 +10,7 @@ import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
 import net.minecraft.util.Hand
 import net.minecraft.util.UseAction
 
-object InteractionTracker : EventHandler {
+object InteractionTracker : EventListener {
 
     val isBlocking: Boolean
         get() = currentInteraction?.action == UseAction.BLOCK

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/InteractionTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/InteractionTracker.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.blocking.NoSlowBlock.player
@@ -10,7 +10,7 @@ import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
 import net.minecraft.util.Hand
 import net.minecraft.util.UseAction
 
-object InteractionTracker : Listenable {
+object InteractionTracker : EventHandler {
 
     val isBlocking: Boolean
         get() = currentInteraction?.action == UseAction.BLOCK
@@ -64,6 +64,6 @@ object InteractionTracker : Listenable {
 
     data class Interaction(val hand: Hand, val action: UseAction)
 
-    override fun isRunning() = inGame
+    override val running = inGame
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SignTranslationFix.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SignTranslationFix.kt
@@ -30,7 +30,7 @@ object VanillaTranslationRecognizer {
 }
 
 fun filterNonVanillaText(text: Text): Text {
-    if (!ModuleTranslationFix.enabled) {
+    if (!ModuleTranslationFix.running) {
         return text
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
@@ -18,14 +18,14 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 
 /**
  * Manages things like [Scaffold]'s silent mode. Not thread safe, please only use this on the main-thread of minecraft
  */
-object SilentHotbar : EventHandler {
+object SilentHotbar : EventListener {
 
     private var hotbarState: SilentHotbarState? = null
     private var ticksSinceLastUpdate: Int = 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/SilentHotbar.kt
@@ -18,14 +18,14 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 
 /**
  * Manages things like [Scaffold]'s silent mode. Not thread safe, please only use this on the main-thread of minecraft
  */
-object SilentHotbar : Listenable {
+object SilentHotbar : EventHandler {
 
     private var hotbarState: SilentHotbarState? = null
     private var ticksSinceLastUpdate: Int = 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/Timer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/Timer.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.kotlin.RequestHandler
 
 // Global minecraft timer
-object Timer : EventHandler {
+object Timer : EventListener {
     private val requestHandler = RequestHandler<Float>()
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/Timer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/Timer.kt
@@ -18,16 +18,16 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.kotlin.RequestHandler
 
 // Global minecraft timer
-object Timer : Listenable {
+object Timer : EventHandler {
     private val requestHandler = RequestHandler<Float>()
 
     /**
@@ -44,7 +44,7 @@ object Timer : Listenable {
      * Requests a timer speed change. If another module requests with a higher priority,
      * the other module is prioritized.
      */
-    fun requestTimerSpeed(timerSpeed: Float, priority: Priority, provider: Module, resetAfterTicks: Int = 1) {
+    fun requestTimerSpeed(timerSpeed: Float, priority: Priority, provider: ClientModule, resetAfterTicks: Int = 1) {
         requestHandler.request(
             RequestHandler.Request(
                 // this prevents requests from being instantly removed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/ClickScheduler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/ClickScheduler.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.combat
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
@@ -44,7 +44,7 @@ import kotlin.random.nextInt
  * This allows us to predict future actions and behave accordingly.
  */
 open class ClickScheduler<T>(val parent: T, showCooldown: Boolean, maxCps: Int = 60, name: String = "ClickScheduler")
-    : Configurable(name), Listenable where T : Listenable {
+    : Configurable(name), EventHandler where T : EventHandler {
 
     companion object {
         val RNG = java.util.Random()
@@ -58,7 +58,7 @@ open class ClickScheduler<T>(val parent: T, showCooldown: Boolean, maxCps: Int =
     private val clickTechnique by enumChoice("Technique", ClickTechnique.STABILIZED)
 
     class Cooldown<T>(module: T) : ToggleableConfigurable(module, "Cooldown", true)
-        where T: Listenable {
+        where T: EventHandler {
 
         val rangeCooldown by floatRange("Timing", 1.0f..1.0f, 0.1f..1f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/ClickScheduler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/ClickScheduler.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.combat
 import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
@@ -44,7 +44,7 @@ import kotlin.random.nextInt
  * This allows us to predict future actions and behave accordingly.
  */
 open class ClickScheduler<T>(val parent: T, showCooldown: Boolean, maxCps: Int = 60, name: String = "ClickScheduler")
-    : Configurable(name), EventHandler where T : EventHandler {
+    : Configurable(name), EventListener where T : EventListener {
 
     companion object {
         val RNG = java.util.Random()
@@ -58,7 +58,7 @@ open class ClickScheduler<T>(val parent: T, showCooldown: Boolean, maxCps: Int =
     private val clickTechnique by enumChoice("Technique", ClickTechnique.STABILIZED)
 
     class Cooldown<T>(module: T) : ToggleableConfigurable(module, "Cooldown", true)
-        where T: EventHandler {
+        where T: EventListener {
 
         val rangeCooldown by floatRange("Timing", 1.0f..1.0f, 0.1f..1f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatManager.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.combat
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.handler
 /**
  * A rotation manager
  */
-object CombatManager : Listenable {
+object CombatManager : EventHandler {
 
     // useful for something like autoSoup
     private var pauseCombat: Int = 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatManager.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.combat
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.AttackEvent
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.event.handler
 /**
  * A rotation manager
  */
-object CombatManager : EventHandler {
+object CombatManager : EventListener {
 
     // useful for something like autoSoup
     private var pauseCombat: Int = 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/EntityTaggingManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/EntityTaggingManager.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.utils.combat
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
@@ -9,7 +9,7 @@ import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.minecraft.entity.Entity
 import java.util.concurrent.ConcurrentHashMap
 
-object EntityTaggingManager: EventHandler {
+object EntityTaggingManager: EventListener {
     private val cache = ConcurrentHashMap<Entity, EntityTag>()
 
     val tickHandler = handler<GameTickEvent> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/EntityTaggingManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/EntityTaggingManager.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.utils.combat
 
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.TagEntityEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -9,7 +9,7 @@ import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.minecraft.entity.Entity
 import java.util.concurrent.ConcurrentHashMap
 
-object EntityTaggingManager: Listenable {
+object EntityTaggingManager: EventHandler {
     private val cache = ConcurrentHashMap<Entity, EntityTag>()
 
     val tickHandler = handler<GameTickEvent> {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/PlayerSimulationCache.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/PlayerSimulationCache.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.utils.entity
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
-object PlayerSimulationCache: EventHandler {
+object PlayerSimulationCache: EventListener {
     private val otherPlayerCache = ConcurrentHashMap<PlayerEntity, SimulatedPlayerCache>()
     private var localPlayerCache: SimulatedPlayerCache? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/PlayerSimulationCache.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/PlayerSimulationCache.kt
@@ -1,6 +1,6 @@
 package net.ccbluex.liquidbounce.utils.entity
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
-object PlayerSimulationCache: Listenable {
+object PlayerSimulationCache: EventHandler {
     private val otherPlayerCache = ConcurrentHashMap<PlayerEntity, SimulatedPlayerCache>()
     private var localPlayerCache: SimulatedPlayerCache? = null
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/input/InputTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/input/InputTracker.kt
@@ -19,7 +19,7 @@
 
 package net.ccbluex.liquidbounce.utils.input
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -32,7 +32,7 @@ import org.lwjgl.glfw.GLFW
  * It listens for mouse button events and provides utility functions to check if
  * a key or mouse button is currently pressed.
  */
-object InputTracker : EventHandler {
+object InputTracker : EventListener {
 
     // Tracks the state of each mouse button (pressed or not).
     private val mouseStates = mutableMapOf<Int, Boolean>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/input/InputTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/input/InputTracker.kt
@@ -19,7 +19,7 @@
 
 package net.ccbluex.liquidbounce.utils.input
 
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -32,7 +32,7 @@ import org.lwjgl.glfw.GLFW
  * It listens for mouse button events and provides utility functions to check if
  * a key or mouse button is currently pressed.
  */
-object InputTracker : Listenable {
+object InputTracker : EventHandler {
 
     // Tracks the state of each mouse button (pressed or not).
     private val mouseStates = mutableMapOf<Int, Boolean>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
@@ -21,14 +21,14 @@
 
 package net.ccbluex.liquidbounce.utils.inventory
 
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.EventManager
-import net.ccbluex.liquidbounce.event.Listenable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ContainerItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemSlot
@@ -53,7 +53,7 @@ import kotlin.random.Random
  *  - Progress Bar
  *  - Off-screen actions
  */
-object InventoryManager : Listenable {
+object InventoryManager : EventHandler {
 
     var isInventoryOpenServerSide = false
         internal set
@@ -74,10 +74,10 @@ object InventoryManager : Listenable {
      * and schedule the inventory actions
      */
     @Suppress("unused")
-    private val repeatingSchedulerExecutor = repeatable {
+    private val repeatingSchedulerExecutor = tickHandler {
         // We are not in-game, so we don't need to do anything and throw away the schedule
         if (!inGame) {
-            return@repeatable
+            return@tickHandler
         }
 
         var maximumCloseDelay = 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
@@ -21,7 +21,7 @@
 
 package net.ccbluex.liquidbounce.utils.inventory
 
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
@@ -53,7 +53,7 @@ import kotlin.random.Random
  *  - Progress Bar
  *  - Off-screen actions
  */
-object InventoryManager : EventHandler {
+object InventoryManager : EventListener {
 
     var isInventoryOpenServerSide = false
         internal set

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/kotlin/RequestHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/kotlin/RequestHandler.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.kotlin
 
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import java.util.*
 
 class RequestHandler<T> {
@@ -40,7 +40,7 @@ class RequestHandler<T> {
     fun getActiveRequestValue(): T? {
         // we remove all outdated requests here
         while ((this.activeRequests.peek() ?: return null).expiresIn <= currentTick ||
-            !this.activeRequests.peek().provider.enabled
+            !this.activeRequests.peek().provider.running
         ) {
             this.activeRequests.remove()
         }
@@ -57,6 +57,6 @@ class RequestHandler<T> {
      * @param provider module which requested value
      */
     class Request<T>(
-        var expiresIn: Int, val priority: Int, val provider: Module, val value: T
+        var expiresIn: Int, val priority: Int, val provider: ClientModule, val value: T
     )
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.render
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -43,7 +43,7 @@ import kotlin.math.sin
  * A target tracker to choose the best enemy to attack
  */
 abstract class TargetRenderer<T: RenderEnvironment>(
-    module: Module
+    module: ClientModule
 ) : ToggleableConfigurable(module, "TargetRendering", true) {
 
     init {
@@ -63,7 +63,7 @@ abstract class TargetRenderer<T: RenderEnvironment>(
 }
 
 
-class WorldTargetRenderer(module: Module) : TargetRenderer<WorldRenderEnvironment>(module) {
+class WorldTargetRenderer(module: ClientModule) : TargetRenderer<WorldRenderEnvironment>(module) {
 
     val legacy = Legacy()
     val circle = Circle(module)
@@ -110,7 +110,7 @@ class WorldTargetRenderer(module: Module) : TargetRenderer<WorldRenderEnvironmen
         }
     }
 
-    inner class Circle(module: Module) : WorldTargetRenderAppearance("Circle") {
+    inner class Circle(module: ClientModule) : WorldTargetRenderAppearance("Circle") {
         override val parent: ChoiceConfigurable<Choice>
             get() = appearance
 
@@ -149,7 +149,7 @@ class WorldTargetRenderer(module: Module) : TargetRenderer<WorldRenderEnvironmen
 
     }
 
-    inner class GlowingCircle(module: Module) : WorldTargetRenderAppearance("GlowingCircle") {
+    inner class GlowingCircle(module: ClientModule) : WorldTargetRenderAppearance("GlowingCircle") {
         override val parent: ChoiceConfigurable<Choice>
             get() = appearance
 
@@ -283,7 +283,7 @@ class WorldTargetRenderer(module: Module) : TargetRenderer<WorldRenderEnvironmen
     }
 }
 
-class OverlayTargetRenderer(module: Module) : TargetRenderer<GUIRenderEnvironment>(module) {
+class OverlayTargetRenderer(module: ClientModule) : TargetRenderer<GUIRenderEnvironment>(module) {
     override val appearance = choices<Choice>(module, "Mode", Legacy(), arrayOf(Legacy()))
 
     inner class Legacy : OverlayTargetRenderAppearance("Arrow") {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.render
 
 import com.mojang.blaze3d.systems.RenderSystem
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -29,7 +29,7 @@ import net.minecraft.util.math.Vec3d
 import org.joml.Matrix4f
 import org.joml.Vector3f
 
-object WorldToScreen: EventHandler {
+object WorldToScreen: EventListener {
 
     private var mvMatrix: Matrix4f? = null
     private var projectionMatrix: Matrix4f? = null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.render
 
 import com.mojang.blaze3d.systems.RenderSystem
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.render.engine.Vec3
@@ -29,7 +29,7 @@ import net.minecraft.util.math.Vec3d
 import org.joml.Matrix4f
 import org.joml.Vector3f
 
-object WorldToScreen: Listenable {
+object WorldToScreen: EventHandler {
 
     private var mvMatrix: Matrix4f? = null
     private var projectionMatrix: Matrix4f? = null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderer.kt
@@ -20,7 +20,7 @@ package net.ccbluex.liquidbounce.utils.render.placement
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventHandler
+import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -42,7 +42,7 @@ import net.minecraft.util.math.Box
 open class PlacementRenderer(
     name: String,
     enabled: Boolean,
-    val module: EventHandler,
+    val module: EventListener,
     val keep: Boolean = true,
     clump: Boolean = true,
     defaultColor: Color4b = Color4b(0, 255, 0, 90)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderer.kt
@@ -20,11 +20,11 @@ package net.ccbluex.liquidbounce.utils.render.placement
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Listenable
+import net.ccbluex.liquidbounce.event.EventHandler
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.repeatable
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.render.EMPTY_BOX
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.block.outlineBox
@@ -42,7 +42,7 @@ import net.minecraft.util.math.Box
 open class PlacementRenderer(
     name: String,
     enabled: Boolean,
-    val module: Listenable,
+    val module: EventHandler,
     val keep: Boolean = true,
     clump: Boolean = true,
     defaultColor: Color4b = Color4b(0, 255, 0, 90)
@@ -88,7 +88,7 @@ open class PlacementRenderer(
     }
 
     @Suppress("unused")
-    private val repeatable = repeatable {
+    private val repeatable = tickHandler {
         if (!outAnimationsFinished && placementRenderHandlers.values.all { it.isFinished() }) {
             outAnimationsFinished = true
         }
@@ -180,9 +180,8 @@ open class PlacementRenderer(
     /**
      * Only run when the module and this is enabled or out-animations are running.
      */
-    override fun isRunning(): Boolean {
-        return module.isRunning() && enabled || !outAnimationsFinished
-    }
+    override val running: Boolean
+        get() = module.running && enabled || !outAnimationsFinished
 
     /**
      * Returns the box color.

--- a/src/test/kotlin/net/ccbluex/liquidbounce/utils/kotlin/RequestHandlerTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/utils/kotlin/RequestHandlerTest.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.kotlin
 
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.ClientModule
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test
 
 class RequestHandlerTest {
     companion object {
-        private val MODULE_1 = Module("module1", Category.MISC, state = true)
-        private val MODULE_2 = Module("module2", Category.MISC, state = true)
-        private val MODULE_3 = Module("module3", Category.MISC, state = true)
-        private val MODULE_4 = Module("module4", Category.MISC, state = true)
+        private val MODULE_1 = ClientModule("module1", Category.MISC, state = true)
+        private val MODULE_2 = ClientModule("module2", Category.MISC, state = true)
+        private val MODULE_3 = ClientModule("module3", Category.MISC, state = true)
+        private val MODULE_4 = ClientModule("module4", Category.MISC, state = true)
     }
 
     @BeforeEach


### PR DESCRIPTION
- refactor: Renamed `Listenable` to `EventListener`
- refactor: Renamed `repeatable` to `tickHandler`
- refactor: Turned `isRunning` into the variable `running`
- refactor: Renamed `Module` to `ClientModule` (Prevents conflicts with Java)
- fix: Mixin often not using `getRunning` but working with the unsafe `getEnabled` instead.