### PR TITLE
feat: gradle task verifyI18nJsonKeys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,47 @@ task detektProjectBaseline(type: io.gitlab.arturbosch.detekt.DetektCreateBaselin
     exclude("**/build/**")
 }
 
+tasks.register("verifyI18nJsonKeys") {
+    def baselineFileName = "en_us.json"
+
+    group = "verification"
+    description = "Compare i18n JSON files with ${baselineFileName} as the baseline and report missing keys."
+
+    def i18nDir = file("src/main/resources/resources/liquidbounce/lang")
+
+    doLast {
+        if (!i18nDir.exists() || !i18nDir.isDirectory()) {
+            throw new GradleException("The specified directory ${i18nDir} does not exist or is not a directory.")
+        }
+
+        def baselineFile = new File(i18nDir, baselineFileName)
+        if (!baselineFile.exists()) {
+            throw new GradleException("Baseline file ${baselineFileName} not found in ${i18nDir}.")
+        }
+
+        def baseline = new JsonSlurper().parse(baselineFile)
+
+        i18nDir.eachFile { file ->
+            if (file.name.endsWith(".json") && file.name != baselineFileName) {
+                def currentFile = new JsonSlurper().parse(file)
+
+                def missingKeys = baseline.keySet() - currentFile.keySet()
+
+                if (missingKeys.isEmpty()) {
+                    println "${file.name} is complete. No missing keys."
+                } else {
+                    def limitedMissingKeys = missingKeys.take(5)
+                    def output = limitedMissingKeys.join(', ')
+                    if (missingKeys.size() > 5) {
+                        output += ", ..."
+                    }
+                    println "${file.name} is missing the following keys (${missingKeys.size()}): ${output}"
+                }
+            }
+        }
+    }
+}
+
 java {
     // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
     // if it is present.


### PR DESCRIPTION
closes #4363 

result example:
```
> Task :verifyI18nJsonKeys
de_de.json is missing the following keys (2): liquidbounce.generic.guilded, liquidbounce.module.fly.messages.setbackDetected
en_pt.json is missing the following keys (251): liquidbounce.command.bind.result.moduleUnbound, liquidbounce.command.bind.result.keyNotFound, liquidbounce.command.client.subcommand.appearance.subcommand.show.result.showingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.hidingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.alreadyHidingAppearance, ...
ja_jp.json is missing the following keys (156): liquidbounce.command.bind.result.moduleUnbound, liquidbounce.command.bind.result.keyNotFound, liquidbounce.command.client.subcommand.appearance.subcommand.show.result.showingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.hidingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.alreadyHidingAppearance, ...
pt_br.json is missing the following keys (252): liquidbounce.command.bind.result.moduleUnbound, liquidbounce.command.bind.result.keyNotFound, liquidbounce.command.client.subcommand.appearance.subcommand.show.result.showingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.hidingAppearance, liquidbounce.command.client.subcommand.appearance.subcommand.hide.result.alreadyHidingAppearance, ...
ru_ru.json is missing the following keys (4): liquidbounce.command.tps.description, liquidbounce.command.tps.result.tpsCheck, liquidbounce.command.tps.result.nan, liquidbounce.module.itemChams.description
ua_ua.json is missing the following keys (180): liquidbounce.command.bind.result.moduleUnbound, liquidbounce.command.bind.result.keyNotFound, liquidbounce.command.coordinates.description, liquidbounce.command.coordinates.subcommand.copy.result.success, liquidbounce.command.targets.subcommand.visual.subcommand.players.description, ...
zh_cn.json is missing the following keys (4): liquidbounce.command.tps.description, liquidbounce.command.tps.result.tpsCheck, liquidbounce.command.tps.result.nan, liquidbounce.module.itemChams.description
```