### PR TITLE
fix(Nextgen): Unnecessary settings to modules that can't be enabled.

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -132,17 +132,25 @@ open class ClientModule(
      * If the module is running and in game. Can be overridden to add additional checks.
      */
     override val running: Boolean
-        get() = super.running && inGame && enabled
+        get() = (super.running && inGame && enabled) || disableActivation
 
     val bind by bind("Bind", InputBind(InputUtil.Type.KEYSYM, bind, bindAction))
         .doNotIncludeWhen { !AutoConfig.includeConfiguration.includeBinds }
-        .independentDescription()
+        .independentDescription().apply {
+            if (disableActivation) {
+                notAnOption()
+            }
+        }
     var hidden by boolean("Hidden", hide)
         .doNotIncludeWhen { !AutoConfig.includeConfiguration.includeHidden }
         .independentDescription()
         .onChange {
             EventManager.callEvent(RefreshArrayListEvent())
             it
+        }.apply {
+            if (disableActivation) {
+                notAnOption()
+            }
         }
 
     /**


### PR DESCRIPTION
Before
---
![java_u3f0O2wCAx](https://github.com/user-attachments/assets/33b6ccf0-eef9-46f1-8a2b-524b336600fa)

After
---
![java_tbgw6eBwUL](https://github.com/user-attachments/assets/70a2ac3e-bea1-4ca1-9ffb-94de4e0918d0)
removed bind (it can't be turned on, what's it for?) & hidden (it's always off, hence always “hidden”)

(the module Targets flagged as disableActivation)