### PR TITLE
feat(PacketMine): make waiting for confirmation optional

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
@@ -371,6 +371,7 @@ object ModulePacketMine : ClientModule("PacketMine", Category.WORLD) {
         }
     }
 
+    @Suppress("FunctionNaming", "FunctionName")
     fun _resetTarget() {
         targetPos = null
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/ModulePacketMine.kt
@@ -82,8 +82,10 @@ object ModulePacketMine : ClientModule("PacketMine", Category.WORLD) {
 
     init {
         mode.onChanged {
-            disable()
-            enable()
+            if (mc.world != null && mc.player != null) {
+                disable()
+                enable()
+            }
         }
     }
 
@@ -281,7 +283,7 @@ object ModulePacketMine : ClientModule("PacketMine", Category.WORLD) {
     private val mouseButtonHandler = handler<MouseButtonEvent> { event ->
         val openScreen = mc.currentScreen != null
         val unchangeableActive = !mode.activeChoice.canManuallyChange && targetPos != null
-        if (openScreen || unchangeableActive) {
+        if (openScreen || unchangeableActive || !player.abilities.allowModifyWorld) {
             return@handler
         }
 
@@ -367,6 +369,10 @@ object ModulePacketMine : ClientModule("PacketMine", Category.WORLD) {
         if (finished && mode.activeChoice.canManuallyChange || targetPos == null) {
             targetPos = blockPos
         }
+    }
+
+    fun _resetTarget() {
+        targetPos = null
     }
 
     /* tweaked minecraft code start */

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/ImmediateMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/ImmediateMineMode.kt
@@ -28,6 +28,8 @@ import net.minecraft.util.math.Direction
 
 object ImmediateMineMode : MineMode("Immediate", canManuallyChange = false, canAbort = false) {
 
+    private val waitForConfirm by boolean("WaitForConfirm", true)
+
     override fun start(blockPos: BlockPos, direction: Direction?) {
         NormalMineMode.start(blockPos, direction)
         network.sendPacket(
@@ -36,7 +38,10 @@ object ImmediateMineMode : MineMode("Immediate", canManuallyChange = false, canA
     }
 
     override fun finish(blockPos: BlockPos, direction: Direction) {
-        /* nothing */
+        if (!waitForConfirm) {
+            ModulePacketMine.finished = true
+            ModulePacketMine._resetTarget()
+        }
     }
 
     override fun shouldUpdate(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/NormalMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/NormalMineMode.kt
@@ -32,6 +32,7 @@ import net.minecraft.util.math.Direction
 object NormalMineMode : MineMode("Normal") {
 
     private val clientSideSet by boolean("ClientSideSet", false)
+    private val waitForConfirm by boolean("WaitForConfirm", true)
 
     override fun start(blockPos: BlockPos, direction: Direction?) {
         EventManager.callEvent(BlockBreakingProgressEvent(blockPos))
@@ -46,6 +47,9 @@ object NormalMineMode : MineMode("Normal") {
         }
 
         ModulePacketMine.finished = true
+        if (!waitForConfirm) {
+            ModulePacketMine._resetTarget()
+        }
     }
 
     override fun shouldUpdate(


### PR DESCRIPTION
- Adds a WaitForConfirm option to immediate and normal that allows skipping the time waiting for the packet from the server confirming the break. Disabled by default.
- Fixes the on change operating when not being in a world. 
- Fixes the module operating when being in adventure mode.