### PR TITLE
fix(TextComponent): add white-space pre formatting for inline text

### DIFF
--- a/src-theme/src/routes/menu/common/TextComponent.svelte
+++ b/src-theme/src/routes/menu/common/TextComponent.svelte
@@ -148,6 +148,7 @@
 
     .text {
         display: inline;
+        white-space: pre;
 
         &.allow-preformatting {
             font-family: monospace;

--- a/src-theme/src/routes/menu/common/TextComponent.svelte
+++ b/src-theme/src/routes/menu/common/TextComponent.svelte
@@ -3,6 +3,7 @@
 
     export let textComponent: TTextComponent | string;
     export let allowPreformatting = false;
+    export let preFormattingMonospace = true;
     export let inheritedColor = "#ffffff";
     export let inheritedStrikethrough = false;
     export let inheritedItalic = false;
@@ -107,7 +108,7 @@
 
 <span class="text-component">
     {#if typeof textComponent === "string"}
-        <svelte:self {fontSize} {allowPreformatting} textComponent={convertLegacyCodes(textComponent)}/>
+        <svelte:self {fontSize} {allowPreformatting} {preFormattingMonospace} textComponent={convertLegacyCodes(textComponent)}/>
     {:else if textComponent}
         {#if textComponent.text}
             {#if !textComponent.text.includes("§")}
@@ -116,9 +117,10 @@
                       class:underlined={textComponent.underlined !== undefined ? textComponent.underlined : inheritedUnderlined}
                       class:strikethrough={textComponent.strikethrough !== undefined ? textComponent.strikethrough : inheritedStrikethrough}
                       class:allow-preformatting={allowPreformatting}
+                      class:monospace={preFormattingMonospace && allowPreformatting}
                       style="color: {textComponent.color !== undefined ? translateColor(textComponent.color) : translateColor(inheritedColor)}; font-size: {fontSize}px;">{textComponent.text}</span>
             {:else}
-                <svelte:self {allowPreformatting} {fontSize}
+                <svelte:self {allowPreformatting} {preFormattingMonospace} {fontSize}
                              inheritedColor={textComponent.color !== undefined ? textComponent.color : inheritedColor}
                              inheritedBold={textComponent.bold !== undefined ? textComponent.bold : inheritedBold}
                              inheritedItalic={textComponent.italic !== undefined ? textComponent.italic : inheritedItalic}
@@ -129,7 +131,7 @@
         {/if}
         {#if textComponent.extra}
             {#each textComponent.extra as e}
-                <svelte:self {allowPreformatting} {fontSize}
+                <svelte:self {allowPreformatting} {preFormattingMonospace} {fontSize}
                              inheritedColor={textComponent.color !== undefined ? textComponent.color : inheritedColor}
                              inheritedBold={textComponent.bold !== undefined ? textComponent.bold : inheritedBold}
                              inheritedItalic={textComponent.italic !== undefined ? textComponent.italic : inheritedItalic}
@@ -148,11 +150,13 @@
 
     .text {
         display: inline;
-        white-space: pre;
 
         &.allow-preformatting {
-            font-family: monospace;
             white-space: pre;
+        }
+
+        &.monospace {
+            font-family: monospace;
         }
 
         &.bold {

--- a/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
+++ b/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
@@ -177,7 +177,7 @@
                             :`data:image/png;base64,${server.icon}`}
                               title={server.name}
                               on:dblclick={() => connectToServer(server.address)}>
-                    <TextComponent allowPreformatting={true} preFormattingMonospace={true} slot="subtitle" fontSize={18}
+                    <TextComponent allowPreformatting={true} preFormattingMonospace={false} slot="subtitle" fontSize={18}
                                    textComponent={server.ping <= 0 ? "§CCan't connect to server" : server.label}/>
 
                     <svelte:fragment slot="tag">

--- a/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
+++ b/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
@@ -177,7 +177,7 @@
                             :`data:image/png;base64,${server.icon}`}
                               title={server.name}
                               on:dblclick={() => connectToServer(server.address)}>
-                    <TextComponent slot="subtitle" fontSize={18}
+                    <TextComponent allowPreformatting={true} preFormattingMonospace={true} slot="subtitle" fontSize={18}
                                    textComponent={server.ping <= 0 ? "§CCan't connect to server" : server.label}/>
 
                     <svelte:fragment slot="tag">


### PR DESCRIPTION
The textcomponent did not render single whitespaces & line breaks, this PR fixes that.
Normal MC:
![image](https://github.com/user-attachments/assets/ed2fbdf9-e346-446d-ac1f-87d2021737a6)
Before:
![image](https://github.com/user-attachments/assets/84d04b8a-8612-48b6-93dc-af84da89e94a)
With fix:
![image](https://github.com/user-attachments/assets/6bf03bdd-686f-454c-84c4-1e97efcd12a9)
closes #4975 
