### PR TITLE
feat(reconnect): Remembers server resource-pack policy

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/custom/MixinConnectScreen.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/custom/MixinConnectScreen.java
@@ -88,7 +88,7 @@ public abstract class MixinConnectScreen extends MixinScreen {
     @Inject(method = "connect(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;Lnet/minecraft/client/network/CookieStorage;)V", at = @At("HEAD"))
     private void injectConnect(MinecraftClient client, ServerAddress address, ServerInfo info, CookieStorage cookieStorage, CallbackInfo ci) {
         this.serverAddress = address;
-        EventManager.INSTANCE.callEvent(new ServerConnectEvent(info.name, info.address));
+        EventManager.INSTANCE.callEvent(new ServerConnectEvent(info));
     }
 
     @ModifyConstant(method = "render", constant = @Constant(intValue = 50))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/GameEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/GameEvents.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.integration.interop.protocol.event.WebSocketEven
 import net.ccbluex.liquidbounce.utils.client.Nameable
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.minecraft.client.gui.screen.Screen
+import net.minecraft.client.network.ServerInfo
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.client.option.Perspective
 import net.minecraft.client.session.Session
@@ -113,7 +114,7 @@ class SplashProgressEvent(val progress: Float, val isComplete: Boolean) : Event(
 
 @Nameable("serverConnect")
 @WebSocketEvent
-class ServerConnectEvent(val serverName: String, val serverAddress: String) : Event()
+class ServerConnectEvent(val serverInfo: ServerInfo) : Event()
 
 @Nameable("disconnect")
 @WebSocketEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
@@ -26,8 +26,6 @@ import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.AccountManager
-import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.ActiveServerList
-import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.toList
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.minecraft.client.gui.screen.TitleScreen
 import net.minecraft.client.gui.screen.multiplayer.ConnectScreen
@@ -40,16 +38,9 @@ object Reconnect : EventListener {
 
     private var lastServer: ServerInfo? = null
 
-    val handleServerConnect = handler<ServerConnectEvent> {
-        lastServer = ServerInfo(it.serverName, it.serverAddress, ServerInfo.ServerType.OTHER)
-            .apply {
-                val existingServer = ActiveServerList.serverList.toList().find { server ->
-                    server.address == it.serverAddress
-                }
-
-                resourcePackPolicy = existingServer?.resourcePackPolicy
-                    ?: ServerInfo.ResourcePackPolicy.PROMPT
-            }
+    @Suppress("unused")
+    private val handleServerConnect = handler<ServerConnectEvent> { event ->
+        lastServer = event.serverInfo
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/Reconnect.kt
@@ -26,6 +26,8 @@ import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.misc.AccountManager
+import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.ActiveServerList
+import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.toList
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.minecraft.client.gui.screen.TitleScreen
 import net.minecraft.client.gui.screen.multiplayer.ConnectScreen
@@ -40,6 +42,14 @@ object Reconnect : EventListener {
 
     val handleServerConnect = handler<ServerConnectEvent> {
         lastServer = ServerInfo(it.serverName, it.serverAddress, ServerInfo.ServerType.OTHER)
+            .apply {
+                val existingServer = ActiveServerList.serverList.toList().find { server ->
+                    server.address == it.serverAddress
+                }
+
+                resourcePackPolicy = existingServer?.resourcePackPolicy
+                    ?: ServerInfo.ResourcePackPolicy.PROMPT
+            }
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
@@ -82,7 +82,7 @@ object ModuleAntiStaff : ClientModule("AntiStaff", Category.MISC) {
 
         @Suppress("unused")
         val handleServerConnect = sequenceHandler<ServerConnectEvent> { event ->
-            val address = event.serverAddress.dropPort().rootDomain()
+            val address = event.serverInfo.address.dropPort().rootDomain()
 
             if (serverStaffList.containsKey(address)) {
                 return@sequenceHandler


### PR DESCRIPTION
- Checks if the server the player is reconnecting to is in the server list.
- If so, it applies the custom server resource-pack policy, otherwise it will set it to default Prompt.

Fixes #5183
Tested locally.