### PR TITLE
fix: formatting of 'egg and snowball' setting of autoshoot

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
@@ -279,7 +279,7 @@ object ModuleAutoShoot : ClientModule("AutoShoot", Category.COMBAT) {
     }
 
     private enum class ThrowableType(override val choiceName: String) : NamedChoice {
-        EGG_AND_SNOWBALL("Egg and Snowball"),
+        EGG_AND_SNOWBALL("EggAndSnowball"),
         ANYTHING("Anything"),
     }
 


### PR DESCRIPTION
The value is currently called `Egg and snowball`. Setting names in LiquidBounce should be in pascal case.