### PR TITLE
feat(legacy): packetdebugger show cancelled packets

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/PacketDebugger.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/PacketDebugger.kt
@@ -5,6 +5,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
+import kotlinx.coroutines.NonCancellable.isCancelled
 import net.ccbluex.liquidbounce.LiquidBounce.hud
 import net.ccbluex.liquidbounce.config.choices
 import net.ccbluex.liquidbounce.config.int
@@ -49,9 +50,11 @@ object PacketDebugger : Module("PacketDebugger", Category.MISC, gameDetecting = 
     private fun logPacket(event: PacketEvent) {
         val packet = event.packet
 
+        val packetEvent = if (event.isCancelled) "§7(§cCancelled§7)" else ""
+
         val packetInfo = buildString {
             append("\n")
-            append("§aPacket: §b${packet.javaClass.simpleName}\n")
+            append("§aPacket: §b${packet.javaClass.simpleName} $packetEvent\n")
             append("§aEventType: §b${event.eventType}\n")
             packet.javaClass.declaredFields.forEach { field ->
                 field.isAccessible = true


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/0681e80e-a2d7-4aff-89ee-ecc7c26c613f)

Closes: #5049