### PR TITLE
fix(legacy): truesight force particlesettings

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/TrueSight.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/TrueSight.kt
@@ -5,6 +5,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import net.ccbluex.liquidbounce.event.EventTarget
+import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.value.boolean
@@ -12,4 +14,11 @@ import net.ccbluex.liquidbounce.value.boolean
 object TrueSight : Module("TrueSight", Category.RENDER) {
     val barriers by boolean("Barriers", true)
     val entities by boolean("Entities", true)
+
+    @EventTarget
+    fun onUpdate(event: UpdateEvent) {
+        if (barriers && mc.gameSettings.particleSetting == 2) {
+            mc.gameSettings.particleSetting = 1
+        }
+    }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRendererLivingEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRendererLivingEntity.java
@@ -78,7 +78,7 @@ public abstract class MixinRendererLivingEntity extends MixinRender {
 
             if (semiVisible) {
                 pushMatrix();
-                color(1f, 1f, 1f, 0.15F);
+                color(1f, 1f, 1f, 0.3F);
                 depthMask(false);
                 glEnable(GL_BLEND);
                 blendFunc(770, 771);


### PR DESCRIPTION
barrier truesight seems to only work only on `all` & `decrease`