### PR TITLE
refactor/fix(legacy): modules fix/cleanup

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Aimbot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Aimbot.kt
@@ -107,13 +107,10 @@ object Aimbot : Module("Aimbot", Category.COMBAT, hideModule = false) {
         }
 
         // Search for the best enemy to target
-        val entity = world.loadedEntityList.asSequence().mapNotNull { entity ->
-            entity.takeIf {
-                Backtrack.runWithNearestTrackedDistance(it) {
-                    isSelected(it, true) && player.canEntityBeSeen(it) && player.getDistanceToEntityBox(
-                        it
-                    ) <= range && rotationDifference(it) <= fov
-                }
+        val entity = world.loadedEntityList.filter {
+            Backtrack.runWithNearestTrackedDistance(it) {
+                isSelected(it, true) && player.canEntityBeSeen(it)
+                        && player.getDistanceToEntityBox(it) <= range && rotationDifference(it) <= fov
             }
         }.minByOrNull { player.getDistanceToEntityBox(it) } ?: return@handler
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/ForwardTrack.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/ForwardTrack.kt
@@ -68,17 +68,16 @@ object ForwardTrack : Module("ForwardTrack", Category.COMBAT) {
 
         val renderManager = mc.renderManager
 
-        world.loadedEntityList.asSequence()
-            .filter { isSelected(it, true) }
+        world.loadedEntityList
+            .filter { it != null && isSelected(it, true) }
             .forEach { target ->
-            target?.run {
-                val vec = usePosition(this)
+                val vec = usePosition(target)
 
                 val (x, y, z) = vec - renderManager.renderPos
 
                 when (espMode.lowercase()) {
                     "box" -> {
-                        val axisAlignedBB = entityBoundingBox.offset(-currPos + Vec3(x, y, z))
+                        val axisAlignedBB = target.entityBoundingBox.offset(Vec3(x, y, z) - target.currPos)
 
                         drawBacktrackBox(axisAlignedBB, color)
                     }
@@ -89,9 +88,9 @@ object ForwardTrack : Module("ForwardTrack", Category.COMBAT) {
 
                         color(0.6f, 0.6f, 0.6f, 1f)
                         renderManager.doRenderEntity(
-                            this,
+                            target,
                             x, y, z,
-                            (prevRotationYaw..rotationYaw).lerpWith(event.partialTicks),
+                            (target.prevRotationYaw..target.rotationYaw).lerpWith(event.partialTicks),
                             event.partialTicks,
                             true
                         )
@@ -119,17 +118,17 @@ object ForwardTrack : Module("ForwardTrack", Category.COMBAT) {
 
                         glColor(color)
                         renderManager.doRenderEntity(
-                            this,
+                            target,
                             x, y, z,
-                            (prevRotationYaw..rotationYaw).lerpWith(event.partialTicks),
+                            (target.prevRotationYaw..target.rotationYaw).lerpWith(event.partialTicks),
                             event.partialTicks,
                             true
                         )
                         glColor(color)
                         renderManager.doRenderEntity(
-                            this,
+                            target,
                             x, y, z,
-                            (prevRotationYaw..rotationYaw).lerpWith(event.partialTicks),
+                            (target.prevRotationYaw..target.rotationYaw).lerpWith(event.partialTicks),
                             event.partialTicks,
                             true
                         )
@@ -137,7 +136,6 @@ object ForwardTrack : Module("ForwardTrack", Category.COMBAT) {
                         glPopAttrib()
                         glPopMatrix()
                     }
-                }
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TickBase.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TickBase.kt
@@ -246,8 +246,9 @@ object TickBase : Module("TickBase", Category.COMBAT) {
 
     private fun getNearestEntityInRange(): EntityLivingBase? {
         val player = mc.thePlayer ?: return null
+        val entities = mc.theWorld.loadedEntityList ?: return null
 
-        return mc.theWorld?.loadedEntityList?.asSequence()?.filterIsInstance<EntityLivingBase>()
-            ?.filter { EntityUtils.isSelected(it, true) }?.minByOrNull { player.getDistanceToEntity(it) }
+        return entities.asSequence().filterIsInstance<EntityLivingBase>()
+            .filter { EntityUtils.isSelected(it, true) }.minByOrNull { player.getDistanceToEntity(it) }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/TimerRange.kt
@@ -376,11 +376,11 @@ object TimerRange : Module("TimerRange", Category.COMBAT, hideModule = false) {
      */
     private fun getNearestEntityInRange(): Entity? {
         val player = mc.thePlayer ?: return null
-        val world = mc.theWorld ?: return null
+        val entities = mc.theWorld?.loadedEntityList ?: return null
 
-        return world.loadedEntityList?.asSequence()
-            ?.filter { entity -> isSelected(entity, true) }
-            ?.filter { entity ->
+        return entities.asSequence()
+            .filter { entity -> isSelected(entity, true) }
+            .filter { entity ->
                 Backtrack.runWithNearestTrackedDistance(entity) {
                     val distance = player.getDistanceToEntityBox(entity)
 
@@ -390,7 +390,7 @@ object TimerRange : Module("TimerRange", Category.COMBAT, hideModule = false) {
                         else -> false
                     }
                 }
-            }?.minByOrNull { player.getDistanceToEntityBox(it) }
+            }.minByOrNull { player.getDistanceToEntityBox(it) }
     }
 
     /**

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
@@ -163,7 +163,7 @@ object BufferSpeed : Module("BufferSpeed", Category.MOVEMENT, hideModule = false
                 return@handler
             }
 
-            if (ice && (blockPos.down().block == Blocks.ice || blockPos.down().block == Blocks.packed_ice)) {
+            if (ice && blockPos.down().block.let { it == Blocks.ice || it == Blocks.packed_ice }) {
                 boost(iceBoost)
                 return@handler
             }
@@ -250,11 +250,13 @@ object BufferSpeed : Module("BufferSpeed", Category.MOVEMENT, hideModule = false
         get() {
             val thePlayer = mc.thePlayer
             val theWorld = mc.theWorld
-            val blocks = mutableListOf<BlockPos>()
-            blocks += BlockPos(thePlayer.posX, thePlayer.posY + 1, thePlayer.posZ - 0.7)
-            blocks += BlockPos(thePlayer.posX + 0.7, thePlayer.posY + 1, thePlayer.posZ)
-            blocks += BlockPos(thePlayer.posX, thePlayer.posY + 1, thePlayer.posZ + 0.7)
-            blocks += BlockPos(thePlayer.posX - 0.7, thePlayer.posY + 1, thePlayer.posZ)
+            val blocks = arrayOf(
+                BlockPos(thePlayer.posX, thePlayer.posY + 1, thePlayer.posZ - 0.7),
+                BlockPos(thePlayer.posX + 0.7, thePlayer.posY + 1, thePlayer.posZ),
+                BlockPos(thePlayer.posX, thePlayer.posY + 1, thePlayer.posZ + 0.7),
+                BlockPos(thePlayer.posX - 0.7, thePlayer.posY + 1, thePlayer.posZ)
+            )
+
             for (blockPos in blocks) {
                 val blockState = theWorld.getBlockState(blockPos)
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/FastStairs.kt
@@ -32,11 +32,10 @@ object FastStairs : Module("FastStairs", Category.MOVEMENT) {
         if (!thePlayer.isMoving || Speed.handleEvents())
             return@handler
 
-
-        if (thePlayer.fallDistance > 0 && !walkingDown)
-            walkingDown = true
-        else if (thePlayer.posY > thePlayer.prevChasingPosY)
-            walkingDown = false
+        when {
+            thePlayer.fallDistance > 0 && !walkingDown -> walkingDown = true
+            thePlayer.posY > thePlayer.prevChasingPosY -> walkingDown = false
+        }
 
         val mode = mode
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
@@ -284,16 +284,16 @@ object Fly : Module("Fly", Category.MOVEMENT, Keyboard.KEY_F, hideModule = false
     fun handleVanillaKickBypass() {
         if (!vanillaKickBypass || !groundTimer.hasTimePassed(1000)) return
         val ground = calculateGround() + 0.5
-        run {
-            var posY = mc.thePlayer.posY
-            while (posY > ground) {
-                sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX, posY, mc.thePlayer.posZ, true))
-                if (posY - 8.0 < ground) break // Prevent next step
-                posY -= 8.0
-            }
+
+        var posY = mc.thePlayer.posY
+        while (posY > ground) {
+            sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX, posY, mc.thePlayer.posZ, true))
+            if (posY - 8.0 < ground) break // Prevent next step
+            posY -= 8.0
         }
+
         sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX, ground, mc.thePlayer.posZ, true))
-        var posY = ground
+        posY = ground
         while (posY < mc.thePlayer.posY) {
             sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX, posY, mc.thePlayer.posZ, true))
             if (posY + 8.0 > mc.thePlayer.posY) break // Prevent next step

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/IceSpeed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/IceSpeed.kt
@@ -11,7 +11,6 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.utils.block.block
-import net.ccbluex.liquidbounce.utils.block.material
 import net.ccbluex.liquidbounce.utils.extensions.isMoving
 import net.minecraft.init.Blocks
 import net.minecraft.util.BlockPos
@@ -38,37 +37,35 @@ object IceSpeed : Module("IceSpeed", Category.MOVEMENT) {
 
         val thePlayer = mc.thePlayer ?: return@handler
 
-        if (thePlayer.onGround && !thePlayer.isOnLadder && !thePlayer.isSneaking && thePlayer.isSprinting && thePlayer.isMoving) {
-            when (mode) {
-                "AAC" -> {
-                    thePlayer.position.down().material.let {
-                        if (it == Blocks.ice || it == Blocks.packed_ice) {
-                            thePlayer.motionX *= 1.342
-                            thePlayer.motionZ *= 1.342
-                            Blocks.ice.slipperiness = 0.6f
-                            Blocks.packed_ice.slipperiness = 0.6f
-                        }
-                    }
+        if (!thePlayer.onGround || thePlayer.isOnLadder || thePlayer.isSneaking || !thePlayer.isSprinting || !thePlayer.isMoving) {
+            return@handler
+        }
+
+        if (thePlayer.position.down().block.let { it != Blocks.ice && it != Blocks.packed_ice }) {
+            return@handler
+        }
+
+        when (mode) {
+            "AAC" -> {
+                thePlayer.motionX *= 1.342
+                thePlayer.motionZ *= 1.342
+                Blocks.ice.slipperiness = 0.6f
+                Blocks.packed_ice.slipperiness = 0.6f
+            }
+
+            "Spartan" -> {
+                val upBlock = BlockPos(thePlayer).up(2).block
+
+                if (upBlock != Blocks.air) {
+                    thePlayer.motionX *= 1.342
+                    thePlayer.motionZ *= 1.342
+                } else {
+                    thePlayer.motionX *= 1.18
+                    thePlayer.motionZ *= 1.18
                 }
 
-                "Spartan" -> {
-                    thePlayer.position.down().material.let {
-                        if (it == Blocks.ice || it == Blocks.packed_ice) {
-                            val upBlock = BlockPos(thePlayer).up(2).block
-
-                            if (upBlock != Blocks.air) {
-                                thePlayer.motionX *= 1.342
-                                thePlayer.motionZ *= 1.342
-                            } else {
-                                thePlayer.motionX *= 1.18
-                                thePlayer.motionZ *= 1.18
-                            }
-
-                            Blocks.ice.slipperiness = 0.6f
-                            Blocks.packed_ice.slipperiness = 0.6f
-                        }
-                    }
-                }
+                Blocks.ice.slipperiness = 0.6f
+                Blocks.packed_ice.slipperiness = 0.6f
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/BedPlates.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/BedPlates.kt
@@ -19,6 +19,8 @@ import net.ccbluex.liquidbounce.ui.client.hud.element.Element.Companion.MAX_GRAD
 import net.ccbluex.liquidbounce.ui.font.Fonts
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.BEDWARS_BLOCKS
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlockTexture
+import net.ccbluex.liquidbounce.utils.block.getAllInBoxMutable
+import net.ccbluex.liquidbounce.utils.extensions.immutableCopy
 import net.ccbluex.liquidbounce.utils.render.ColorSettingsFloat
 import net.ccbluex.liquidbounce.utils.render.ColorSettingsInteger
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawRoundedRect
@@ -29,7 +31,6 @@ import net.ccbluex.liquidbounce.utils.render.shader.shaders.RainbowShader
 import net.ccbluex.liquidbounce.utils.render.toColorArray
 import net.minecraft.block.Block
 import net.minecraft.block.BlockBed
-import net.minecraft.block.state.IBlockState
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager.resetColor
 import net.minecraft.init.Blocks
@@ -100,17 +101,10 @@ object BedPlates : Module("BedPlates", Category.RENDER, hideModule = false) {
         val bedSet = mutableSetOf<BlockPos>()
 
         val radius = maxRenderDistance
-        val mutable = BlockPos.MutableBlockPos(0, 0, 0)
-        for (i in -radius..radius) {
-            for (j in -radius..radius) {
-                for (k in -radius..radius) {
-                    mutable.set(player.posX.toInt() + j, player.posY.toInt() + i, player.posZ.toInt() + k)
-                    val blockState: IBlockState = world.getBlockState(mutable)
-
-                    if (blockState.block == Blocks.bed && blockState.getValue(BlockBed.PART) == BlockBed.EnumPartType.FOOT) {
-                        bedBlocks(mutable.immutable, blockList, bedBlockLists, bedSet)
-                    }
-                }
+        player.position.getAllInBoxMutable(radius).forEach {
+            val blockState = world.getBlockState(it)
+            if (blockState.block == Blocks.bed && blockState.getValue(BlockBed.PART) == BlockBed.EnumPartType.FOOT) {
+                bedBlocks(it.immutableCopy(), blockList, bedBlockLists, bedSet)
             }
         }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/PointerESP.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/PointerESP.kt
@@ -120,95 +120,95 @@ object PointerESP : Module("PointerESP", Category.RENDER, hideModule = false) {
             if (entity !is EntityLivingBase || !bot && isBot(entity)) continue
             if (!team && Teams.isInYourTeam(entity)) continue
 
-            if (EntityUtils.isSelected(entity, false)) {
-                val interpolatedPosX = entity.lastTickPosX + (entity.posX - entity.lastTickPosX) * ticks
-                val interpolatedPosZ = entity.lastTickPosZ + (entity.posZ - entity.lastTickPosZ) * ticks
-                val pos1 = (interpolatedPosX - playerPosX) * 0.2
-                val pos2 = (interpolatedPosZ - playerPosZ) * 0.2
+            if (!EntityUtils.isSelected(entity, false)) continue
 
-                val cos = cos(player.rotationYaw * (PI / 180))
-                val sin = sin(player.rotationYaw * (PI / 180))
-                val rotY = -(pos2 * cos - pos1 * sin)
-                val rotX = -(pos1 * cos + pos2 * sin)
-                val arrowAngle = (atan2(rotY, rotX) * 180 / PI).toFloat() + 90f
+            val interpolatedPosX = entity.lastTickPosX + (entity.posX - entity.lastTickPosX) * ticks
+            val interpolatedPosZ = entity.lastTickPosZ + (entity.posZ - entity.lastTickPosZ) * ticks
+            val pos1 = (interpolatedPosX - playerPosX) * 0.2
+            val pos2 = (interpolatedPosZ - playerPosZ) * 0.2
 
-                if (player.getDistanceSqToEntity(entity) > maxRenderDistanceSq) continue
+            val cos = cos(player.rotationYaw * (PI / 180))
+            val sin = sin(player.rotationYaw * (PI / 180))
+            val rotY = -(pos2 * cos - pos1 * sin)
+            val rotX = -(pos1 * cos + pos2 * sin)
+            val arrowAngle = (atan2(rotY, rotX) * 180 / PI).toFloat() + 90f
 
-                val alpha = if (distanceAlpha) {
-                    (alpha - (sqrt((playerPosX - interpolatedPosX).pow(2) + (playerPosZ - interpolatedPosZ).pow(2)) / maxRenderDistance)
-                        .coerceAtMost(1.0) * (alpha - alphaMin)).toInt()
-                } else alpha
+            if (player.getDistanceSqToEntity(entity) > maxRenderDistanceSq) continue
 
-                val targetHealth = getHealth(entity, healthFromScoreboard, absorption)
-                val arrowsColor = when {
-                    targetHealth <= 0 -> Color(255, 0, 0, alpha)
+            val alpha = if (distanceAlpha) {
+                (alpha - (sqrt((playerPosX - interpolatedPosX).pow(2) + (playerPosZ - interpolatedPosZ).pow(2)) / maxRenderDistance)
+                    .coerceAtMost(1.0) * (alpha - alphaMin)).toInt()
+            } else alpha
 
-                    colorTeam -> entity.colorFromDisplayName() ?: continue
+            val targetHealth = getHealth(entity, healthFromScoreboard, absorption)
+            val arrowsColor = when {
+                targetHealth <= 0 -> Color(255, 0, 0, alpha)
 
-                    healthMode == "Custom" -> {
-                        ColorUtils.interpolateHealthColor(
-                            entity,
-                            healthColors.color().red,
-                            healthColors.color().green,
-                            healthColors.color().blue,
-                            alpha,
-                            healthFromScoreboard,
-                            absorption
-                        )
-                    }
+                colorTeam -> entity.colorFromDisplayName() ?: continue
 
-                    colorMode == "Rainbow" -> ColorUtils.rainbow()
-                    else -> Color(colors.color().red, colors.color().green, colors.color().blue, alpha)
+                healthMode == "Custom" -> {
+                    ColorUtils.interpolateHealthColor(
+                        entity,
+                        healthColors.color().red,
+                        healthColors.color().green,
+                        healthColors.color().blue,
+                        alpha,
+                        healthFromScoreboard,
+                        absorption
+                    )
                 }
 
-                glColor4f(
-                    arrowsColor.red / 255f,
-                    arrowsColor.green / 255f,
-                    arrowsColor.blue / 255f,
-                    arrowsColor.alpha / 255f
-                )
-
-                glRotatef(arrowAngle, 0f, 0f, 1f)
-
-                when (mode.lowercase()) {
-                    "solid" -> {
-                        glBegin(GL_TRIANGLES)
-                        glVertex2f(0f, arrowRadius)
-                        glVertex2d(
-                            sin(-halfAngle * PI / 180) * arrowSize,
-                            arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
-                        )
-                        glVertex2d(
-                            sin(halfAngle * PI / 180) * arrowSize,
-                            arrowRadius + cos(halfAngle * PI / 180) * arrowSize
-                        )
-                        glEnd()
-                    }
-
-                    "line", "loopline" -> {
-                        glLineWidth(thickness)
-                        glBegin(GL_LINE_STRIP)
-                        glVertex2d(
-                            sin(-halfAngle * PI / 180) * arrowSize,
-                            arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
-                        )
-                        glVertex2f(0f, arrowRadius)
-                        glVertex2d(
-                            sin(halfAngle * PI / 180) * arrowSize,
-                            arrowRadius + cos(halfAngle * PI / 180) * arrowSize
-                        )
-                        if (mode == "LoopLine") {
-                            glVertex2d(
-                                sin(-halfAngle * PI / 180) * arrowSize,
-                                arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
-                            )
-                        }
-                        glEnd()
-                    }
-                }
-
-                glRotatef(-arrowAngle, 0f, 0f, 1f)
+                colorMode == "Rainbow" -> ColorUtils.rainbow()
+                else -> Color(colors.color().red, colors.color().green, colors.color().blue, alpha)
             }
+
+            glColor4f(
+                arrowsColor.red / 255f,
+                arrowsColor.green / 255f,
+                arrowsColor.blue / 255f,
+                arrowsColor.alpha / 255f
+            )
+
+            glRotatef(arrowAngle, 0f, 0f, 1f)
+
+            when (mode.lowercase()) {
+                "solid" -> {
+                    glBegin(GL_TRIANGLES)
+                    glVertex2f(0f, arrowRadius)
+                    glVertex2d(
+                        sin(-halfAngle * PI / 180) * arrowSize,
+                        arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
+                    )
+                    glVertex2d(
+                        sin(halfAngle * PI / 180) * arrowSize,
+                        arrowRadius + cos(halfAngle * PI / 180) * arrowSize
+                    )
+                    glEnd()
+                }
+
+                "line", "loopline" -> {
+                    glLineWidth(thickness)
+                    glBegin(GL_LINE_STRIP)
+                    glVertex2d(
+                        sin(-halfAngle * PI / 180) * arrowSize,
+                        arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
+                    )
+                    glVertex2f(0f, arrowRadius)
+                    glVertex2d(
+                        sin(halfAngle * PI / 180) * arrowSize,
+                        arrowRadius + cos(halfAngle * PI / 180) * arrowSize
+                    )
+                    if (mode == "LoopLine") {
+                        glVertex2d(
+                            sin(-halfAngle * PI / 180) * arrowSize,
+                            arrowRadius + cos(-halfAngle * PI / 180) * arrowSize
+                        )
+                    }
+                    glEnd()
+                }
+            }
+
+            glRotatef(-arrowAngle, 0f, 0f, 1f)
         }
 
         glEnable(GL_TEXTURE_2D)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/PointerESP.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/PointerESP.kt
@@ -18,6 +18,7 @@ import net.ccbluex.liquidbounce.utils.attack.EntityUtils.colorFromDisplayName
 import net.ccbluex.liquidbounce.utils.attack.EntityUtils.getHealth
 import net.ccbluex.liquidbounce.utils.render.ColorSettingsInteger
 import net.ccbluex.liquidbounce.utils.render.ColorUtils
+import net.ccbluex.liquidbounce.utils.render.RenderUtils.glColor
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.entity.EntityLivingBase
 import org.lwjgl.opengl.GL11.*
@@ -159,15 +160,10 @@ object PointerESP : Module("PointerESP", Category.RENDER, hideModule = false) {
                 }
 
                 colorMode == "Rainbow" -> ColorUtils.rainbow()
-                else -> Color(colors.color().red, colors.color().green, colors.color().blue, alpha)
+                else -> colors.color(a = alpha)
             }
 
-            glColor4f(
-                arrowsColor.red / 255f,
-                arrowsColor.green / 255f,
-                arrowsColor.blue / 255f,
-                arrowsColor.alpha / 255f
-            )
+            glColor(arrowsColor)
 
             glRotatef(arrowAngle, 0f, 0f, 1f)
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Nuker.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Nuker.kt
@@ -35,13 +35,6 @@ import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.STOP_DEST
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
 import java.awt.Color
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.hashSetOf
-import kotlin.collections.minusAssign
-import kotlin.collections.plusAssign
-import kotlin.collections.sortedBy
-import kotlin.collections.sortedByDescending
 import kotlin.math.roundToInt
 
 object Nuker : Module("Nuker", Category.WORLD, gameDetecting = false, hideModule = false) {

--- a/src/main/java/net/ccbluex/liquidbounce/utils/block/BlockUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/block/BlockUtils.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.utils.block
 
 import net.ccbluex.liquidbounce.utils.client.MinecraftInstance
+import net.ccbluex.liquidbounce.utils.extensions.immutableCopy
 import net.minecraft.block.Block
 import net.minecraft.block.BlockGlass
 import net.minecraft.block.BlockSoulSand
@@ -94,7 +95,7 @@ object BlockUtils : MinecraftInstance {
                     val block = mutable.block ?: continue
 
                     if (targetBlocks == null || targetBlocks.contains(block)) {
-                        val pos = mutable.immutable
+                        val pos = mutable.immutableCopy()
                         if (predicate(pos, block)) {
                             blocks[pos] = block
                         }

--- a/src/main/java/net/ccbluex/liquidbounce/utils/extensions/MathExtensions.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/extensions/MathExtensions.kt
@@ -73,6 +73,11 @@ operator fun Vec3.times(number: Double) = Vec3(xCoord * number, yCoord * number,
 operator fun Vec3.div(number: Double) = times(1 / number)
 operator fun Vec3.unaryMinus(): Vec3 = this.times(-1.0)
 
+fun Vec3i.copy(x: Int = this.x, y: Int = this.y, z: Int = this.z) = Vec3i(x, y, z)
+fun BlockPos.copy(x: Int = this.x, y: Int = this.y, z: Int = this.z) = BlockPos(x, y, z)
+fun BlockPos.MutableBlockPos.copy(x: Int = this.x, y: Int = this.y, z: Int = this.z) = BlockPos.MutableBlockPos(x, y, z)
+fun Vec3.copy(x: Double = this.xCoord, y: Double = this.yCoord, z: Double = this.zCoord) = Vec3(x, y, z)
+
 fun Vec3.offset(direction: EnumFacing, value: Double): Vec3 {
     val vec3i = direction.directionVec
 

--- a/src/main/java/net/ccbluex/liquidbounce/utils/extensions/MathExtensions.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/extensions/MathExtensions.kt
@@ -78,6 +78,9 @@ fun BlockPos.copy(x: Int = this.x, y: Int = this.y, z: Int = this.z) = BlockPos(
 fun BlockPos.MutableBlockPos.copy(x: Int = this.x, y: Int = this.y, z: Int = this.z) = BlockPos.MutableBlockPos(x, y, z)
 fun Vec3.copy(x: Double = this.xCoord, y: Double = this.yCoord, z: Double = this.zCoord) = Vec3(x, y, z)
 
+fun BlockPos.immutableCopy() = BlockPos(x, y, z)
+fun BlockPos.mutableCopy() = BlockPos.MutableBlockPos(x, y, z)
+
 fun Vec3.offset(direction: EnumFacing, value: Double): Vec3 {
     val vec3i = direction.directionVec
 
@@ -89,7 +92,7 @@ fun Vec3.offset(direction: EnumFacing, value: Double): Vec3 {
 }
 
 fun Vec3.withY(value: Double, useCurrentY: Boolean = false): Vec3 {
-    return Vec3(xCoord, (yCoord.takeIf { useCurrentY } ?: 0.0) + value, zCoord)
+    return Vec3(xCoord, (if (useCurrentY) yCoord else 0.0) + value, zCoord)
 }
 
 val Vec3_ZERO: Vec3


### PR DESCRIPTION
1. fix: IceSpeed was comparing Material with Block
2. fix: ItemESP abnormal FPS drop
3. fix: ItemESP tags with Glow Mode
4. refactor: ItemESP item list
5. refactor: remove redundant asSequence in Aimbot & ForwardTrack
6. refactor: remove redundant null check of mc.theWorld.loadedEntityList
7. refactor: Projectiles data class & ArrayDeque
8. feat: copy method for Vec3/Vec3i/BlockPos
9. fix: `BlockPos.getImmutable` does not exist in old forge version