### PR TITLE
fix(FakePlayer): wrong method

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/CommandFakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/CommandFakePlayer.kt
@@ -326,7 +326,7 @@ object CommandFakePlayer : CommandFactory, EventListener {
             return@handler
         }
 
-        val contains = fakePlayers.none { player ->
+        val contains = fakePlayers.any { player ->
             player.id == event.entity.id
         }
 


### PR DESCRIPTION
- fixes attacking non fakeplayer entities being not possible with fakeplayers spawned
- fixes basic fakeplayer attacking