### PR TITLE
feat: send TickEnd-Packets

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.*;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disablers.DisablerSpigotSpam;
 import net.ccbluex.liquidbounce.features.module.modules.misc.betterchat.ModuleBetterChat;
+import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleEndTick;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAntiExploit;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleNoRotateSet;
 import net.ccbluex.liquidbounce.utils.aiming.Rotation;
@@ -40,6 +41,7 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.packet.c2s.play.ClientTickEndC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.c2s.play.TeleportConfirmC2SPacket;
 import net.minecraft.network.packet.s2c.play.*;
@@ -157,6 +159,9 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         // Confirm teleport
         this.connection.send(new TeleportConfirmC2SPacket(packet.teleportId()));
         // Silently accept yaw and pitch values requested by the server.
+        if (ModuleEndTick.INSTANCE.getRunning()) {
+            this.connection.send(ClientTickEndC2SPacket.INSTANCE);
+        }
         this.connection.send(new PlayerMoveC2SPacket.Full(playerEntity.getX(), playerEntity.getY(), playerEntity.getZ(), j, k, false, playerEntity.horizontalCollision));
         Choice activeChoice = ModuleNoRotateSet.INSTANCE.getMode().getActiveChoice();
         if (activeChoice.equals(ModuleNoRotateSet.ResetRotation.INSTANCE)) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayNetworkHandler.java
@@ -162,6 +162,7 @@ public abstract class MixinClientPlayNetworkHandler extends ClientCommonNetworkH
         if (ModuleEndTick.INSTANCE.getRunning()) {
             this.connection.send(ClientTickEndC2SPacket.INSTANCE);
         }
+
         this.connection.send(new PlayerMoveC2SPacket.Full(playerEntity.getX(), playerEntity.getY(), playerEntity.getZ(), j, k, false, playerEntity.horizontalCollision));
         Choice activeChoice = ModuleNoRotateSet.INSTANCE.getMode().getActiveChoice();
         if (activeChoice.equals(ModuleNoRotateSet.ResetRotation.INSTANCE)) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -31,8 +31,6 @@ import net.ccbluex.liquidbounce.features.module.modules.client.ModuleRichPresenc
 import net.ccbluex.liquidbounce.features.module.modules.client.ModuleTargets
 import net.ccbluex.liquidbounce.features.module.modules.combat.*
 import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleAutoBow
-import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleDroneControl
-import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleProjectileAimbot
 import net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor.ModuleAutoArmor
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals
 import net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura.ModuleCrystalAura
