### PR TITLE
fix(BetterChat/AntiSpam): Stacking overlay messages

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/network/message/MixinMessageHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/network/message/MixinMessageHandler.java
@@ -73,7 +73,7 @@ public class MixinMessageHandler {
 
     @Inject(method = "onGameMessage", at = @At(value = "HEAD"), cancellable = true)
     private void injectGameMessage(Text message, boolean overlay, CallbackInfo ci) {
-        var result = liquid_bounce$emitChatEvent(null, message, ChatReceiveEvent.ChatType.GAME_MESSAGE);
+        var result = liquid_bounce$emitChatEvent(null, message, overlay ? ChatReceiveEvent.ChatType.DISGUISED_CHAT_MESSAGE : ChatReceiveEvent.ChatType.GAME_MESSAGE);
         if (result) {
             lastProcessTime = Util.getMeasuringTimeMs();
             ci.cancel();

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/AntiSpam.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/AntiSpam.kt
@@ -43,7 +43,7 @@ object AntiSpam : ToggleableConfigurable(ModuleBetterChat, "AntiSpam", true) {
 
         // stacks messages so that e.g., when a message is sent twice
         // it gets replaces by a new messages that has `[2]` appended
-        if (stack) {
+        if (stack && event.type != ChatReceiveEvent.ChatType.DISGUISED_CHAT_MESSAGE) {
             // always cancel so each message gets an ID
             event.cancelEvent()
 


### PR DESCRIPTION
Messages that should go as OVERLAY are still stacked by AntiSpam/Stack anyway.

They show up in chat when they shouldn't.