### PR TITLE
feat(ColorSetting): chroma effect options

### DIFF
--- a/src-theme/src/integration/types.ts
+++ b/src-theme/src/integration/types.ts
@@ -78,6 +78,9 @@ export interface ColorSetting {
     valueType: string;
     name: string;
     value: number;
+    rainbowMode: string;
+    rainbowSpeed: number;
+    temporaryValue: number; // TODO remove
 }
 
 export interface BooleanSetting {

--- a/src-theme/src/integration/types.ts
+++ b/src-theme/src/integration/types.ts
@@ -80,7 +80,6 @@ export interface ColorSetting {
     value: number;
     rainbowMode: string;
     rainbowSpeed: number;
-    temporaryValue: number; // TODO remove
 }
 
 export interface BooleanSetting {

--- a/src-theme/src/routes/clickgui/setting/color/ColorSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/color/ColorSetting.svelte
@@ -2,10 +2,11 @@
     import "@simonwep/pickr/dist/themes/classic.min.css";
     import "./pickr.scss";
     import {createEventDispatcher, onMount} from "svelte";
-    import type {ColorSetting, ModuleSetting,} from "../../../integration/types.js";
+    import type {ColorSetting, ModuleSetting} from "../../../../integration/types.js";
     import Pickr from "@simonwep/pickr";
-    import {convertToSpacedString, spaceSeperatedNames} from "../../../theme/theme_config";
-    import {intToRgba, rgbaToHex, rgbaToInt} from "../../../integration/util";
+    import {convertToSpacedString, spaceSeperatedNames} from "../../../../theme/theme_config";
+    import {intToRgba, rgbaToHex, rgbaToInt} from "../../../../integration/util";
+    import RainbowSpeed from "./Rainbow.svelte";
 
     export let setting: ModuleSetting;
 
@@ -78,19 +79,20 @@
     </div>
     <div class="color-picker" class:hidden>
         <button bind:this={colorPicker} />
+        <RainbowSpeed bind:setting={setting} />
     </div>
 </div>
 
 <style lang="scss">
-    @import "../../../colors.scss";
+  @import "../../../../colors.scss";
 
-    .setting {
-        display: grid;
-        grid-template-areas:
+  .setting {
+    display: grid;
+    grid-template-areas:
             "a b"
             "c c";
-        padding: 7px 0px;
-    }
+    padding: 7px 0px;
+  }
 
     .name {
         grid-area: a;
@@ -124,7 +126,6 @@
     .value-spot {
         grid-area: b;
         display: flex;
-
         align-items: stretch;
     }
 
@@ -140,6 +141,7 @@
         background-color: blue;
         border-style: none;
     }
+
     .color-pickr-button:focus {
         outline: 3px solid #ffffff;
     }

--- a/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
+++ b/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
@@ -17,7 +17,7 @@
     let slider: HTMLElement;
     let apiSlider: API;
 
-    $: if (slider) {
+    $: if (slider && !apiSlider) {
         apiSlider = noUiSlider.create(slider, {
             start: cSetting.rainbowSpeed,
             connect: "lower",
@@ -33,7 +33,7 @@
             setting = {...cSetting};
         });
 
-        apiSlider.on("set", () => { // TODO dispatch on change?
+        apiSlider.on("set", () => {
             dispatch("change");
         });
     }
@@ -49,7 +49,7 @@
           on:change={handleRainbowModeChange}/>
 {#if cSetting.rainbowMode !== "None" }
     <div class="speed">
-        <div class="name">{"Speed"}</div>
+        <div class="name-speed">{"Speed"}</div>
         <div class="speed-value">
             <ValueInput valueType="int" value={cSetting.rainbowSpeed}
                         on:change={(e) => apiSlider.set(e.detail.value)}/>
@@ -80,9 +80,20 @@
     font-size: 12px;
   }
 
+  .name-speed {
+    font-weight: 500;
+    color: $clickgui-text-color;
+    font-size: 12px;
+    margin-bottom: 5px;
+  }
+
   .name {
     grid-area: a;
     font-weight: 500;
+    color: $clickgui-text-color;
+    font-size: 12px;
+    margin-bottom: 5px;
+    margin-top: 5px;
   }
 
   .speed-value {

--- a/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
+++ b/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+    import {createEventDispatcher, onMount} from "svelte";
+    import type {ColorSetting, ModuleSetting} from "../../../../integration/types.js";
+    import {spaceSeperatedNames} from "../../../../theme/theme_config";
+    import Dropdown from "./../common/Dropdown.svelte";
+    import "nouislider/dist/nouislider.css";
+    import "./../nouislider.scss";
+    import noUiSlider, {type API} from "nouislider";
+    import ValueInput from "./../common/ValueInput.svelte";
+
+    export let setting: ModuleSetting;
+
+    const cSetting = setting as ColorSetting;
+
+    const dispatch = createEventDispatcher();
+
+    let slider: HTMLElement;
+    let apiSlider: API;
+
+    onMount(() => {
+        apiSlider = noUiSlider.create(slider, {
+            start: cSetting.rainbowSpeed,
+            connect: "lower",
+            range: {
+                min: 1,
+                max: 100,
+            },
+            step: 1,
+        });
+
+        apiSlider.on("update", (values) => {
+            cSetting.rainbowSpeed = parseInt((values[0]).toString());
+            setting = {...cSetting};
+        });
+
+        apiSlider.on("set", () => { // TODO dispatch on change?
+            dispatch("change");
+        });
+    });
+
+    function handleRainbowModeChange() {
+        setting = {...cSetting};
+        dispatch("change");
+    }
+</script>
+
+<div class="name">{$spaceSeperatedNames ? "Rainbow Mode" : "RainbowMode"}</div>
+<Dropdown name={null} options={["None", "Cycle", "Pulse"]} bind:value={cSetting.rainbowMode}
+          on:change={handleRainbowModeChange}/>
+{#if cSetting.rainbowMode !== "None" }
+    <div class="speed">
+        <div class="name">{"Speed"}</div>
+        <div class="speed-value">
+            <ValueInput valueType="int" value={cSetting.rainbowSpeed}
+                        on:change={(e) => apiSlider.set(e.detail.value)}/>
+        </div>
+        <div bind:this={slider} class="speed-slider"></div>
+    </div>
+{/if}
+
+<style lang="scss">
+  @import "../../../../colors.scss";
+
+  .speed {
+    padding: 7px 0 2px 0;
+    display: grid;
+    grid-template-areas:
+            "a b"
+            "d d";
+    grid-template-columns: 1fr max-content;
+    column-gap: 5px;
+
+    /* animation fix */
+    min-height: 46px;
+  }
+
+  .speed-value {
+    color: $clickgui-text-color;
+    font-weight: 500;
+    font-size: 12px;
+  }
+
+  .name {
+    grid-area: a;
+    font-weight: 500;
+  }
+
+  .speed-value {
+    grid-area: b;
+  }
+
+  .speed-slider {
+    grid-area: d;
+    padding-right: 10px;
+  }
+</style>

--- a/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
+++ b/src-theme/src/routes/clickgui/setting/color/Rainbow.svelte
@@ -17,7 +17,7 @@
     let slider: HTMLElement;
     let apiSlider: API;
 
-    onMount(() => {
+    $: if (slider) {
         apiSlider = noUiSlider.create(slider, {
             start: cSetting.rainbowSpeed,
             connect: "lower",
@@ -36,7 +36,7 @@
         apiSlider.on("set", () => { // TODO dispatch on change?
             dispatch("change");
         });
-    });
+    }
 
     function handleRainbowModeChange() {
         setting = {...cSetting};

--- a/src-theme/src/routes/clickgui/setting/color/color_utils.ts
+++ b/src-theme/src/routes/clickgui/setting/color/color_utils.ts
@@ -1,0 +1,143 @@
+
+export class Color4b {
+
+    public r: number;
+    public g: number;
+    public b: number;
+    public a: number;
+
+    constructor(r: number, g: number, b: number, a: number) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+
+    public static fromPacked(packed: number): Color4b {
+        return new Color4b(
+            (packed >> 16) && 0xFF,
+            (packed >> 8) && 0xFF,
+            (packed && 0xFF),
+            (packed >> 24) && 0xFF
+        );
+    }
+
+    public static fromHex(hex: string): Color4b {
+        if (hex.startsWith("#")) {
+            hex = hex.slice(1);
+        }
+
+        let hasAlpha = hex.length == 8;
+        if (hex.length != 6 && !hasAlpha) {
+            throw new Error("Invalid Hex " + hex);
+        }
+
+        if (hasAlpha) {
+            let rgba = BigInt("0x" + hex);
+            return new Color4b(
+                Number(rgba >> BigInt(24)) && 0xFF,
+                Number(rgba >> BigInt(16)) && 0xFF,
+                Number(rgba >> BigInt(8)) && 0xFF,
+                Number(rgba && 0xFF)
+            );
+        } else {
+            let rgb = parseInt(hex, 16)
+            return new Color4b(
+                (rgb >> 24) && 0xFF,
+                (rgb >> 16) && 0xFF,
+                (rgb >> 8) && 0xFF,
+                255
+            );
+        }
+    }
+
+    public getBrightness(): number {
+        return Math.max(this.r, this.g, this.b) / 255;
+    }
+
+    public brightness(brightness: number) {
+        if (brightness < 0 || brightness > 1) {
+            throw new Error("Brightness out of range! Must be between 0 and 1.");
+        }
+
+        const hsb = this.getHsb();
+        this.setHsb(hsb.h, hsb.s, brightness);
+    }
+
+    public hue(hue: number) {
+        if (hue < 0 || hue > 1) {
+            throw new Error("Hue out of range! Must be between 0 and 1.");
+        }
+
+        const hsb = this.getHsb();
+        this.setHsb(hue, hsb.s, hsb.b);
+    }
+
+    public getHsb() {
+        const red = this.r / 255.0;
+        const green = this.g / 255.0;
+        const blue = this.b / 255.0;
+
+        const max = Math.max(red, green, blue);
+        const min = Math.min(red, green, blue);
+        const delta = max - min;
+
+        let h = 0;
+        if (delta !== 0) {
+            if (max === red) {
+                h = (green - blue) / delta + (green < blue ? 6 : 0);
+            } else if (max === green) {
+                h = (blue - red) / delta + 2;
+            } else {
+                h = (red - green) / delta + 4;
+            }
+            h /= 6;
+        }
+
+        const s = max === 0 ? 0 : delta / max;
+        const b = max;
+
+        return {h, s, b};
+    }
+
+    public setHsb(h: number, s: number, b: number) {
+        const i = Math.floor(h * 6);
+        const f = h * 6 - i;
+        const p = b * (1 - s);
+        const q = b * (1 - f * s);
+        const t = b * (1 - (1 - f) * s);
+
+        let r = this.r;
+        let g = this.g;
+        let blue = this.b;
+        switch (i % 6) {
+            case 0:
+                [r, g, blue] = [b, t, p];
+                break;
+            case 1:
+                [r, g, blue] = [q, b, p];
+                break;
+            case 2:
+                [r, g, blue] = [p, b, t];
+                break;
+            case 3:
+                [r, g, blue] = [p, q, b];
+                break;
+            case 4:
+                [r, g, blue] = [t, p, b];
+                break;
+            case 5:
+                [r, g, blue] = [b, p, q];
+                break;
+        }
+
+        this.r = Math.round(r * 255);
+        this.g = Math.round(g * 255);
+        this.b = Math.round(blue * 255);
+    }
+
+    public asHex(): string {
+        return `#${(((this.a) << 24) | (this.r << 16) | (this.g << 8) | this.b).toString(16).slice(1).toUpperCase()}`
+    }
+
+}

--- a/src-theme/src/routes/clickgui/setting/color/pickr.scss
+++ b/src-theme/src/routes/clickgui/setting/color/pickr.scss
@@ -1,4 +1,4 @@
-@import "../../../colors.scss";
+@import "../../../../colors.scss";
 
 .pcr-button {
     display: none;

--- a/src-theme/src/routes/clickgui/setting/common/GenericSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/common/GenericSetting.svelte
@@ -9,7 +9,7 @@
     import IntRangeSetting from "../IntRangeSetting.svelte";
     import IntSetting from "../IntSetting.svelte";
     import TogglableSetting from "../TogglableSetting.svelte";
-    import ColorSetting from "../ColorSetting.svelte";
+    import ColorSetting from "../color/ColorSetting.svelte";
     import TextSetting from "../TextSetting.svelte";
     import BlocksSetting from "../blocks/BlocksSetting.svelte";
     import {slide} from "svelte/transition";

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
@@ -24,10 +24,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.config.gson.fileGson
-import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.config.types.Configurable
-import net.ccbluex.liquidbounce.config.types.DynamicConfigurable
-import net.ccbluex.liquidbounce.config.types.Value
+import net.ccbluex.liquidbounce.config.types.*
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -293,6 +290,10 @@ object ConfigSystem {
         // Otherwise we simply deserialize the value
         runCatching {
             value.deserializeFrom(fileGson, jsonObject["value"])
+            if (value is CustomDeserializing) {
+                value.deserialize(fileGson, jsonObject)
+            }
+
         }.onFailure {
             logger.error("Unable to deserialize value ${value.name}", it)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ColorValue.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/ColorValue.kt
@@ -1,0 +1,119 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.config.types
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
+import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
+import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
+import net.ccbluex.liquidbounce.event.EventListener
+import net.ccbluex.liquidbounce.event.events.GameRenderEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.render.engine.Color4b
+import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import org.apache.commons.lang3.StringUtils
+import java.util.*
+import kotlin.math.abs
+import kotlin.math.min
+
+private const val MAX_SPEED = 100
+
+class ColorValue(name: String, defaultValue: Color4b) :
+    Value<Color4b>(name, defaultValue, ValueType.COLOR), CustomDeserializing {
+
+    @SerializedName("rainbowMode")
+    var rainbowMode = RainbowMode.NONE
+
+    @SerializedName("rainbowSpeed")
+    var rainbowSpeed = 20
+
+    @Exclude
+    @ProtocolExclude
+    private var temporaryValue: Color4b? = null
+
+    init {
+        ColorValueManager.values[this] = null
+    }
+
+    override fun get() = temporaryValue ?: super.get()
+
+    override fun deserialize(gson: Gson, jsonObject: JsonObject) {
+        println(jsonObject)
+        rainbowSpeed = jsonObject["rainbowSpeed"]?.asInt?.coerceIn(0..MAX_SPEED) ?: return
+        val modeName = jsonObject["rainbowMode"]?.asString ?: return
+        rainbowMode = RainbowMode.entries.firstOrNull {
+            StringUtils.equalsIgnoreCase(it.choiceName, modeName)
+        } ?: return
+        rainbowMode.init(this)
+    }
+
+    enum class RainbowMode(override val choiceName: String) : NamedChoice {
+
+        NONE("None") {
+
+            override fun update(value: ColorValue, time: Long) {
+                // nothing
+            }
+
+            override fun init(value: ColorValue) {
+                value.temporaryValue = null
+            }
+
+        },
+        CYCLE("Cycle") {
+
+            override fun update(value: ColorValue, time: Long) {
+                val frequency = getFrequency(value)
+                value.temporaryValue = value.inner.hue((time % frequency).toFloat() / frequency)
+            }
+
+        },
+        PULSE("Pulse") {
+
+            override fun update(value: ColorValue, time: Long) {
+                val frequency = getFrequency(value)
+                val oscillation = abs((time % (frequency * 2)) - frequency) / frequency
+                val brightness = 0.3f - 0.3f * oscillation + min(value.inner.getBrightness(), 0.7f)
+                value.temporaryValue = value.inner.brightness(brightness)
+            }
+
+        };
+
+        abstract fun update(value: ColorValue, time: Long)
+
+        open fun init(value: ColorValue) {}
+
+        fun getFrequency(value: ColorValue) = ((MAX_SPEED + 1 - value.rainbowSpeed) * 200)
+
+    }
+
+}
+
+object ColorValueManager : EventListener {
+
+    val values = WeakHashMap<ColorValue, Void>()
+
+    @Suppress("unused")
+    private val renderHandler = handler<GameRenderEvent>(priority = EventPriorityConvention.FIRST_PRIORITY) {
+        val time = System.currentTimeMillis()
+        values.keys.forEach { it.rainbowMode.update(it, time) }
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Configurable.kt
@@ -220,7 +220,7 @@ open class Configurable(
 
     fun curve(name: String, default: Easing) = enumChoice(name, default)
 
-    fun color(name: String, default: Color4b) = value(name, default, ValueType.COLOR)
+    fun color(name: String, default: Color4b) = ColorValue(name, default).apply { this@Configurable.inner.add(this) }
 
     fun block(name: String, default: Block) = value(name, default, ValueType.BLOCK)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/CustomDeserializing.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/CustomDeserializing.kt
@@ -1,0 +1,29 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.config.types
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+/**
+ * Can be implemented by value types to deserialize additional data.
+ */
+interface CustomDeserializing {
+    fun deserialize(gson: Gson, jsonObject: JsonObject)
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
-
 package net.ccbluex.liquidbounce.config.types
 
 import com.google.gson.Gson
@@ -189,7 +188,7 @@ open class Value<T : Any>(
         logger.error("Could not set value ${this.inner}")
     }
 
-    fun get() = inner
+    open fun get() = inner
 
     fun set(t: T) {
         // Do nothing if value is the same

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
@@ -24,9 +24,6 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.FriendManager
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.GenericColorMode
-import net.ccbluex.liquidbounce.render.GenericRainbowColorMode
-import net.ccbluex.liquidbounce.render.GenericStaticColorMode
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.client.bypassesNameProtection
 import net.ccbluex.liquidbounce.utils.client.toText
@@ -44,33 +41,14 @@ import net.minecraft.text.Text
 object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
 
     private val replacement by text("Replacement", "You")
-
-    private val colorMode = choices<GenericColorMode<Unit>>(
-        "ColorMode",
-        0,
-        {
-            arrayOf(GenericStaticColorMode(it, Color4b(255, 179, 72, 50)), GenericRainbowColorMode(it))
-        }
-    )
+    private val color by color("Color", Color4b(255, 179, 72, 50))
 
     private object ReplaceFriendNames : ToggleableConfigurable(this, "ObfuscateFriends", true) {
-        val colorMode = choices<GenericColorMode<Unit>>(
-            ReplaceFriendNames,
-            "ColorMode",
-            0
-        ) {
-            arrayOf(GenericStaticColorMode(it, Color4b(0, 241, 255)), GenericRainbowColorMode(it))
-        }
+        val color by color("Color", Color4b(0, 241, 255))
     }
 
     private object ReplaceOthers : ToggleableConfigurable(this, "ObfuscateOthers", false) {
-        val colorMode = ReplaceOthers.choices<GenericColorMode<Unit>>(
-            ReplaceOthers,
-            "ColorMode",
-            0
-        ) {
-            arrayOf(GenericStaticColorMode(it, Color4b(71, 71, 71)), GenericRainbowColorMode(it))
-        }
+        val color by color("Color", Color4b(71, 71, 71))
     }
 
     init {
@@ -84,9 +62,9 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
     private val replacementMappings = NameProtectMappings()
 
     private val coloringInfo = NameProtectMappings.ColoringInfo(
-        username = { this.colorMode.activeChoice.getColor(Unit) },
-        friends = { ReplaceFriendNames.colorMode.activeChoice.getColor(Unit) },
-        otherPlayers = { ReplaceOthers.colorMode.activeChoice.getColor(Unit) },
+        username = { color },
+        friends = { ReplaceFriendNames.color },
+        otherPlayers = { ReplaceOthers.color },
     )
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -59,8 +59,7 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
     private val colorMode = choices("ColorMode", 0) {
         arrayOf(
             MapColorMode(it),
-            GenericStaticColorMode(it, Color4b(255, 179, 72, 50)),
-            GenericRainbowColorMode(it)
+            GenericStaticColorMode(it, Color4b(255, 179, 72, 50))
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleESP.kt
@@ -38,7 +38,6 @@ import net.minecraft.util.math.Box
  *
  * Allows you to see targets through walls.
  */
-
 object ModuleESP : ClientModule("ESP", Category.RENDER) {
 
     override val baseKey: String
@@ -48,8 +47,7 @@ object ModuleESP : ClientModule("ESP", Category.RENDER) {
     private val colorModes = choices("ColorMode", 0) {
         arrayOf(
             GenericEntityHealthColorMode(it),
-            GenericStaticColorMode(it, Color4b.WHITE.alpha(100)),
-            GenericRainbowColorMode(it)
+            GenericStaticColorMode(it, Color4b.WHITE.alpha(100))
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -24,8 +24,10 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.*
+import net.ccbluex.liquidbounce.render.BoxRenderer
 import net.ccbluex.liquidbounce.render.engine.Color4b
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.minecraft.entity.Entity
 import net.minecraft.entity.ItemEntity
@@ -44,12 +46,7 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         get() = "liquidbounce.module.itemEsp"
 
     private val modes = choices("Mode", OutlineMode, arrayOf(GlowMode, OutlineMode, BoxMode))
-    private val colorMode = choices("ColorMode", 0) {
-        arrayOf(
-            GenericStaticColorMode(it, Color4b(255, 179, 72, 255)),
-            GenericRainbowColorMode(it)
-        )
-    }
+    private val color by color("Color", Color4b(255, 179, 72, 255))
 
     private object BoxMode : Choice("Box") {
 
@@ -62,9 +59,8 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         val renderHandler = handler<WorldRenderEvent> { event ->
             val matrixStack = event.matrixStack
 
-            val base = getColor()
-            val baseColor = base.alpha(50)
-            val outlineColor = base.alpha(100)
+            val baseColor = color.alpha(50)
+            val outlineColor = color.alpha(100)
 
             val filtered = world.entities.filter(::shouldRender)
 
@@ -94,5 +90,4 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
 
     fun shouldRender(it: Entity?) = it is ItemEntity || it is ArrowEntity
 
-    fun getColor() = this.colorMode.activeChoice.getColor(null)
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -46,7 +46,7 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         get() = "liquidbounce.module.itemEsp"
 
     private val modes = choices("Mode", OutlineMode, arrayOf(GlowMode, OutlineMode, BoxMode))
-    private val color by color("Color", Color4b(255, 179, 72, 255))
+    val color by color("Color", Color4b(255, 179, 72, 255))
 
     private object BoxMode : Choice("Box") {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
@@ -48,8 +48,7 @@ object ModuleTracers : ClientModule("Tracers", Category.RENDER) {
     private val modes = choices("ColorMode", 0) {
         arrayOf(
             DistanceColor,
-            GenericStaticColorMode(it, Color4b(0, 160, 255, 255)),
-            GenericRainbowColorMode(it)
+            GenericStaticColorMode(it, Color4b(0, 160, 255, 255))
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderConfigurables.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderConfigurables.kt
@@ -3,7 +3,6 @@ package net.ccbluex.liquidbounce.render
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.render.engine.Color4b
-import net.ccbluex.liquidbounce.render.utils.rainbow
 import net.ccbluex.liquidbounce.utils.entity.getActualHealth
 import net.minecraft.block.BlockState
 import net.minecraft.entity.LivingEntity
@@ -22,13 +21,6 @@ class GenericStaticColorMode(
 
     override fun getColor(param: Any?) = staticColor
 
-}
-
-class GenericRainbowColorMode(
-    override val parent: ChoiceConfigurable<*>,
-    private val alpha: Int = 50
-) : GenericColorMode<Any?>("Rainbow") {
-    override fun getColor(param: Any?) = rainbow().alpha(alpha)
 }
 
 class MapColorMode(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/RenderTasks.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/RenderTasks.kt
@@ -23,6 +23,7 @@ import net.minecraft.util.math.Vec3i
 import java.awt.Color
 import java.nio.ByteBuffer
 import kotlin.math.cos
+import kotlin.math.max
 import kotlin.math.sin
 
 data class Vec4(val x: Float, val y: Float, val z: Float, val w: Float) {
@@ -169,6 +170,24 @@ data class Color4b(val r: Int, val g: Int, val b: Int, val a: Int) {
     fun blue(blue: Int) = Color4b(this.r, this.g, blue, this.a)
 
     fun alpha(alpha: Int) = Color4b(this.r, this.g, this.b, alpha)
+
+    fun getBrightness() = max(r, max(g, b)).toFloat() / 255f
+
+    fun brightness(brightness: Float): Color4b {
+        require(brightness in 0f..1f) { "Brightness out of range!" }
+        val hsb = FloatArray(3)
+        Color.RGBtoHSB(r, g, b, hsb)
+        val rgb = Color.HSBtoRGB(hsb[0], hsb[1], brightness)
+        return Color4b((rgb shr 16) and 0xFF, (rgb shr 8) and 0xFF, rgb and 0xFF, a)
+    }
+
+    fun hue(hue: Float): Color4b {
+        require(hue in 0f..1f) { "Hue out of range!" }
+        val hsb = FloatArray(3)
+        Color.RGBtoHSB(r, g, b, hsb)
+        val rgb = Color.HSBtoRGB(hue, hsb[1], hsb[2])
+        return Color4b((rgb shr 16) and 0xFF, (rgb shr 8) and 0xFF, rgb and 0xFF, a)
+    }
 
     fun toARGB() = (a shl 24) or (r shl 16) or (g shl 8) or b
 


### PR DESCRIPTION
Adds a cyclic rainbow mode and a pulse mode to color settings.
TODOs (mainly about the GUI):
- [ ] Complete the ClickGUI options implementation
- [ ] Adjust the default values
- [ ] Display the temporary color in the ClickGUI (calculate the current color it the ClickGUI)
- [x] Fix the ClickGUI only sending changes on color change but not on mode / speed change
- [x] Fix the ClickGUI being stuck for whatever reason when i create an `HTMLElement`