@@ -266,6 +264,7 @@ object ModuleManager : EventListener, Iterable<ClientModule> by modules {
             ModuleVehicleControl,
             ModuleSpider,
             ModuleTargetStrafe,
+            ModuleEndTick,
 
             // Player
             ModuleAntiVoid,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/aimbot/autobow/AutoBowFastChargeFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/aimbot/autobow/AutoBowFastChargeFeature.kt
@@ -5,6 +5,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleAutoBow
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.minecraft.entity.effect.StatusEffects
 import net.minecraft.item.BowItem
@@ -49,7 +50,7 @@ object AutoBowFastChargeFeature : ToggleableConfigurable(ModuleAutoBow, "FastCha
                 }
 
                 // Speed up ticks (MC 1.8)
-                network.sendPacket(packetType.generatePacket())
+                packetType.generatePacket().send()
 
                 // Show visual effect (not required to work - but looks better)
                 player.tickActiveItemStack()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsPacket.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleC
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.canDoCriticalHit
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.modes
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.entity.LivingEntity
 
 /**
@@ -98,10 +99,10 @@ object CriticalsPacket : Choice("Packet") {
     }
 
     private fun p(mod: Double, onGround: Boolean = false) {
-        network.sendPacket(packetType.generatePacket().apply {
+        packetType.generatePacket().apply {
             this.y += mod
             this.onGround = onGround
-        })
+        }.send()
     }
 
     enum class Mode(override val choiceName: String) : NamedChoice {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/SubmoduleIdPredict.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.raytraceBox
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.entity.decoration.EndCrystalEntity
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -70,7 +71,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
             }
 
             oldRotation = RotationManager.serverRotation
-            network.sendPacket(PlayerMoveC2SPacket.Full(
+            PlayerMoveC2SPacket.Full(
                 player.x,
                 player.y,
                 player.z,
@@ -78,7 +79,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 rotation.pitch,
                 player.isOnGround,
                 player.horizontalCollision
-            ))
+            ).send()
         }
 
         fun rotateBack() {
@@ -86,7 +87,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 return
             }
 
-            network.sendPacket(PlayerMoveC2SPacket.Full(
+            PlayerMoveC2SPacket.Full(
                 player.x,
                 player.y,
                 player.z,
@@ -94,7 +95,7 @@ object SubmoduleIdPredict : ToggleableConfigurable(ModuleCrystalAura, "IDPredict
                 oldRotation!!.pitch,
                 player.isOnGround,
                 player.horizontalCollision
-            ))
+            ).send()
         }
 
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -16,6 +16,7 @@ import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.math.toVec3
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -86,24 +87,24 @@ object ImmediateMode : TpAuraChoice("Immediate") {
         val times = (floor((abs(deltaX) + abs(deltaY) + abs(deltaZ)) / 10) - 1).toInt()
         val packetToSend = MovePacketType.FULL
         repeat(times) {
-            network.sendPacket(packetToSend.generatePacket().apply {
+            packetToSend.generatePacket().apply {
                 this.x = player.x
                 this.y = player.y
                 this.z = player.z
                 this.yaw = player.yaw
                 this.pitch = player.pitch
                 this.onGround = player.isOnGround
-            })
+            }.send()
         }
 
-        network.sendPacket(packetToSend.generatePacket().apply {
+        packetToSend.generatePacket().apply {
             this.x = x
             this.y = y
             this.z = z
             this.yaw = player.yaw
             this.pitch = player.pitch
             this.onGround = player.isOnGround
-        })
+        }.send()
 
         desyncPlayerPosition = position
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleDamage.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.exactPosition
 import net.ccbluex.liquidbounce.utils.math.component1
 import net.ccbluex.liquidbounce.utils.math.component2
@@ -60,21 +61,21 @@ object ModuleDamage : ClientModule("Damage", Category.EXPLOIT, disableActivation
                         z,
                         false,
                         player.horizontalCollision))
-                    network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(
+                    PlayerMoveC2SPacket.PositionAndOnGround(
                         x,
                         y,
                         z,
                         false,
                         player.horizontalCollision
-                    ))
+                    ).send()
                 }
-                network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(
+                PlayerMoveC2SPacket.PositionAndOnGround(
                     x,
                     y,
                     z,
                     true,
                     player.horizontalCollision
-                ))
+                ).send()
             }
         ),
         AAC(
@@ -93,14 +94,14 @@ object ModuleDamage : ClientModule("Damage", Category.EXPLOIT, disableActivation
         Verus(
             "Verus",
             {
-                network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-                    player.horizontalCollision))
-                network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z, false,
-                    player.horizontalCollision))
-                network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-                    player.horizontalCollision))
-                network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
-                    player.horizontalCollision))
+                PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+                    player.horizontalCollision).send()
+                PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z, false,
+                    player.horizontalCollision).send()
+                PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+                    player.horizontalCollision).send()
+                PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
+                    player.horizontalCollision).send()
             }
         )
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
@@ -58,15 +59,13 @@ object ModuleKick : ClientModule("Kick", Category.EXPLOIT, disableActivation = t
             world.disconnect()
         }),
         INVALID_PACKET("InvalidPacket", {
-            network.sendPacket(
-                PlayerMoveC2SPacket.PositionAndOnGround(
-                    Double.NaN,
-                    Double.NEGATIVE_INFINITY,
-                    Double.POSITIVE_INFINITY,
-                    !player.isOnGround,
-                    !player.horizontalCollision
-                )
-            )
+            PlayerMoveC2SPacket.PositionAndOnGround(
+                Double.NaN,
+                Double.NEGATIVE_INFINITY,
+                Double.POSITIVE_INFINITY,
+                !player.isOnGround,
+                !player.horizontalCollision
+            ).send()
         }),
         SELF_HURT("SelfHurt", {
             network.sendPacket(PlayerInteractEntityC2SPacket.attack(player, player.isSneaking))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTimeShift.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleTimeShift.kt
@@ -152,7 +152,7 @@ object ModuleTimeShift : ClientModule("TimeShift", Category.EXPLOIT, disableOnQu
             Timer.requestTimerSpeed(timer, Priority.IMPORTANT_FOR_USAGE_1, this@ModuleTimeShift)
 
             repeat(tickSpeed) {
-                network.sendPacket(packetType.generatePacket())
+                packetType.generatePacket().send()
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
@@ -25,10 +25,7 @@ import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
-import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
-import net.ccbluex.liquidbounce.utils.client.asText
-import net.ccbluex.liquidbounce.utils.client.chat
-import net.ccbluex.liquidbounce.utils.client.sendPacketSilently
+import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.minecraft.network.packet.c2s.common.CommonPongC2SPacket
 import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket
@@ -102,41 +99,35 @@ internal object DisablerVerusExperimental : ToggleableConfigurable(ModuleDisable
                         (!waitForGround || player.isOnGround)) {
                         lastVoidTP = System.currentTimeMillis()
 
-                        sendPacketSilently(
-                            PlayerMoveC2SPacket.Full(
-                                player.x,
-                                -48.0,
-                                player.z,
-                                player.yaw,
-                                player.pitch,
-                                true,
-                                player.horizontalCollision
-                            )
-                        )
+                        PlayerMoveC2SPacket.Full(
+                            player.x,
+                            -48.0,
+                            player.z,
+                            player.yaw,
+                            player.pitch,
+                            true,
+                            player.horizontalCollision
+                        ).send(true)
 
-                        sendPacketSilently(
-                            PlayerMoveC2SPacket.Full(
-                                player.lastX,
-                                player.lastBaseY,
-                                player.lastZ,
-                                player.lastYaw,
-                                player.lastPitch,
-                                false,
-                                player.horizontalCollision
-                            )
-                        )
+                        PlayerMoveC2SPacket.Full(
+                            player.lastX,
+                            player.lastBaseY,
+                            player.lastZ,
+                            player.lastYaw,
+                            player.lastPitch,
+                            false,
+                            player.horizontalCollision
+                        ).send(true)
 
-                        sendPacketSilently(
-                            PlayerMoveC2SPacket.Full(
-                                player.x,
-                                player.y,
-                                player.z,
-                                player.yaw,
-                                player.pitch,
-                                player.isOnGround,
-                                player.horizontalCollision
-                            )
-                        )
+                        PlayerMoveC2SPacket.Full(
+                            player.x,
+                            player.y,
+                            player.z,
+                            player.yaw,
+                            player.pitch,
+                            player.isOnGround,
+                            player.horizontalCollision
+                        ).send(true)
 
                         sendPacketSilently(TeleportConfirmC2SPacket(lastTeleportId))
                         chat("Teleport confirmed".asText().styled { it.withColor(Formatting.GREEN) })

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/NegativeInfinityExploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/NegativeInfinityExploit.kt
@@ -22,6 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher.exploitChoices
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
 /**
@@ -35,8 +36,8 @@ object NegativeInfinityExploit : Choice("NegativeInfinity") {
             get() = exploitChoices
 
         override fun enable() {
-            network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(Double.NEGATIVE_INFINITY,
-                Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, true, false))
+            PlayerMoveC2SPacket.PositionAndOnGround(Double.NEGATIVE_INFINITY,
+                Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, true, false).send()
             ModuleServerCrasher.enabled = false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleEndTick.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleEndTick.kt
@@ -1,0 +1,31 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2024 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement
+
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.minecraft.network.packet.c2s.play.ClientTickEndC2SPacket
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
+
+/**
+ * Module EndTick
+ *
+ * Toggles sending a [ClientTickEndC2SPacket] after every [PlayerMoveC2SPacket].
+ */
+object ModuleEndTick : ClientModule("EndTick", Category.MOVEMENT, state = true, hide = true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
@@ -91,7 +91,7 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
                 return@handler
             }
 
-            sendPacketSilently(MovePacketType.FULL.generatePacket().apply {
+            MovePacketType.FULL.generatePacket().apply {
                 val change = it.packet.change
                 this.x = change.position.x
                 this.y = change.position.y
@@ -99,7 +99,7 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
                 this.yaw = change.yaw
                 this.pitch = change.pitch
                 this.onGround = false
-            })
+            }.send(true)
 
             teleport(indicatedTeleport.x, indicatedTeleport.y, indicatedTeleport.z)
             this.indicatedTeleport = null
@@ -120,7 +120,7 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
             val times = (floor((abs(deltaX) + abs(deltaY) + abs(deltaZ)) / 10) - 1).toInt()
             val packetToSend = if (allFull) MovePacketType.FULL else MovePacketType.POSITION_AND_ON_GROUND
             repeat(times) {
-                network.sendPacket(packetToSend.generatePacket().apply {
+                packetToSend.generatePacket().apply {
                     this.x = player.x
                     this.y = player.y
                     this.z = player.z
@@ -131,10 +131,10 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
                         GroundMode.FALSE -> false
                         GroundMode.CORRECT -> player.isOnGround
                     }
-                })
+                }.send()
             }
 
