### PR TITLE
fix(UiRenderer): blur feedback loop

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
@@ -46,7 +46,7 @@ object UiRenderer : MinecraftShortcuts {
         arrayOf(
             UniformProvider("texture0") { pointer ->
                 GlStateManager._activeTexture(GL13.GL_TEXTURE0)
-                GlStateManager._bindTexture(mc.framebuffer.colorAttachment)
+                GlStateManager._bindTexture(tmpFramebuffer.colorAttachment)
                 GL20.glUniform1i(pointer, 0)
             },
             UniformProvider("overlay") { pointer ->
@@ -62,6 +62,18 @@ object UiRenderer : MinecraftShortcuts {
     private var isDrawingHudFramebuffer = false
 
     private val overlayFramebuffer by lazy {
+        val fb = SimpleFramebuffer(
+            mc.window.framebufferWidth,
+            mc.window.framebufferHeight,
+            true
+        )
+
+        fb.setClearColor(0.0f, 0.0f, 0.0f, 0.0f)
+
+        fb
+    }
+
+    private val tmpFramebuffer by lazy {
         val fb = SimpleFramebuffer(
             mc.window.framebufferWidth,
             mc.window.framebufferHeight,
@@ -138,6 +150,12 @@ object UiRenderer : MinecraftShortcuts {
         RenderSystem.disableBlend()
 //        RenderSystem.disableDepthTest()
 //        RenderSystem.resetTextureMatrix()
+
+        // Draw Minecraft's framebuffer to the temporary one to avoid feedback loop
+        this.tmpFramebuffer.clear()
+        this.tmpFramebuffer.beginWrite(true)
+
+        mc.framebuffer.drawInternal(mc.window.framebufferWidth, mc.window.framebufferHeight)
 
         mc.framebuffer.beginWrite(true)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
@@ -157,7 +157,7 @@ object UiRenderer : MinecraftShortcuts {
 
         mc.framebuffer.drawInternal(mc.window.framebufferWidth, mc.window.framebufferHeight)
 
-        mc.framebuffer.beginWrite(true)
+        mc.framebuffer.beginWrite(false)
 
         UiBlurShader.blit()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/UiRenderer.kt
@@ -153,7 +153,7 @@ object UiRenderer : MinecraftShortcuts {
 
         // Draw Minecraft's framebuffer to the temporary one to avoid feedback loop
         this.tmpFramebuffer.clear()
-        this.tmpFramebuffer.beginWrite(true)
+        this.tmpFramebuffer.beginWrite(false)
 
         mc.framebuffer.drawInternal(mc.window.framebufferWidth, mc.window.framebufferHeight)
 
@@ -172,6 +172,7 @@ object UiRenderer : MinecraftShortcuts {
 
     fun setupDimensions(width: Int, height: Int) {
         this.overlayFramebuffer.resize(width, height)
+        this.tmpFramebuffer.resize(width, height)
     }
 
 }


### PR DESCRIPTION
## Description of the Issue
While running the client a few days ago, I noticed visual artifacts in the blur effect. Upon investigating the code, I discovered that the blur implementation had a **feedback loop**, which leads to undefined behavior according to the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Framebuffer_Object#Feedback_Loops). As stated on the wiki:  

> "Do not do this. What you will get is undefined behavior."  

To address this issue, I have implemented a fix to eliminate the feedback loop.

---

## Deeper Dive into the Issue
The problem stems from the way the blur shader interacts with the framebuffer. Specifically, in the following code snippet, the blur shader is configured to use the color attachment bound to the `mc` framebuffer (`mc fbo`):  

```kt
private object UiBlurShader : BlitShader(
    resourceToString("/resources/liquidbounce/shaders/sobel.vert"),
    resourceToString("/resources/liquidbounce/shaders/blur/ui_blur.frag"),
    arrayOf(
        UniformProvider("texture0") { pointer ->
            GlStateManager._activeTexture(GL13.GL_TEXTURE0)
            GlStateManager._bindTexture(mc.framebuffer.colorAttachment)
            GL20.glUniform1i(pointer, 0)
        },
        UniformProvider("overlay") { pointer ->
            val active = GlStateManager._getActiveTexture()
            GlStateManager._activeTexture(GL13.GL_TEXTURE9)
            GlStateManager._bindTexture(overlayFramebuffer.colorAttachment)
            GL20.glUniform1i(pointer, 9)
            GlStateManager._activeTexture(active)
        },
        UniformProvider("radius") { pointer -> GL20.glUniform1f(pointer, getBlurRadius()) }
    ))
```

However, later in the code, the blur shader **writes directly into the `mc fbo`** while also using its texture as input. This results in **simultaneous reading and writing** of the texture, causing undefined behavior:  

```kt
fun endUIOverlayDrawing() {
    if (!this.isDrawingHudFramebuffer) {
        return
    }

    this.isDrawingHudFramebuffer = false

    GlobalFramebuffer.pop()
    this.overlayFramebuffer.endWrite()

    // Remember the previous projection matrix because the draw method changes it AND NEVER FUCKING CHANGES IT
    // BACK IN ORDER TO INTRODUCE HARD TO FUCKING FIND BUGS. Thanks Mojang :+1:
    val projectionMatrix = RenderSystem.getProjectionMatrix()
    val vertexSorting = RenderSystem.getProjectionType()

    RenderSystem.disableBlend()
//        RenderSystem.disableDepthTest()
//        RenderSystem.resetTextureMatrix()

    mc.framebuffer.beginWrite(true)

    UiBlurShader.blit()

    RenderSystem.enableBlend()
    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA)

    this.overlayFramebuffer.drawInternal(mc.window.framebufferWidth, mc.window.framebufferHeight)

    RenderSystem.setProjectionMatrix(projectionMatrix, vertexSorting)
    RenderSystem.defaultBlendFunc()
}
```

This behavior is problematic because rendering into a framebuffer while simultaneously sampling from its texture attachment violates the rules of framebuffer usage. The result is platform-dependent and unpredictable, as documented in the Khronos Wiki.

---

## The Fix
To resolve the issue, I introduced a **temporary framebuffer** to act as a safe intermediary during the blur operation. Instead of using the `mc` framebuffer's color attachment directly in the blur shader, the texture from the `mc` framebuffer is **copied into the temporary framebuffer**. This creates a duplicate of the scene that the blur shader can safely use as input.  

By ensuring the blur shader operates exclusively on the copied texture, we completely avoid the feedback loop and the associated undefined behavior.  

This solution adheres to proper framebuffer usage rules while maintaining the intended blur effect without introducing any visual or functional regressions.

---

## Potential MacOS Fix
Interestingly, this fix might also resolve the issue where the blur effect does not work on macOS systems, but take that with a grain of salt. While I cannot confirm this, as I am unable to test it on macOS, it seems likely that the undefined behavior manifests differently across platforms and GPUs.

**Request:** If someone has access to a macOS system, please test this fix and share the results to confirm whether it resolves the issue on that platform.

---

## Testing Details
- **Primary Environment:**  
  - **Operating System:** Windows 11  
  - **GPU:** NVIDIA GeForce RTX 2060  
  - **Observation:** The bug was visible in this environment.  

- **Secondary Environment:**  
  - **Operating System:** Fedora  
  - **GPU:** AMD Radeon RX 570 Series  
  - **Observation:** The bug was not visible on this system. However, I tested the fix here to ensure it does not introduce any new bugs.  

---

## Results
The issue is resolved with the provided fix. To illustrate the difference, here is a video showing the results before and after the fix: 

https://www.youtube.com/watch?v=HGF8BMXMFVs

*Note: The video quality is reduced due to suboptimal OBS settings and YouTube compression. However, with close observation (e.g., above the "a" in "Particles"), you can notice pixel flickering in the original version that is no longer present after the fix. Under normal conditions (without video compression), the difference is significantly clearer.*