### PR TITLE
chore(MCEF): bump dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,14 +130,18 @@ dependencies {
         exclude group: "org.apache.logging.log4j", module: "log4j-slf4j-impl"
         exclude group: "org.slf4j", module: "slf4j-api"
         exclude group: "com.mojang", module: "authlib"
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
     }
 
     // JCEF Support
-    includeModDependency "com.github.CCBlueX:mcef:${project.mcef_version}"
+    includeModDependency ("com.github.CCBlueX:mcef:${project.mcef_version}") {
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
+    }
     includeDependency "org.apache.commons:commons-exec:1.3"
     includeDependency "org.apache.commons:commons-compress:1.27.1"
     includeDependency ("com.github.CCBlueX:netty-httpserver:2.1.1") {
         exclude group: "io.netty", module: "netty-all"
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
     }
 
     // Discord RPC Support

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ kotlin_version=2.1.0
 # https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/
 fabric_kotlin_version=1.13.0+kotlin.2.1.0
 # mcef
-mcef_version=1.3.1-1.21.4
+mcef_version=1.3.2-1.21.4
 # mc-authlib
 mc_authlib_version=1.4.1
 # Recommended mods


### PR DESCRIPTION
MCEF now uses OkHttp as well. Also fixed not excluding kotlin-stdlib from JAR export.