-            network.sendPacket(packetToSend.generatePacket().apply {
+            packetToSend.generatePacket().apply {
                 this.x = x
                 this.y = y
                 this.z = z
@@ -145,7 +145,7 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
                     GroundMode.FALSE -> false
                     GroundMode.CORRECT -> player.isOnGround
                 }
-            })
+            }.send()
         }
 
         val entity = player.vehicle ?: player

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.block.FluidBlock
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -139,7 +140,7 @@ internal object FlyCreative : Choice("Creative") {
         }
 
         if (shouldFlyDown()) {
-            network.sendPacket(MovePacketType.POSITION_AND_ON_GROUND.generatePacket())
+            MovePacketType.POSITION_AND_ON_GROUND.generatePacket().send()
         }
 
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.lang.translation
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.regular
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.ccbluex.liquidbounce.utils.movement.zeroXZ
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -130,14 +131,14 @@ internal object FlySentinel20thApr : Choice("Sentinel20thApr") {
 
     private fun boost() {
         hasBeenHurt = false
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-            player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z,
-            false, player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-            player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
-            player.horizontalCollision))
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+            player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z,
+            false, player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+            player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
+            player.horizontalCollision).send()
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.client.notification
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -89,18 +90,14 @@ object FlyNcpClip : Choice("NcpClip") {
             waitUntil { collidesVertical() }
 
             if (clipping != 0f) {
-                network.sendPacket(
-                    PlayerMoveC2SPacket.PositionAndOnGround(
-                        player.x, player.y + clipping, player.z,
-                        false, player.horizontalCollision
-                    )
-                )
-                network.sendPacket(
-                    PlayerMoveC2SPacket.PositionAndOnGround(
-                        player.x, player.y, player.z,
-                        false, player.horizontalCollision
-                    )
-                )
+                PlayerMoveC2SPacket.PositionAndOnGround(
+                    player.x, player.y + clipping, player.z,
+                    false, player.horizontalCollision
+                ).send()
+                PlayerMoveC2SPacket.PositionAndOnGround(
+                    player.x, player.y, player.z,
+                    false, player.horizontalCollision
+                ).send()
             }
 
             if (blink) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.Timer
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.block.FluidBlock
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -84,11 +85,9 @@ internal object FlyVerusB3869Flat : Choice("VerusB3896Flat") {
         player.velocity.x = 0.0
         player.velocity.z = 0.0
 
-        network.sendPacket(
-            PlayerMoveC2SPacket.PositionAndOnGround(
-                player.x, player.y - 0.5, player.z,
-                false, player.horizontalCollision
-            )
-        )
+        PlayerMoveC2SPacket.PositionAndOnGround(
+            player.x, player.y - 0.5, player.z,
+            false, player.horizontalCollision
+        ).send()
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.movement.zeroXZ
@@ -49,14 +50,14 @@ internal object FlyVerusB3896Damage : Choice("VerusB3896Damage") {
     private var gotDamage = false
 
     override fun enable() {
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-            player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z, false,
-            player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
-            player.horizontalCollision))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
-            player.horizontalCollision))
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+            player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z, false,
+            player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false,
+            player.horizontalCollision).send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true,
+            player.horizontalCollision).send()
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286.kt
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.m
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.handlePacket
 import net.ccbluex.liquidbounce.utils.client.regular
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.block.Blocks
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
@@ -61,12 +62,10 @@ internal object FlyVulcan286 : Choice("Vulcan286-113") {
         chat(regular(message("vulcanGhostNewMessage")))
 
         // Send Packet to desync
-        network.sendPacket(
-            PlayerMoveC2SPacket.Full(
-                player.x, player.y - 0.1, player.z,
-                player.yaw, player.pitch, player.isOnGround, player.horizontalCollision
-            )
-        )
+        PlayerMoveC2SPacket.Full(
+            player.x, player.y - 0.1, player.z,
+            player.yaw, player.pitch, player.isOnGround, player.horizontalCollision
+        ).send()
     }
 
     override fun disable() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/VulcanLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/VulcanLongJump.kt
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.ModuleLongJump
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket
@@ -102,15 +103,13 @@ internal object VulcanLongJump : Choice("Vulcan289") {
         if (player.isOnGround && !recievedLagback && player.hurtTime == 0 && !didLongJump) {
             repeat(3) {
                 for (position in jumpingSequence) {
-                    network.sendPacket(
-                        PlayerMoveC2SPacket.PositionAndOnGround(
-                            player.pos.x,
-                            player.pos.y + position,
-                            player.pos.z,
-                            false,
-                            false
-                        )
-                    )
+                    PlayerMoveC2SPacket.PositionAndOnGround(
+                        player.pos.x,
+                        player.pos.y + position,
+                        player.pos.z,
+                        false,
+                        false
+                    ).send()
                 }
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModulePingSpoof
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.directionYaw
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.strafe
@@ -122,13 +123,14 @@ class SpeedSentinelDamage(override val parent: ChoiceConfigurable<*>) : Choice("
         externalDamageAdjust = 0
         hasBeenHurt = false
         enabledTime = System.currentTimeMillis()
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false, false))
-        network.sendPacket(
-            PlayerMoveC2SPacket.PositionAndOnGround(
-                player.x, player.y + 3.25, player.z,
-            false, false))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false, false))
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true, false))
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false, false)
+            .send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y + 3.25, player.z, false, false)
+            .send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, false, false)
+            .send()
+        PlayerMoveC2SPacket.PositionAndOnGround(player.x, player.y, player.z, true, false)
+            .send()
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleReverseStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleReverseStep.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.getBlock
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.FallingPlayer
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
@@ -100,7 +101,7 @@ object ModuleReverseStep : ClientModule("ReverseStep", Category.MOVEMENT) {
                     // and therefore lose the simulation.
                     if (simulatePlayer.onGround) {
                         if (simulationQueue.isNotEmpty()) {
-                            simulationQueue.forEach(network::sendPacket)
+                            simulationQueue.forEach { it.send() }
                         }
 
                         player.setPosition(simulatePlayer.pos)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.Timer
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.canStep
 import net.ccbluex.liquidbounce.utils.entity.strafe
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -154,7 +155,7 @@ object ModuleStep : ClientModule("Step", Category.MOVEMENT) {
                         }
                         this.z = player.z
                     }
-                }.forEach(network::sendPacket)
+                }.forEach { it.send() }
             ticksWait = wait.random()
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.Timer
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.item.isConsumable
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
@@ -116,7 +117,7 @@ object ModuleFastUse : ClientModule("FastUse", Category.PLAYER) {
 
                 waitTicks(delay)
                 repeat(speed) {
-                    network.sendPacket(packetType.generatePacket())
+                    packetType.generatePacket().send()
                 }
                 player.stopUsingItem()
             }
