### PR TITLE
fix(ClientModule): disable activation

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -50,7 +50,8 @@ open class ClientModule(
     bind: Int = InputUtil.UNKNOWN_KEY.code, // default bind
     bindAction: InputBind.BindAction = InputBind.BindAction.TOGGLE, // default action
     state: Boolean = false, // default state
-    @Exclude val disableActivation: Boolean = false, // disable activation
+    @Exclude val notActivatable: Boolean = false, // disable settings that are not needed if the module can't be enabled
+    @Exclude val disableActivation: Boolean = notActivatable, // disable activation
     hide: Boolean = false, // default hide
     @Exclude val disableOnQuit: Boolean = false, // disables module when player leaves the world,
     @Exclude val aliases: Array<out String> = emptyArray() // additional names under which the module is known
@@ -139,12 +140,12 @@ open class ClientModule(
      * If the module is running and in game. Can be overridden to add additional checks.
      */
     override val running: Boolean
-        get() = super.running && inGame && (enabled || disableActivation)
+        get() = super.running && inGame && (enabled || notActivatable)
 
     val bind by bind("Bind", InputBind(InputUtil.Type.KEYSYM, bind, bindAction))
         .doNotIncludeWhen { !AutoConfig.includeConfiguration.includeBinds }
         .independentDescription().apply {
-            if (disableActivation) {
+            if (notActivatable) {
                 notAnOption()
             }
         }
@@ -155,7 +156,7 @@ open class ClientModule(
             EventManager.callEvent(RefreshArrayListEvent)
             it
         }.apply {
-            if (disableActivation) {
+            if (notActivatable) {
                 notAnOption()
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleTargets.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleTargets.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.combat.combatTargetsConfigurable
 import net.ccbluex.liquidbounce.utils.combat.visualTargetsConfigurable
 
-object ModuleTargets : ClientModule("Targets", Category.CLIENT, disableActivation = true, hide = true,
+object ModuleTargets : ClientModule("Targets", Category.CLIENT, notActivatable = true, hide = true,
     aliases = arrayOf("Enemies")) {
     init {
         tree(combatTargetsConfigurable)


### PR DESCRIPTION
The changes introduced by #4967 should only apply to modules that don't contain enable logic. Currently this only applies to the targets module. 