### PR TITLE
CI: GitHub code scanning integration for detekt errors / warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,3 +92,11 @@ jobs:
           CI: true
         with:
           arguments: genSources build
+
+      # Make sure we always run this upload task,
+      # because the previous step may fail if there are findings.
+      - name: Upload SARIF to GitHub using the upload-sarif action
+        uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
+        with:
+          sarif_file: build/reports/detekt/detekt.sarif

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -120,8 +120,6 @@ object LiquidBounce : EventListener {
      */
     @Suppress("unused")
     val startHandler = handler<ClientStartEvent> {
-        // intentionally empty catch and try statement to trigger detekt
-        try { } catch { }
         runCatching {
             logger.info("Launching $CLIENT_NAME v$clientVersion by $CLIENT_AUTHOR")
             logger.debug("Loading from cloud: '$CLIENT_CLOUD'")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -120,6 +120,8 @@ object LiquidBounce : EventListener {
      */
     @Suppress("unused")
     val startHandler = handler<ClientStartEvent> {
+        // intentionally empty catch and try statement to trigger detekt
+        try { } catch { }
         runCatching {
             logger.info("Launching $CLIENT_NAME v$clientVersion by $CLIENT_AUTHOR")
             logger.debug("Loading from cloud: '$CLIENT_CLOUD'")


### PR DESCRIPTION
This PR pretty much just adds more QoL. Nothing really useful for anyone who isn't reviewing the code for PRs.
See https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning#about-third-party-code-scanning-tools

I just stole it from the detekt docs, GitHub adds a little embed at the end of the line which shows the workflow and some other info from the SARIF file you give it.
Another tip that I discovered: If you click on the SARIF file that detekt generates, IntelliJ IDEA will show everything detekt found in the "Server-side Analysis" tab of the "Problems" view.
See https://detekt.dev/docs/introduction/reporting/#integration-with-github-code-scanning