### PR TITLE
chore(Sequence): rename withContext to waitFor

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
@@ -160,10 +160,11 @@ open class Sequence<T : Event>(val owner: EventListener, val handler: Suspendabl
     internal suspend fun sync() = wait { 0 }
 
     /**
-     * A custom implementation of `withContext`, which makes the Sequence correctly suspended by the task.
+     * Start a task with given context, and wait for its completion.
+     * @see withContext
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    suspend fun <T> withContext(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+    suspend fun <T> waitFor(context: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
         // Set parent job as `this.coroutine`
         val deferred = CoroutineScope(coroutine + context).async(context, block = block)
         // Use `waitUntil` to avoid duplicated resumption

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
@@ -131,12 +131,12 @@ object ModuleRichPresence : ClientModule("RichPresence", Category.CLIENT, state 
 
     @Suppress("unused")
     val updateCycle = tickHandler {
-        waitTicks(20)
+        waitSeconds(1)
 
         /**
          * Don't block the render thread
          */
-        withContext(Dispatchers.IO) {
+        waitFor(Dispatchers.IO) {
             if (enabled) {
                 connectIpc()
             } else {
@@ -145,7 +145,7 @@ object ModuleRichPresence : ClientModule("RichPresence", Category.CLIENT, state 
 
             // Check ipc client is connected and send rpc
             if (ipcClient == null || ipcClient!!.status != PipeStatus.CONNECTED) {
-                return@withContext
+                return@waitFor
             }
 
             ipcClient!!.sendRichPresence {


### PR DESCRIPTION
`withContext` could be confusing because there is already a `withContext` provided by the Kotlin coroutine lib which cannot be used for SequenceHandler, so a new name could be more applicable.