### PR TITLE
fix(sequences): Sequences still running after disable

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -66,21 +66,6 @@ interface EventListener {
         }
     }
 
-    /**
-     * Cancels all sequences associated with this event listener.
-     * This is called when a module is disabled to ensure no sequences continue running.
-     */
-    fun cancelAllSequences() {
-        SequenceManager.sequences.removeAll { sequence ->
-            if (sequence.owner == this) {
-                sequence.cancel()
-                true
-            } else {
-                false
-            }
-        }
-    }
-
 }
 
 inline fun <reified T : Event> EventListener.handler(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -66,6 +66,21 @@ interface EventListener {
         }
     }
 
+    /**
+     * Cancels all sequences associated with this event listener.
+     * This is called when a module is disabled to ensure no sequences continue running.
+     */
+    fun cancelAllSequences() {
+        SequenceManager.sequences.removeAll { sequence ->
+            if (sequence.owner == this) {
+                sequence.cancel()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
 }
 
 inline fun <reified T : Event> EventListener.handler(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
@@ -52,6 +52,21 @@ object SequenceManager : EventListener {
         }
     }
 
+    /**
+     * Cancels all sequences associated with an event listener.
+     * This is called when a module is disabled to ensure no sequences continue running.
+     */
+    fun cancelAllSequences(owner: EventListener) {
+        sequences.removeAll { sequence ->
+            if (sequence.owner == owner) {
+                sequence.cancel()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
 }
 
 open class Sequence<T : Event>(val owner: EventListener, val handler: SuspendableHandler<T>, protected val event: T) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -92,6 +92,8 @@ open class ClientModule(
             if (new) {
                 enable()
             } else {
+                // Cancel all sequences when module is disabled, maybe disable first and then cancel?
+                cancelAllSequences()
                 disable()
             }
         }.onSuccess {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.types.*
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.SequenceManager.cancelAllSequences
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
@@ -93,7 +94,7 @@ open class ClientModule(
                 enable()
             } else {
                 // Cancel all sequences when module is disabled, maybe disable first and then cancel?
-                cancelAllSequences()
+                cancelAllSequences(this)
                 disable()
             }
         }.onSuccess {


### PR DESCRIPTION
This PR fixes that when having a tickHandler that is waiting in a module, and the module it toggled off and on again, that the sequence is still running and only stops when finished, while the new sequence is also running.
fixes #5053 

This may require some testing to be sure it does not have any side effects.