### PR TITLE
feat(NoFall): not with mace option

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
@@ -71,7 +71,7 @@ object ModuleNoFall : ClientModule("NoFall", Category.PLAYER) {
             }
 
             // With Elytra - we don't want to reduce fall damage.
-            if (!notWhileGliding && player.isGliding && player.isInPose(EntityPose.GLIDING)) {
+            if (notWhileGliding && player.isGliding && player.isInPose(EntityPose.GLIDING)) {
                 return false
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
@@ -22,6 +22,7 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes.*
 import net.minecraft.entity.EntityPose
+import net.minecraft.item.Items
 
 /**
  * NoFall module
@@ -50,7 +51,8 @@ object ModuleNoFall : ClientModule("NoFall", Category.PLAYER) {
         )
     ).apply(::tagBy)
 
-    private var duringFallFlying by boolean("DuringFallFlying", false)
+    private var notWhileGliding by boolean("NotWhileGliding", false)
+    private var notWithMace by boolean("NotWithMace", true)
 
     override val running: Boolean
         get() {
@@ -69,7 +71,12 @@ object ModuleNoFall : ClientModule("NoFall", Category.PLAYER) {
             }
 
             // With Elytra - we don't want to reduce fall damage.
-            if (!duringFallFlying && player.isGliding && player.isInPose(EntityPose.GLIDING)) {
+            if (!notWhileGliding && player.isGliding && player.isInPose(EntityPose.GLIDING)) {
+                return false
+            }
+
+            // Check if we are holding a mace
+            if (notWithMace && player.mainHandStack.item == Items.MACE) {
                 return false
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/ModuleNoFall.kt
@@ -51,7 +51,7 @@ object ModuleNoFall : ClientModule("NoFall", Category.PLAYER) {
         )
     ).apply(::tagBy)
 
-    private var notWhileGliding by boolean("NotWhileGliding", false)
+    private var notWhileGliding by boolean("NotWhileGliding", true)
     private var notWithMace by boolean("NotWithMace", true)
 
     override val running: Boolean


### PR DESCRIPTION
Also renames DuringFallFlying to NotWhileGliding and inverts the logic.