### PR TITLE
fix: locate feature of clickgui search

### DIFF
--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -32,8 +32,8 @@
         }, 500);
     });
 
-    highlightModuleName.subscribe(() => {
-        if (name !== $highlightModuleName) {
+    highlightModuleName.subscribe((m) => {
+        if (name !== m) {
             return;
         }
 

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -142,9 +142,9 @@
         }, 500)
     }
 
-    highlightModuleName.subscribe(() => {
+    highlightModuleName.subscribe((m) => {
         const highlightModule = modules.find(
-            (m) => m.name === $highlightModuleName,
+            (m) => m.name === m.name,
         );
         if (highlightModule) {
             panelConfig.zIndex = ++$maxPanelZIndex;


### PR DESCRIPTION
This feature broke when updating to Svelte 5.