### PR TITLE
fix: arraylist out transition missing

### DIFF
--- a/src-theme/src/routes/hud/elements/ArrayList.svelte
+++ b/src-theme/src/routes/hud/elements/ArrayList.svelte
@@ -50,7 +50,7 @@
 
 <div class="arraylist">
     {#each enabledModules as {name, tag} (name)}
-        <div class="module" animate:flip={{ duration: 200 }} in:fly={{ x: 50, duration: 200 }}>
+        <div class="module" animate:flip={{ duration: 200 }} transition:fly={{ x: 50, duration: 200 }}>
             {$spaceSeperatedNames ? convertToSpacedString(name) : name}
             {#if tag}
                 <span class="tag"> {tag}</span>


### PR DESCRIPTION
The transition was removed because it could mess up Svelte 4's internal transition states. This is no longer an issue in Svelte 5. Unfortunately, Svelte 5 introduced another issue that causes choppy animations under some circumstances. This also affects the array list when multiple modules are toggled simultaneously. This is still better than before.