### PR TITLE
feat(AutoBuff): rotating timing on-tick + on-use

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
@@ -37,8 +37,7 @@ abstract class Buff(
 ) : ToggleableConfigurable(ModuleAutoBuff, name, true) {
 
     internal open val passesRequirements: Boolean
-        get() = enabled && !player.isDead && !InventoryManager.isInventoryOpenServerSide
-            && !interaction.currentGameMode.isCreative
+        get() = enabled && !InventoryManager.isInventoryOpenServerSide
 
     /**
      * Try to run feature if possible, otherwise return false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
@@ -25,12 +25,17 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.Buff
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff
+import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff.AutoBuffRotationsConfigurable.RotationTimingMode.*
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Pot.isPotion
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager.currentRotation
+import net.ccbluex.liquidbounce.utils.aiming.withFixedYaw
+import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.FallingPlayer
+import net.ccbluex.liquidbounce.utils.entity.rotation
 import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
 import net.ccbluex.liquidbounce.utils.item.getPotionEffects
 import net.ccbluex.liquidbounce.utils.item.isNothing
@@ -106,20 +111,52 @@ object Pot : Buff("Pot", isValidItem = { stack, forUse -> isPotion(stack, forUse
     private val allowLingering by boolean("AllowLingering", false)
 
     override suspend fun execute(sequence: Sequence<*>, slot: HotbarItemSlot) {
-        sequence.waitUntil {
-            // TODO: Use movement prediction to splash against walls and away from the player
-            //   See https://github.com/CCBlueX/LiquidBounce/issues/2051
-            RotationManager.aimAt(
-                Rotation(player.yaw, (85f..90f).random().toFloat()),
-                configurable = ModuleAutoBuff.rotations,
-                provider = ModuleAutoBuff,
-                priority = Priority.IMPORTANT_FOR_PLAYER_LIFE
-            )
+        // TODO: Use movement prediction to splash against walls and away from the player
+        //   See https://github.com/CCBlueX/LiquidBounce/issues/2051
+        var rotation = Rotation(player.yaw, (85f..90f).random().toFloat())
 
-            RotationManager.serverRotation.pitch > 85
+        when (ModuleAutoBuff.rotations.rotationTiming) {
+            NORMAL -> {
+                RotationManager.aimAt(
+                    rotation,
+                    configurable = ModuleAutoBuff.rotations,
+                    provider = ModuleAutoBuff,
+                    priority = Priority.IMPORTANT_FOR_PLAYER_LIFE
+                )
+
+                sequence.waitUntil {
+                    (currentRotation ?: player.rotation).pitch > 85
+                }
+
+                rotation = rotation.normalize()
+            }
+            ON_TICK -> {
+                rotation = rotation.normalize()
+                network.sendPacket(MovePacketType.FULL.generatePacket().apply {
+                    yaw = rotation.yaw
+                    pitch = rotation.pitch
+                })
+            }
+            ON_USE -> {
+                rotation = rotation.normalize()
+            }
         }
 
-        useHotbarSlotOrOffhand(slot)
+        useHotbarSlotOrOffhand(
+            slot,
+            yaw = rotation.yaw,
+            pitch = rotation.pitch,
+        )
+
+        when (ModuleAutoBuff.rotations.rotationTiming) {
+            ON_TICK -> {
+                network.sendPacket(MovePacketType.FULL.generatePacket().apply {
+                    yaw = player.withFixedYaw(currentRotation ?: player.rotation)
+                    pitch = currentRotation?.pitch ?: player.pitch
+                })
+            }
+            else -> { }
+        }
 
         // Wait at least 1 tick to make sure, we do not continue with something else too early
         sequence.waitTicks(1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
@@ -190,8 +190,8 @@ fun findItemsInContainer(screen: GenericContainerScreen) =
 fun useHotbarSlotOrOffhand(
     item: HotbarItemSlot,
     ticksUntilReset: Int = 1,
-    yaw: Float = RotationManager.serverRotation.yaw,
-    pitch: Float = RotationManager.serverRotation.pitch
+    yaw: Float = RotationManager.currentRotation?.yaw ?: player.yaw,
+    pitch: Float = RotationManager.currentRotation?.yaw ?: player.pitch,
 ) = when (item) {
     OffHandSlot -> interactItem(Hand.OFF_HAND, yaw, pitch)
     else -> interactItem(Hand.MAIN_HAND, yaw, pitch) {
@@ -201,8 +201,8 @@ fun useHotbarSlotOrOffhand(
 
 fun interactItem(
     hand: Hand,
-    yaw: Float = RotationManager.serverRotation.yaw,
-    pitch: Float = RotationManager.serverRotation.yaw,
+    yaw: Float = RotationManager.currentRotation?.yaw ?: player.yaw,
+    pitch: Float = RotationManager.currentRotation?.yaw ?: player.pitch,
     preInteraction: () -> Unit = { }
 ) {
     preInteraction()


### PR DESCRIPTION
Both modes allow potions to be thrown on the same tick without changing the server-side view. This means that this mode does not interrupt combat.