### PR TITLE
refactor: Speed

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -39,14 +39,11 @@
     <ID>BracesOnIfStatements:ModuleTimerRange.kt$ModuleTimerRange$if</ID>
     <ID>BracesOnIfStatements:RenderShortcuts.kt$else</ID>
     <ID>BracesOnIfStatements:RenderShortcuts.kt$if</ID>
-    <ID>BracesOnIfStatements:SpeedGeneric.kt$SpeedBHopBase$if</ID>
     <ID>BracesOnIfStatements:SpeedGrimCollide.kt$SpeedGrimCollide$if</ID>
-    <ID>BracesOnIfStatements:SpeedHypixelBHop.kt$SpeedHypixelBHop$if</ID>
     <ID>BracesOnIfStatements:SpeedPreventDeadlyJump.kt$SpeedPreventDeadlyJump$if</ID>
     <ID>BracesOnIfStatements:TargetFinding.kt$BlockPlacementTarget$if</ID>
     <ID>BracesOnIfStatements:TargetRenderer.kt$WorldTargetRenderer.GlowingCircle$else</ID>
     <ID>BracesOnIfStatements:TargetRenderer.kt$WorldTargetRenderer.GlowingCircle$if</ID>
-    <ID>CognitiveComplexMethod:AStarMode.kt$AStarMode$override fun enable()</ID>
     <ID>CognitiveComplexMethod:AStarMode.kt$AStarMode$private fun findPath(start: Vec3i, end: Vec3i, maxCost: Int, maxIterations: Int = 500): List&lt;Vec3i></ID>
     <ID>CognitiveComplexMethod:AutoConfig.kt$AutoConfig$fun handlePossibleAutoConfig(jsonObject: JsonObject)</ID>
     <ID>CognitiveComplexMethod:BlockExtensions.kt$fun Block?.isInteractable(blockState: BlockState?): Boolean</ID>
@@ -124,7 +121,6 @@
     <ID>PrintStackTrace:CommandManager.kt$CommandManager$e</ID>
     <ID>ReturnCount:IntegrationListener.kt$IntegrationListener$private fun handleScreenSituation(screen: Screen?): Boolean</ID>
     <ID>ReturnCount:SpeedAntiCornerBump.kt$SpeedAntiCornerBump$fun getSuggestedJumpDelay( simulatedPlayer: SimulatedPlayer, n: Int = 2, ): Int?</ID>
