### PR TITLE
fix: bad disconnect event hook

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -369,4 +369,9 @@ public abstract class MixinMinecraftClient {
         }
     }
 
+    @Inject(method = "onDisconnected", at = @At("HEAD"))
+    private void handleDisconnection(CallbackInfo ci) {
+        EventManager.INSTANCE.callEvent(DisconnectEvent.INSTANCE);
+    }
+
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientConnection.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientConnection.java
@@ -20,7 +20,6 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.network;
 
 import io.netty.channel.ChannelPipeline;
 import net.ccbluex.liquidbounce.event.EventManager;
-import net.ccbluex.liquidbounce.event.events.DisconnectEvent;
 import net.ccbluex.liquidbounce.event.events.PacketEvent;
 import net.ccbluex.liquidbounce.event.events.PipelineEvent;
 import net.ccbluex.liquidbounce.event.events.TransferOrigin;
@@ -100,11 +99,6 @@ public abstract class MixinClientConnection {
             final PipelineEvent event = new PipelineEvent(pipeline, local);
             EventManager.INSTANCE.callEvent(event);
         }
-    }
-
-    @Inject(method = "handleDisconnection", at = @At("HEAD"))
-    private void handleDisconnection(CallbackInfo ci) {
-        EventManager.INSTANCE.callEvent(DisconnectEvent.INSTANCE);
     }
 
 }


### PR DESCRIPTION
The event triggered when being in-game and a ping connection timed out in the backgroung causing things to get disabled. This is now fixed by using the onDisconnect function in MinecraftClient