### PR TITLE
chore: MCEF 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     }
 
     // JCEF Support
-    includeModDependency "com.github.CCBlueX:mcef:1.2.1-1.21.1"
+    includeModDependency "com.github.CCBlueX:mcef:1.3.0-1.21.1"
     includeDependency "org.apache.commons:commons-exec:1.3"
     includeDependency ("com.github.CCBlueX:netty-httpserver:2.1.1") {
         exclude group: "io.netty", module: "netty-all"


### PR DESCRIPTION
This update introduces a more robust resource manager - which will now make use of the new LiquidBounce Resource API:
- GET https://api.liquidbounce.net/api/v3/resource/:name/:commit/:platform
- GET https://api.liquidbounce.net/api/v3/resource/:name/:commit/:platform/checksum

This means from now on downloads are being served via Cloudflare R2 - which should be much faster and not rely on our infrastructure so much.

Error handling was slightly improved as well.