@@ -136,7 +137,7 @@ object ModuleFastUse : ClientModule("FastUse", Category.PLAYER) {
         val repeatable = tickHandler {
             if (accelerateNow && player.itemUseTime >= consumeTime) {
                 repeat(speed) {
-                    network.sendPacket(packetType.generatePacket())
+                    packetType.generatePacket().send()
                 }
 
                 player.stopUsingItem()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager.currentRotation
 import net.ccbluex.liquidbounce.utils.aiming.withFixedYaw
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.FallingPlayer
 import net.ccbluex.liquidbounce.utils.entity.rotation
@@ -133,10 +134,10 @@ object Pot : Buff("Pot", isValidItem = { stack, forUse -> isPotion(stack, forUse
             }
             ON_TICK -> {
                 rotation = rotation.normalize()
-                network.sendPacket(MovePacketType.FULL.generatePacket().apply {
+                MovePacketType.FULL.generatePacket().apply {
                     yaw = rotation.yaw
                     pitch = rotation.pitch
-                })
+                }.send()
             }
             ON_USE -> {
                 rotation = rotation.normalize()
@@ -151,10 +152,10 @@ object Pot : Buff("Pot", isValidItem = { stack, forUse -> isPotion(stack, forUse
 
         when (ModuleAutoBuff.rotations.rotationTiming) {
             ON_TICK -> {
-                network.sendPacket(MovePacketType.FULL.generatePacket().apply {
+                MovePacketType.FULL.generatePacket().apply {
                     yaw = player.withFixedYaw(currentRotation ?: player.rotation)
                     pitch = currentRotation?.pitch ?: player.pitch
-                })
+                }.send()
             }
             else -> { }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHoplite.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHoplite.kt
@@ -5,6 +5,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PlayerTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
 internal object NoFallHoplite : Choice("Hoplite") {
@@ -25,8 +26,8 @@ internal object NoFallHoplite : Choice("Hoplite") {
         if (!player.isOnGround && player.fallDistance > 2f) {
             // Goes up a tiny bit to stop fall damage on 1.17+ servers.
             // Abuses Grim 1.17 extra packets to not flag timer.
-            network.sendPacket(PlayerMoveC2SPacket.Full(player.x, player.y + 1.0E-9, player.z,
-                player.yaw, player.pitch, player.isOnGround, player.horizontalCollision))
+            PlayerMoveC2SPacket.Full(player.x, player.y + 1.0E-9, player.z,
+                player.yaw, player.pitch, player.isOnGround, player.horizontalCollision).send()
 
             player.onLanding()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.Timer
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.entity.isFallingToVoid
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 
@@ -41,9 +42,9 @@ internal object NoFallHypixelPacket : Choice("HypixelPacket") {
     val repeatable = tickHandler {
         if (player.fallDistance - player.velocity.y >= 3.3 && voidCheck()) {
             Timer.requestTimerSpeed(0.5f, Priority.IMPORTANT_FOR_PLAYER_LIFE, ModuleNoFall)
-            network.sendPacket(MovePacketType.ON_GROUND_ONLY.generatePacket().apply {
+            MovePacketType.ON_GROUND_ONLY.generatePacket().apply {
                 onGround = true
-            })
+            }.send()
             player.fallDistance = 0F
             waitTicks(1)
             Timer.requestTimerSpeed(1f, Priority.NORMAL, ModuleNoFall)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallPacket.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
+import net.ccbluex.liquidbounce.utils.client.send
 
 internal object NoFallPacket : Choice("Packet") {
 
@@ -34,9 +35,9 @@ internal object NoFallPacket : Choice("Packet") {
 
     val repeatable = tickHandler {
         if (always || player.fallDistance > 2f && player.age > 20) {
-            network.sendPacket(packetType.generatePacket().apply {
+            packetType.generatePacket().apply {
                 onGround = true
-            })
+            }.send()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
@@ -22,6 +22,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
 /**
@@ -37,7 +38,7 @@ internal object NoFallSpartan524Flag : Choice("Spartan524Flag") {
 
     val repeatable = tickHandler {
         if (player.fallDistance > 2f) {
-            network.sendPacket(PlayerMoveC2SPacket.OnGroundOnly(true, player.horizontalCollision))
+            PlayerMoveC2SPacket.OnGroundOnly(true, player.horizontalCollision).send()
             waitTicks(1)
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleSurround.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleSurround.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.block.placer.NoRotationMode
 import net.ccbluex.liquidbounce.utils.block.targetfinding.BlockPlacementTargetFindingOptions
 import net.ccbluex.liquidbounce.utils.block.targetfinding.CenterTargetPositionFactory
 import net.ccbluex.liquidbounce.utils.block.targetfinding.findBestBlockPlacementTarget
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.collection.Filter
 import net.ccbluex.liquidbounce.utils.collection.getSlot
 import net.ccbluex.liquidbounce.utils.entity.getFeetBlockPos
@@ -386,11 +387,8 @@ object ModuleSurround : ClientModule("Surround", Category.WORLD, disableOnQuit =
 
         if (rotationMode.send) {
             val rotation = placementTarget.rotation.normalize()
-            network.connection!!.send(
                 PlayerMoveC2SPacket.LookAndOnGround(rotation.yaw, rotation.pitch, player.isOnGround,
-                    player.horizontalCollision),
-                null
-            )
+                    player.horizontalCollision).send()
         }
 
         placer.doPlacement(false, blockPos ?: blockPos1!!.toImmutable(), placementTarget)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationModes.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationModes.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import net.ccbluex.liquidbounce.utils.client.RestrictedSingleUseAction
+import net.ccbluex.liquidbounce.utils.client.send
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
@@ -80,11 +81,8 @@ class NoRotationMode(configurable: ChoiceConfigurable<RotationMode>, module: Cli
         PostRotationExecutor.addTask(module, postMove, task = {
             if (send) {
                 val fixedRotation = rotation.normalize()
-                network.connection!!.send(
-                    PlayerMoveC2SPacket.LookAndOnGround(fixedRotation.yaw, fixedRotation.pitch, player.isOnGround,
-                        player.horizontalCollision),
-                    null
-                )
+                PlayerMoveC2SPacket.LookAndOnGround(fixedRotation.yaw, fixedRotation.pitch, player.isOnGround,
+                    player.horizontalCollision).send()
             }
 
             onFinished()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacerRotationModes.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacerRotationModes.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.utils.aiming.*
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.ccbluex.liquidbounce.utils.block.targetfinding.BlockPlacementTarget
 import net.ccbluex.liquidbounce.utils.client.RestrictedSingleUseAction
+import net.ccbluex.liquidbounce.utils.client.send
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.BlockPos
@@ -117,11 +118,8 @@ class NoRotationMode(configurable: ChoiceConfigurable<BlockPlacerRotationMode>, 
 
             if (send) {
                 val rotation = placementTarget.rotation.normalize()
-                network.connection!!.send(
-                    PlayerMoveC2SPacket.LookAndOnGround(rotation.yaw, rotation.pitch, player.isOnGround,
-                        player.horizontalCollision),
-                    null
-                )
+                PlayerMoveC2SPacket.LookAndOnGround(rotation.yaw, rotation.pitch, player.isOnGround,
+                    player.horizontalCollision).send()
             }
 
             placer.doPlacement(isSupport, pos, placementTarget)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -23,10 +23,7 @@ import net.ccbluex.liquidbounce.utils.aiming.Rotation
 import net.ccbluex.liquidbounce.utils.block.DIRECTIONS_EXCLUDING_UP
 import net.ccbluex.liquidbounce.utils.block.isBlastResistant
 import net.ccbluex.liquidbounce.utils.block.raycast
-import net.ccbluex.liquidbounce.utils.client.mc
-import net.ccbluex.liquidbounce.utils.client.network
-import net.ccbluex.liquidbounce.utils.client.player
-import net.ccbluex.liquidbounce.utils.client.toRadians
+import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.math.minus
 import net.ccbluex.liquidbounce.utils.math.plus
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
@@ -53,7 +50,6 @@ import net.minecraft.util.math.*
 import net.minecraft.util.shape.VoxelShapes
 import net.minecraft.world.Difficulty
 import net.minecraft.world.RaycastContext
-import net.minecraft.world.explosion.Explosion
 import net.minecraft.world.explosion.ExplosionBehavior
 import net.minecraft.world.explosion.ExplosionImpl
 import kotlin.math.cos
@@ -619,9 +615,9 @@ fun ClientPlayerEntity.warp(pos: Vec3d? = null, onGround: Boolean = false) {
     }
 
     if (pos != null) {
-        network.sendPacket(PlayerMoveC2SPacket.PositionAndOnGround(pos.x, pos.y, pos.z, onGround, horizontalCollision))
+        PlayerMoveC2SPacket.PositionAndOnGround(pos.x, pos.y, pos.z, onGround, horizontalCollision).send()
     } else {
-        network.sendPacket(PlayerMoveC2SPacket.OnGroundOnly(onGround, horizontalCollision))
+        PlayerMoveC2SPacket.OnGroundOnly(onGround, horizontalCollision).send()
     }
 }
 


### PR DESCRIPTION
Already mentioned in #4980 as something to consider in 1.21.2+, this PR introduces a system to always send a TickEnd packet after move packets.

These changes are untested and should be considered when anti-cheats start including the packet in their checks.

I'm not sure if it should be a module or an option somewhere else. Also whether it should be enabled by default, disabled by default, or dependent on VFP.

I also don't know if we should send the TickEnd packets after the VehicleMove packets.