-    <ID>SpreadOperator:AStarMode.kt$AStarMode$( Vec3i(-1, 0, 0), // left Vec3i(1, 0, 0), // right *(-9..9).map { Vec3i(0, it, 0) }.toTypedArray(), // up- and down Vec3i(0, 0, -1), // front Vec3i(0, 0, 1) // back )</ID>
     <ID>SpreadOperator:ModuleVomit.kt$ModuleVomit$( *emptySlots.map { slot -> CreativeInventoryAction.performFillSlot(randomStack, slot) } .toTypedArray(), *emptySlots.map { slot -> ClickInventoryAction.performThrow(null, slot) } .toTypedArray() )</ID>
     <ID>StringLiteralDuplication:AutoQueueGommeDuels.kt$AutoQueueGommeDuels$"AutoPlay"</ID>
     <ID>StringLiteralDuplication:ScriptSetting.kt$ScriptSetting$"default"</ID>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
@@ -232,7 +232,7 @@ object CriticalsJump : Choice("Jump") {
         return ticksTillFall + 1.0f < nextPossibleCrit
     }
 
-    fun isActive(): Boolean {
+    private fun isActive(): Boolean {
         if (!ModuleCriticals.running) {
             return false
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -24,7 +24,6 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.modes.CriticalsJump
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed.OnlyInCombat.modes
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed.OnlyOnPotionEffect.potionEffects
@@ -106,6 +105,7 @@ object ModuleSpeed : ClientModule("Speed", Category.MOVEMENT) {
     init {
         tree(OnlyInCombat)
         tree(OnlyOnPotionEffect)
+        tree(SpeedYawOffset)
     }
 
     override val running: Boolean
@@ -132,9 +132,6 @@ object ModuleSpeed : ClientModule("Speed", Category.MOVEMENT) {
         notWhileSneaking && player.isSneaking -> false
         else -> true
     }
-
-    fun shouldDelayJump() = !mc.options.jumpKey.isPressed && (SpeedAntiCornerBump.shouldDelayJump()
-        || CriticalsJump.shouldWaitForJump())
 
     private object OnlyInCombat : ToggleableConfigurable(this, "OnlyInCombat", false) {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.modes.CriticalsJump
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed.OnlyInCombat.modes
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed.OnlyOnPotionEffect.potionEffects
@@ -102,6 +103,8 @@ object ModuleSpeed : ClientModule("Speed", Category.MOVEMENT) {
     private val notDuringScaffold by boolean("NotDuringScaffold", true)
     private val notWhileSneaking by boolean("NotWhileSneaking", false)
 
+    private val avoidEdgeBump by boolean("AvoidEdgeBump", true)
+
     init {
         tree(OnlyInCombat)
         tree(OnlyOnPotionEffect)
@@ -179,6 +182,18 @@ object ModuleSpeed : ClientModule("Speed", Category.MOVEMENT) {
             get() = potionEffects
 
         abstract fun checkPotionEffects(): Boolean
+    }
+
+    internal fun doOptimizationsPreventJump(): Boolean {
+        if (CriticalsJump.running && CriticalsJump.shouldWaitForJump(0.42f)) {
+            return true
+        }
+
+        if (avoidEdgeBump && SpeedAntiCornerBump.shouldDelayJump()) {
+            return true
+        }
+
+        return false
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/SpeedYawOffset.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/SpeedYawOffset.kt
@@ -1,0 +1,93 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.speed
+
+import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.utils.aiming.Rotation
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
+
+/**
+ * Makes you go faster by strafing 45deg
+ */
+object SpeedYawOffset : ToggleableConfigurable(ModuleSpeed, "YawOffset", false) {
+
+    private val yawOffsetMode by enumChoice("YawOffsetMode", YawOffsetMode.AIR)
+    private val rotationsConfigurable = RotationsConfigurable(this)
+
+    private var yaw = 0f
+
+    @Suppress("unused")
+    private val yawOffsetHandler = handler<GameTickEvent> {
+        when (yawOffsetMode) {
+            YawOffsetMode.GROUND -> groundYawOffset() // makes you strafe more on ground
+            YawOffsetMode.AIR -> airYawOffset() // 45deg strafe on air
+            YawOffsetMode.NONE -> return@handler
+        }
+
+        val rotation = Rotation(player.yaw - yaw, player.pitch)
+
+        RotationManager.aimAt(
+            rotationsConfigurable.toAimPlan(rotation), Priority.NOT_IMPORTANT,
+            ModuleSpeed
+        )
+    }
+
+    private fun groundYawOffset(): Float {
+        yaw = if (player.isOnGround) {
+            when {
+                mc.options.forwardKey.isPressed && mc.options.leftKey.isPressed -> 45f
+                mc.options.forwardKey.isPressed && mc.options.rightKey.isPressed -> -45f
+                mc.options.backKey.isPressed && mc.options.leftKey.isPressed -> 135f
+                mc.options.backKey.isPressed && mc.options.rightKey.isPressed -> -135f
+                mc.options.backKey.isPressed -> 180f
+                mc.options.leftKey.isPressed -> 90f
+                mc.options.rightKey.isPressed -> -90f
+                else -> 0f
+            }
+        } else {
+            0f
+        }
+        return 0f
+    }
+
+    private fun airYawOffset(): Float {
+        yaw = when {
+            !player.isOnGround &&
+                mc.options.forwardKey.isPressed &&
+                !mc.options.leftKey.isPressed &&
+                !mc.options.rightKey.isPressed
+                -> -45f
+
+            else -> 0f
+        }
+        return 0f
+    }
+
+    private enum class YawOffsetMode(override val choiceName: String) : NamedChoice {
+        GROUND("Ground"),
+        AIR("Air"),
+        NONE("None")
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedGeneric.kt
@@ -23,8 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
-import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.modes.CriticalsJump
-import net.ccbluex.liquidbounce.features.module.modules.movement.speed.SpeedAntiCornerBump
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed.doOptimizationsPreventJump
 import net.ccbluex.liquidbounce.utils.entity.downwards
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -47,8 +46,6 @@ class SpeedLegitHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
 
 open class SpeedBHopBase(name: String, override val parent: ChoiceConfigurable<*>) : Choice(name) {
 
-    private val avoidEdgeBump by boolean("AvoidEdgeBump", true)
-
     @Suppress("unused")
     private val handleMovementInput = handler<MovementInputEvent> { event ->
         if (!player.isOnGround || !event.directionalInput.isMoving) {
@@ -60,18 +57,6 @@ open class SpeedBHopBase(name: String, override val parent: ChoiceConfigurable<*
         }
 
         event.jumping = true
-    }
-
-    private fun doOptimizationsPreventJump(): Boolean {
-        if (CriticalsJump.running && CriticalsJump.shouldWaitForJump(0.42f)) {
-            return true
-        }
-
-        if (avoidEdgeBump && SpeedAntiCornerBump.shouldDelayJump()) {
-            return true
-        }
-
-        return false
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/blocksmc/SpeedBlocksMC.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/blocksmc/SpeedBlocksMC.kt
@@ -65,8 +65,8 @@ class SpeedBlocksMC(override val parent: ChoiceConfigurable<*>) : Choice("Blocks
         player.strafe(speed = 0.0)
     }
 
-    val repeatable = tickHandler {
-
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
         if (player.isOnGround) {
             airTicks = 0
             canSpeed = true
@@ -133,7 +133,8 @@ class SpeedBlocksMC(override val parent: ChoiceConfigurable<*>) : Choice("Blocks
 
     }
 
-    val jumpEvent = handler<PlayerJumpEvent> {
+    @Suppress("unused")
+    private val jumpHandler = handler<PlayerJumpEvent> {
         val atLeast = 0.281 + 0.2 * (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0)
         if (!canSpeed) {
             return@handler
@@ -146,9 +147,10 @@ class SpeedBlocksMC(override val parent: ChoiceConfigurable<*>) : Choice("Blocks
         player.strafe(speed = player.sqrtSpeed.coerceAtLeast(atLeast) - 0.01)
     }
 
-    val movementInputEvent = handler<MovementInputEvent> {
-        if (player.moving) {
-            it.jumping = true
+    @Suppress("unused")
+    private val movementInputHandler = handler<MovementInputEvent> { event ->
+        if (event.directionalInput.isMoving) {
+            event.jumping = true
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimCollide.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/grim/SpeedGrimCollide.kt
@@ -24,7 +24,8 @@ class SpeedGrimCollide(override val parent: ChoiceConfigurable<*>) : Choice("Gri
      *
      * This only works on client version being 1.9+.
      */
-    val tickHandler = handler<PlayerTickEvent> {
+    @Suppress("unused")
+    private val tickHandler = handler<PlayerTickEvent> {
         if (player.input.movementForward == 0.0f && player.input.movementSideways == 0.0f) { return@handler }
         var collisions = 0
         val box = player.boundingBox.expand(1.0)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexGround.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexGround.kt
@@ -38,7 +38,8 @@ class SpeedHylexGround(override val parent: ChoiceConfigurable<*>) : Choice("Hyl
         super.enable()
     }
 
-    val repeatable = tickHandler {
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
         if (!player.isOnGround) {
             groundTicks = 0
             return@tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/hylex/SpeedHylexLowHop.kt
@@ -34,8 +34,10 @@ import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
  */
 class SpeedHylexLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("HylexLowHop", parent) {
 
-    var airTicks = 0
-    val repeatable = tickHandler {
+    private var airTicks = 0
+
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
         if (player.isOnGround) {
             airTicks = 0
             if (player.moving && player.sqrtSpeed < 0.32) {
@@ -82,8 +84,8 @@ class SpeedHylexLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBa
     }
 
     @Suppress("unused")
-    private val jumpHandler = handler<PlayerJumpEvent> {
-        it.motion = 0.33f
+    private val jumpHandler = handler<PlayerJumpEvent> { event ->
+        event.motion = 0.33f
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/intave/SpeedIntave14.kt
@@ -20,22 +20,15 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.intave
 
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventListener
-import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
-import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
-import net.ccbluex.liquidbounce.utils.aiming.Rotation
-import net.ccbluex.liquidbounce.utils.aiming.RotationManager
-import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
 import net.ccbluex.liquidbounce.utils.entity.strafe
-import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.entity.MovementType
 
 /**
@@ -45,7 +38,6 @@ import net.minecraft.entity.MovementType
  */
 class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("Intave14", parent) {
 
-    private val yawOffsetMode by enumChoice("YawOffsetMode", YawOffsetMode.AIR)
 
     companion object {
         private const val BOOST_CONSTANT = 0.003
@@ -92,8 +84,6 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
      */
     private val lowHop by boolean("LowHop", true)
 
-    private val rotationsConfigurable = RotationsConfigurable(this)
-
     @Suppress("unused")
     private val jumpHandler = handler<PlayerJumpEvent> { event ->
         if (lowHop) {
@@ -101,58 +91,4 @@ class SpeedIntave14(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase(
         }
     }
 
-    private var yaw = 0f
-
-    @Suppress("unused")
-    private val yawOffsetHandler = handler<GameTickEvent> {
-        when (yawOffsetMode) {
-            YawOffsetMode.GROUND -> groundYawOffset() // makes you strafe more on ground
-            YawOffsetMode.AIR -> airYawOffset() // 45deg strafe on air
-            YawOffsetMode.NONE -> return@handler
-        }
-
-        val rotation = Rotation(player.yaw - yaw, player.pitch)
-
-        RotationManager.aimAt(
-            rotationsConfigurable.toAimPlan(rotation), Priority.NOT_IMPORTANT,
-            ModuleSpeed
-        )
-    }
-
-    private fun groundYawOffset(): Float {
-        yaw = if (player.isOnGround) {
-            when {
-                mc.options.forwardKey.isPressed && mc.options.leftKey.isPressed -> 45f
-                mc.options.forwardKey.isPressed && mc.options.rightKey.isPressed -> -45f
-                mc.options.backKey.isPressed && mc.options.leftKey.isPressed -> 135f
-                mc.options.backKey.isPressed && mc.options.rightKey.isPressed -> -135f
-                mc.options.backKey.isPressed -> 180f
-                mc.options.leftKey.isPressed -> 90f
-                mc.options.rightKey.isPressed -> -90f
-                else -> 0f
-            }
-        } else {
-            0f
-        }
-        return 0f
-    }
-
-    private fun airYawOffset(): Float {
-        yaw = when {
-            !player.isOnGround &&
-                mc.options.forwardKey.isPressed &&
-                !mc.options.leftKey.isPressed &&
-                !mc.options.rightKey.isPressed
-                -> -45f
-
-            else -> 0f
-        }
-        return 0f
-    }
-
-    private enum class YawOffsetMode(override val choiceName: String) : NamedChoice {
-        GROUND("Ground"),
-        AIR("Air"),
-        NONE("None")
-    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/ncp/SpeedNCP.kt
@@ -51,7 +51,7 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
         private var ticksInAir = 0
 
         @Suppress("unused")
-        private val repeatable = tickHandler {
+        private val tickHandler = tickHandler {
             if (player.isOnGround) {
                 ticksInAir = 0
                 return@tickHandler
@@ -74,10 +74,11 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
     }
 
     private inner class Boost(parent: EventListener?) : ToggleableConfigurable(parent, "Boost", true) {
-        private val initialBoostMultiplier by float("InitialBoostMultiplier", 1f, 0.01f..10f)
+        private val initialBoostMultiplier by float("InitialBoostMultiplier", 1f,
+            0.01f..10f)
 
         @Suppress("unused")
-        val repeatable = tickHandler {
+        private val tickHandler = tickHandler {
             if (player.moving) {
                 player.velocity.x *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())
                 player.velocity.z *= 1f + (BOOST_CONSTANT * initialBoostMultiplier.toDouble())
@@ -102,7 +103,7 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
     }
 
     @Suppress("unused")
-    private val repeatable = tickHandler {
+    private val tickHandler = tickHandler {
         val speedMultiplier = player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0
 
         if (player.moving) {
@@ -126,9 +127,9 @@ class SpeedNCP(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("NCP"
     }
 
     @Suppress("unused")
-    private val jumpHandler = handler<PlayerJumpEvent> {
+    private val jumpHandler = handler<PlayerJumpEvent> { event ->
         if (shouldLowHop) {
-            it.motion = 0.4f
+            event.motion = 0.4f
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
@@ -112,9 +112,9 @@ class SpeedSentinelDamage(override val parent: ChoiceConfigurable<*>) : Choice("
     }
 
     @Suppress("unused")
-    private val movementInputHandler = handler<MovementInputEvent> {
-        if (player.moving && hasBeenHurt) {
-            it.jumping = true
+    private val movementInputHandler = handler<MovementInputEvent> { event ->
+        if (event.directionalInput.isMoving && hasBeenHurt) {
+            event.jumping = true
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/spartan/SpeedSpartan524.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/spartan/SpeedSpartan524.kt
@@ -42,7 +42,8 @@ import net.ccbluex.liquidbounce.utils.movement.zeroXZ
  */
 class SpeedSpartan524(override val parent: ChoiceConfigurable<*>) : Choice("Spartan524") {
 
-    val repeatable = tickHandler {
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
         if (!player.moving) {
             return@tickHandler
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
@@ -20,14 +20,13 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.verus
 
-import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
 import net.ccbluex.liquidbounce.utils.entity.moving
@@ -40,20 +39,16 @@ import net.minecraft.entity.MovementType
  * @anticheatVersion b3882
  * @testedOn eu.anticheat-test.com
  */
-class SpeedVerusB3882(override val parent: ChoiceConfigurable<*>) : Choice("VerusB3882") {
+class SpeedVerusB3882(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("VerusB3882", parent) {
 
-    val movementInputEvent = handler<MovementInputEvent> {
-        if (player.moving) {
-            it.jumping = true
-        }
-    }
-
-    val afterJumpEvent = handler<PlayerAfterJumpEvent> {
+    @Suppress("unused")
+    private val afterJumpHandler = handler<PlayerAfterJumpEvent> {
         player.velocity.x *= 1.1
         player.velocity.z *= 1.1
     }
 
-    val moveHandler = handler<PlayerMoveEvent> { event ->
+    @Suppress("unused")
+    private val moveHandler = handler<PlayerMoveEvent> { event ->
         // Might just strafe when player controls itself
         if (event.type == MovementType.SELF && player.moving) {
             val movement = event.movement
@@ -61,8 +56,10 @@ class SpeedVerusB3882(override val parent: ChoiceConfigurable<*>) : Choice("Veru
         }
     }
 
-    val timerRepeatable = tickHandler {
+    @Suppress("unused")
+    private val timerHandler = tickHandler {
         Timer.requestTimerSpeed(2.0F, Priority.IMPORTANT_FOR_USAGE_1, ModuleSpeed)
         waitTicks(101)
     }
+
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan286.kt
@@ -39,7 +39,8 @@ class SpeedVulcan286(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase
     private inline val goingSideways: Boolean
         get() = player.input.movementSideways != 0f
 
-    val afterJumpEvent = sequenceHandler<PlayerAfterJumpEvent> {
+    @Suppress("unused")
+    private val afterJumpHandler = sequenceHandler<PlayerAfterJumpEvent> {
         // We might lose the effect during runtime of the sequence,
         // but we don't care, since it is Vulcan.
         val speedLevel = (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
@@ -38,7 +38,9 @@ import kotlin.math.abs
  * Tested on both anticheat-test.com and loyisa.cn
  */
 class SpeedVulcan288(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("Vulcan288", parent) {
-    val afterJumpEvent = sequenceHandler<PlayerAfterJumpEvent> {
+
+    @Suppress("unused")
+    private val afterJumpHandler = sequenceHandler<PlayerAfterJumpEvent> {
         val hasSpeed = (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0) != 0
 
         player.strafe(speed = if (hasSpeed) 0.771 else 0.5)
@@ -53,7 +55,9 @@ class SpeedVulcan288(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase
         waitTicks(1)
         player.strafe(speed = if (hasSpeed) 0.595 else 0.28)
     }
-    val repeatable = tickHandler {
+
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
         val hasSpeed = (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0) != 0
         if (!player.isOnGround) {
             if (abs(player.fallDistance) > 0 && hasSpeed) {
@@ -62,10 +66,13 @@ class SpeedVulcan288(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase
             }
         }
     }
-    val packetHandler = handler<PacketEvent> { event ->
+
+    @Suppress("unused")
+    private val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
         if (packet is PlayerMoveC2SPacket && player.velocity.y < 0) {
             packet.onGround = true
         }
     }
+
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcanGround286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcanGround286.kt
@@ -39,7 +39,8 @@ import net.minecraft.util.shape.VoxelShapes
  */
 class SpeedVulcanGround286(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("VulcanGround286", parent) {
 
-    val repeatable = tickHandler {
+    @Suppress("unused")
+    private val afterJumpHandler = tickHandler {
         if (player.moving && collidesBottomVertical()) {
             val speedEffect = player.getStatusEffect(StatusEffects.SPEED)
             val isAffectedBySpeed = speedEffect != null && speedEffect.amplifier > 0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
@@ -20,16 +20,13 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.watchdog
 
-import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler
-import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
-import net.ccbluex.liquidbounce.utils.entity.moving
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -42,7 +39,7 @@ import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
  * @anticheatVersion 12.12.2023
  * @testedOn hypixel.net
  */
-class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : Choice("HypixelBHop") {
+class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("HypixelBHop", parent) {
 
     private val horizontalAcceleration by boolean("HorizontalAcceleration", true)
     private val verticalAcceleration by boolean("VerticalAcceleration", true)
@@ -103,17 +100,6 @@ class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : Choice("Hyp
         }
 
         player.strafe(speed = player.sqrtSpeed.coerceAtLeast(atLeast))
-    }
-
-    val moveHandler = handler<MovementInputEvent> {
-        if (!player.isOnGround || !player.moving) {
-            return@handler
-        }
-
-        if (ModuleSpeed.shouldDelayJump())
-            return@handler
-
-        it.jumping = true
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelLowHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelLowHop.kt
@@ -20,14 +20,11 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.watchdog
 
-import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
-import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
-import net.ccbluex.liquidbounce.utils.entity.moving
+import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.entity.effect.StatusEffects
@@ -37,17 +34,17 @@ import net.minecraft.entity.effect.StatusEffects
  * @anticheatVersion 01.10.24
  * @testedOn hypixel.net
  */
-class SpeedHypixelLowHop(override val parent: ChoiceConfigurable<*>) : Choice("HypixelLowHop") {
+class SpeedHypixelLowHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("HypixelLowHop", parent) {
 
     companion object {
         var shouldStrafe = false
     }
 
     private var glide by boolean("Glide", true)
-
     private var airTicks = 0
+
     @Suppress("unused")
-    val repeatable = tickHandler {
+    val tickHandler = tickHandler {
         shouldStrafe = false
 
         if (player.isOnGround) {
@@ -87,22 +84,11 @@ class SpeedHypixelLowHop(override val parent: ChoiceConfigurable<*>) : Choice("H
         }
     }
 
-    val jumpEvent = handler<PlayerJumpEvent> {
+    @Suppress("unused")
+    private val jumpHandler = handler<PlayerJumpEvent> {
         val atLeast = 0.281 + 0.13 * (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0)
 
         player.strafe(speed = player.sqrtSpeed.coerceAtLeast(atLeast))
-    }
-
-    val moveHandler = handler<MovementInputEvent> {
-        if (!player.isOnGround || !player.moving) {
-            return@handler
-        }
-
-        if (ModuleSpeed.shouldDelayJump()) {
-            return@handler
-        }
-
-        it.jumping = true
     }
 
     override fun disable() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWalk.kt
@@ -31,8 +31,8 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 object ModuleAutoWalk : ClientModule("AutoWalk", Category.PLAYER) {
 
     @Suppress("unused")
-    val moveInputHandler = handler<MovementInputEvent>(priority = 1000) {
-        it.directionalInput = it.directionalInput.copy(forwards = true)
+    private val moveInputHandler = handler<MovementInputEvent>(priority = 1000) { event ->
+        event.directionalInput = event.directionalInput.copy(forwards = true)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/movement/MovementUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/movement/MovementUtils.kt
@@ -59,9 +59,8 @@ data class DirectionalInput(
         return result
     }
 
-    fun isMoving(): Boolean {
-        return forwards || backwards || left || right
-    }
+    val isMoving: Boolean
+        get() = forwards || backwards || left || right
 
     companion object {
         val NONE = DirectionalInput(forwards = false, backwards = false, left = false, right = false)


### PR DESCRIPTION
- Yaw Offset can now be used with any speed mode
- AutoWalk not triggering Speed (fixes https://github.com/CCBlueX/LiquidBounce/issues/4766)
- The Avoid Edge Bump option is now available as a general switch on [Speed]. It may not apply to every mode, but I think it is easier to understand and change if it applies globally.