### PR TITLE
feat(legacy): Damage Module new modes/improvements

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -5,15 +5,17 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import net.ccbluex.liquidbounce.LiquidBounce.eventManager
 import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.PacketEvent
+import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.utils.client.PacketUtils
+import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPacket
+import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.extensions.component1
 import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
+import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.network.play.client.C03PacketPlayer.C06PacketPlayerPosLook
 import net.minecraft.network.play.server.S19PacketEntityStatus
@@ -23,13 +25,18 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
     private val mode by choices("Mode", arrayOf("Fake", "NCP", "AAC", "Verus"), "NCP")
 
     // Verus
-    private val verusMode by choices("VerusMode", arrayOf("Default", "Damage1", "Damage2", "Damage3", "Damage4", "CustomDamage"), "Damage1") { mode.equals("Verus", true) }
-    private val customPacket1Clip by float("CustomDamage-Packet1Clip", 4f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
-    private val customPacket2Clip by float("CustomDamage-Packet2Clip", -0.2f, -1f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
-    private val customPacket3Clip by float("CustomDamage-Packet3Clip", 0.5f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+    private val verusMode by choices("VerusMode",
+        arrayOf("Default", "Damage1", "Damage2", "Damage3", "Damage4", "CustomDamage"), "Damage1"
+    ) { mode == "Verus" }
+    private val customPacket1Clip by float("CustomDamage-Packet1Clip", 4f, 0f..5f)
+    { mode == "Verus" && verusMode == "CustomDamage" }
+    private val customPacket2Clip by float("CustomDamage-Packet2Clip", -0.2f, -1f..5f)
+    { mode == "Verus" && verusMode == "CustomDamage" }
+    private val customPacket3Clip by float("CustomDamage-Packet3Clip", 0.5f, 0f..5f)
+    { mode == "Verus" && verusMode == "CustomDamage" }
 
     // NCP
-    private val ncpMode by choices("NCPMode", arrayOf("Glitch", "JumpPacket"), "Glitch") { mode.equals("NCP", true) }
+    private val ncpMode by choices("NCPMode", arrayOf("Glitch", "JumpPacket"), "Glitch") { mode == "NCP" }
 
     // General Settings
     private val damageAmount by int("Damage", 1, 1..20)
@@ -47,59 +54,57 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
         if (onlyOnGround && !player.onGround) return
 
         when (mode.lowercase()) {
-            "fake" -> fakeDamage(player)
             "ncp" -> handleNCPDamage(player)
-            "aac" -> applyAACDamage(player)
+            "aac" -> player.motionY = 5 * damageAmount.toDouble()
             "verus" -> handleVerusDamage(player)
         }
     }
 
+    val onPacket = handler<PacketEvent> { event ->
+        if (mode != "Fake") return@handler
 
-    private fun fakeDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
-        val statusPacket = S19PacketEntityStatus(player, 2.toByte())
-        val event = PacketEvent(statusPacket, EventState.RECEIVE)
+        val player = mc.thePlayer ?: return@handler
+        val packet = event.packet
 
-        eventManager.call(event)
+        if (packet is S19PacketEntityStatus && event.eventType == EventState.RECEIVE
+            && packet.opCode == 2.toByte() && packet.entityId == player.entityId) {
 
-        if (!event.isCancelled) {
-            player.handleStatusUpdate(2.toByte())
+            if (!event.isCancelled) {
+                player.handleStatusUpdate(2.toByte())
+            }
         }
     }
 
-
-    private fun handleNCPDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+    private fun handleNCPDamage(player: EntityPlayerSP) {
         val (x, y, z) = player
 
         when (ncpMode.lowercase()) {
             "glitch" -> {
                 repeat(65 * damageAmount) {
-                    PacketUtils.sendPackets(
+                    sendPackets(
                         C04PacketPlayerPosition(x, y + 0.049, z, false),
                         C04PacketPlayerPosition(x, y, z, false)
                     )
                 }
-                PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, true))
+                sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
             "jumppacket" -> {
                 repeat(4) {
                     jumpYPositions.forEach { yOffset ->
-                        PacketUtils.sendPacket(C04PacketPlayerPosition(x, y + yOffset, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y + yOffset, z, false))
                     }
-                    PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y, z, false))
                 }
-                PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, true))
+                sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
         }
     }
-    private fun applyAACDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
-        player.motionY = 5 * damageAmount.toDouble()
-    }
 
-    private fun handleVerusDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+    private fun handleVerusDamage(player: EntityPlayerSP) {
         val (x, y, z) = player
         when (verusMode.lowercase()) {
             "default" -> {
-                PacketUtils.sendPackets(
+                sendPackets(
                     C04PacketPlayerPosition(x, y + 3.0001, z, false),
                     C06PacketPlayerPosLook(x, y, z, player.rotationYaw, player.rotationPitch, false),
                     C06PacketPlayerPosLook(x, y, z, player.rotationYaw, player.rotationPitch, true)
@@ -110,7 +115,7 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
             "damage3" -> sendVerusDamagePackets(x, y, z, 4.0, 0.0)
             "damage4" -> sendVerusDamagePackets(x, y, z, 3.42,0.0)
             "customdamage" -> {
-                PacketUtils.sendPackets(
+                sendPackets(
                     C04PacketPlayerPosition(x, y + customPacket1Clip.toDouble(), z, false),
                     C04PacketPlayerPosition(x, y + customPacket2Clip.toDouble(), z, false),
                     C04PacketPlayerPosition(x, y + customPacket3Clip.toDouble(), z, true)
@@ -119,8 +124,8 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
         }
     }
 
-    private fun sendVerusDamagePackets(x:Double,y:Double,z:Double,yClip:Double,yOffset:Double) {
-        PacketUtils.sendPackets(
+    private fun sendVerusDamagePackets(x: Double, y: Double, z: Double, yClip: Double, yOffset: Double) {
+        sendPackets(
             C04PacketPlayerPosition(x, y + yClip, z, false),
             C04PacketPlayerPosition(x, y, z, false),
             C04PacketPlayerPosition(x, y + yOffset, z, true)

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -10,8 +10,7 @@ import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.Category
-import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPacket
-import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPackets
+import net.ccbluex.liquidbounce.utils.client.PacketUtils
 import net.ccbluex.liquidbounce.utils.extensions.component1
 import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
@@ -22,133 +21,109 @@ import net.minecraft.network.play.server.S19PacketEntityStatus
 object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
 
     private val mode by choices("Mode", arrayOf("Fake", "NCP", "AAC", "Verus"), "NCP")
+
+    // Verus
     private val verusMode by choices("VerusMode", arrayOf("Default", "Damage1", "Damage2", "Damage3", "Damage4", "CustomDamage"), "Damage1") { mode.equals("Verus", true) }
+    private val customPacket1Clip by float("CustomDamage-Packet1Clip", 4f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+    private val customPacket2Clip by float("CustomDamage-Packet2Clip", -0.2f, -1f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+    private val customPacket3Clip by float("CustomDamage-Packet3Clip", 0.5f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+
+    // NCP
     private val ncpMode by choices("NCPMode", arrayOf("Glitch", "JumpPacket"), "Glitch") { mode.equals("NCP", true) }
-    private val packet1 by float("CustomDamage-Packet1Clip", 4f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
-    private val packet2 by float("CustomDamage-Packet2Clip", -0.2f, -1f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
-    private val packet3 by float("CustomDamage-Packet3Clip", 0.5f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
-    private val damage by int("Damage", 1, 1..20)
-    private val onlyGround by boolean("OnlyGround", true)
-    private val jumpYPosArr = arrayOf(
-        0.41999998688698, 0.7531999805212, 1.00133597911214, 1.16610926093821,
-        1.24918707874468, 1.24918707874468, 1.1707870772188, 1.0155550727022,
-        0.78502770378924, 0.4807108763317, 0.10408037809304, 0.0
+
+    // General Settings
+    private val damageAmount by int("Damage", 1, 1..20)
+    private val onlyOnGround by boolean("OnlyGround", true)
+
+    private val jumpYPositions = arrayOf(
+        0.42, 0.75, 1.00, 1.17,
+        1.25, 1.25, 1.17, 1.02,
+        0.78, 0.48, 0.10, 0.0
     )
 
     override fun onEnable() {
-        val thePlayer = mc.thePlayer ?: return
+        val player = mc.thePlayer ?: return
 
-        if (onlyGround && !thePlayer.onGround) {
-            return
-        }
+        if (onlyOnGround && !player.onGround) return
 
         when (mode.lowercase()) {
-            "fake" -> {
-                val event = PacketEvent(S19PacketEntityStatus(thePlayer, 2.toByte()), EventState.RECEIVE)
-                eventManager.call(event)
-                if (!event.isCancelled) {
-                    thePlayer.handleStatusUpdate(2.toByte())
-                }
-            }
-            "ncp" -> {
-                when (ncpMode.lowercase()) {
-                    "glitch" -> {
-                        val (x, y, z) = thePlayer
+            "fake" -> fakeDamage(player)
+            "ncp" -> handleNCPDamage(player)
+            "aac" -> applyAACDamage(player)
+            "verus" -> handleVerusDamage(player)
+        }
+    }
 
-                        repeat(65 * damage) {
-                            sendPackets(
-                                C04PacketPlayerPosition(x, y + 0.049, z, false),
-                                C04PacketPlayerPosition(x, y, z, false)
-                            )
-                        }
-                        sendPacket(C04PacketPlayerPosition(x, y, z, true))
-                    }
-                    "jumppacket" -> {
-                        val (x, y, z) = thePlayer
 
-                        repeat(4) {
-                            jumpYPosArr.forEach {
-                                sendPacket(C04PacketPlayerPosition(x, y + it, z, false))
-                            }
-                            sendPacket(C04PacketPlayerPosition(x, y, z, false))
-                        }
-                        sendPacket(C04PacketPlayerPosition(x, y, z, true))
-                    }
+    private fun fakeDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+        val statusPacket = S19PacketEntityStatus(player, 2.toByte())
+        val event = PacketEvent(statusPacket, EventState.RECEIVE)
+
+        eventManager.call(event)
+
+        if (!event.isCancelled) {
+            player.handleStatusUpdate(2.toByte())
+        }
+    }
+
+
+    private fun handleNCPDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+        val (x, y, z) = player
+
+        when (ncpMode.lowercase()) {
+            "glitch" -> {
+                repeat(65 * damageAmount) {
+                    PacketUtils.sendPackets(
+                        C04PacketPlayerPosition(x, y + 0.049, z, false),
+                        C04PacketPlayerPosition(x, y, z, false)
+                    )
                 }
+                PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
-            "aac" -> {
-                thePlayer.motionY = 5 * damage.toDouble()
-            }
-            "verus" -> {
-                when (verusMode.lowercase()) {
-                    "default" -> {
-                        // Nota: você pode ser flagado uma ou duas vezes
-                        sendPacket(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX,
-                                thePlayer.posY + 3.0001,
-                                thePlayer.posZ,
-                                false
-                            )
-                        )
-                        sendPacket(
-                            C06PacketPlayerPosLook(
-                                thePlayer.posX,
-                                thePlayer.posY,
-                                thePlayer.posZ,
-                                thePlayer.rotationYaw,
-                                thePlayer.rotationPitch,
-                                false
-                            )
-                        )
-                        sendPacket(
-                            C06PacketPlayerPosLook(
-                                thePlayer.posX,
-                                thePlayer.posY,
-                                thePlayer.posZ,
-                                thePlayer.rotationYaw,
-                                thePlayer.rotationPitch,
-                                true
-                            )
-                        )
+            "jumppacket" -> {
+                repeat(4) {
+                    jumpYPositions.forEach { yOffset ->
+                        PacketUtils.sendPacket(C04PacketPlayerPosition(x, y + yOffset, z, false))
                     }
-                    "damage1" -> {
-                        sendPackets(
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.05, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.41999998688697815, thePlayer.posZ, true)
-                        )
-                    }
-                    "damage2" -> {
-                        sendPackets(
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.35, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
-                        )
-                    }
-                    "damage3" -> {
-                        sendPackets(
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 4, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
-                        )
-                    }
-                    "damage4" -> {
-                        sendPackets(
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.42, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
-                        )
-                    }
-                    "customdamage" -> {
-                        sendPackets(
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet1.toDouble(), thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet2.toDouble(), thePlayer.posZ, false),
-                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet3.toDouble(), thePlayer.posZ, true)
-                        )
-                    }
+                    PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, false))
                 }
+                PacketUtils.sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
         }
+    }
+    private fun applyAACDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+        player.motionY = 5 * damageAmount.toDouble()
+    }
+
+    private fun handleVerusDamage(player: net.minecraft.client.entity.EntityPlayerSP) {
+        val (x, y, z) = player
+        when (verusMode.lowercase()) {
+            "default" -> {
+                PacketUtils.sendPackets(
+                    C04PacketPlayerPosition(x, y + 3.0001, z, false),
+                    C06PacketPlayerPosLook(x, y, z, player.rotationYaw, player.rotationPitch, false),
+                    C06PacketPlayerPosLook(x, y, z, player.rotationYaw, player.rotationPitch, true)
+                )
+            }
+            "damage1" -> sendVerusDamagePackets(x, y, z, 3.05,0.41999998688697815)
+            "damage2" -> sendVerusDamagePackets(x, y, z, 3.35,0.0)
+            "damage3" -> sendVerusDamagePackets(x, y, z, 4.0, 0.0)
+            "damage4" -> sendVerusDamagePackets(x, y, z, 3.42,0.0)
+            "customdamage" -> {
+                PacketUtils.sendPackets(
+                    C04PacketPlayerPosition(x, y + customPacket1Clip.toDouble(), z, false),
+                    C04PacketPlayerPosition(x, y + customPacket2Clip.toDouble(), z, false),
+                    C04PacketPlayerPosition(x, y + customPacket3Clip.toDouble(), z, true)
+                )
+            }
+        }
+    }
+
+    private fun sendVerusDamagePackets(x:Double,y:Double,z:Double,yClip:Double,yOffset:Double) {
+        PacketUtils.sendPackets(
+            C04PacketPlayerPosition(x, y + yClip, z, false),
+            C04PacketPlayerPosition(x, y, z, false),
+            C04PacketPlayerPosition(x, y + yOffset, z, true)
+        )
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -43,7 +43,7 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
     private val onlyOnGround by boolean("OnlyGround", true)
 
     private val jumpYPositions = arrayOf(
-        0.42, 0.75, 1.00, 1.17,
+        0.42, 0.75, 1.0, 1.17,
         1.25, 1.25, 1.17, 1.02,
         0.78, 0.48, 0.10, 0.0
     )

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -42,7 +42,7 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
     private val damageAmount by int("Damage", 1, 1..20) { mode in arrayOf("NCP", "AAC") }
     private val onlyOnGround by boolean("OnlyGround", true)
 
-    private val jumpYPositions = arrayOf(
+    private val jumpYPositions = doubleArrayOf(
         0.42, 0.75, 1.0, 1.17,
         1.25, 1.25, 1.17, 1.02,
         0.78, 0.48, 0.10, 0.0

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -39,7 +39,7 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
     private val ncpMode by choices("NCPMode", arrayOf("Glitch", "JumpPacket"), "Glitch") { mode == "NCP" }
 
     // General Settings
-    private val damageAmount by int("Damage", 1, 1..20)
+    private val damageAmount by int("Damage", 1, 1..20) { mode in arrayOf("NCP", "AAC") }
     private val onlyOnGround by boolean("OnlyGround", true)
 
     private val jumpYPositions = arrayOf(
@@ -89,7 +89,7 @@ object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
                 sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
             "jumppacket" -> {
-                repeat(4) {
+                repeat(4 * damageAmount) {
                     jumpYPositions.forEach { yOffset ->
                         sendPacket(C04PacketPlayerPosition(x, y + yOffset, z, false))
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -5,8 +5,11 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.LiquidBounce.eventManager
+import net.ccbluex.liquidbounce.event.EventState
+import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
+import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.client.PacketUtils.sendPackets
 import net.ccbluex.liquidbounce.utils.extensions.component1
@@ -14,55 +17,138 @@ import net.ccbluex.liquidbounce.utils.extensions.component2
 import net.ccbluex.liquidbounce.utils.extensions.component3
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.network.play.client.C03PacketPlayer.C06PacketPlayerPosLook
+import net.minecraft.network.play.server.S19PacketEntityStatus
 
 object Damage : Module("Damage", Category.EXPLOIT, canBeEnabled = false) {
 
-    private val mode by choices("Mode", arrayOf("NCP", "AAC", "Verus"), "NCP")
+    private val mode by choices("Mode", arrayOf("Fake", "NCP", "AAC", "Verus"), "NCP")
+    private val verusMode by choices("VerusMode", arrayOf("Default", "Damage1", "Damage2", "Damage3", "Damage4", "CustomDamage"), "Damage1") { mode.equals("Verus", true) }
+    private val ncpMode by choices("NCPMode", arrayOf("Glitch", "JumpPacket"), "Glitch") { mode.equals("NCP", true) }
+    private val packet1 by float("CustomDamage-Packet1Clip", 4f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+    private val packet2 by float("CustomDamage-Packet2Clip", -0.2f, -1f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
+    private val packet3 by float("CustomDamage-Packet3Clip", 0.5f, 0f..5f) { mode.equals("Verus", true) && verusMode.equals("CustomDamage", true) }
     private val damage by int("Damage", 1, 1..20)
+    private val onlyGround by boolean("OnlyGround", true)
+    private val jumpYPosArr = arrayOf(
+        0.41999998688698, 0.7531999805212, 1.00133597911214, 1.16610926093821,
+        1.24918707874468, 1.24918707874468, 1.1707870772188, 1.0155550727022,
+        0.78502770378924, 0.4807108763317, 0.10408037809304, 0.0
+    )
 
     override fun onEnable() {
         val thePlayer = mc.thePlayer ?: return
 
+        if (onlyGround && !thePlayer.onGround) {
+            return
+        }
+
         when (mode.lowercase()) {
-            "ncp" -> {
-                val (x, y, z) = thePlayer
-
-                repeat(65 * damage) {
-                    sendPackets(
-                        C04PacketPlayerPosition(x, y + 0.049, z, false),
-                        C04PacketPlayerPosition(x, y, z, false)
-                    )
+            "fake" -> {
+                val event = PacketEvent(S19PacketEntityStatus(thePlayer, 2.toByte()), EventState.RECEIVE)
+                eventManager.call(event)
+                if (!event.isCancelled) {
+                    thePlayer.handleStatusUpdate(2.toByte())
                 }
-
-                sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
+            "ncp" -> {
+                when (ncpMode.lowercase()) {
+                    "glitch" -> {
+                        val (x, y, z) = thePlayer
 
-            "aac" -> thePlayer.motionY = 5 * damage.toDouble()
+                        repeat(65 * damage) {
+                            sendPackets(
+                                C04PacketPlayerPosition(x, y + 0.049, z, false),
+                                C04PacketPlayerPosition(x, y, z, false)
+                            )
+                        }
+                        sendPacket(C04PacketPlayerPosition(x, y, z, true))
+                    }
+                    "jumppacket" -> {
+                        val (x, y, z) = thePlayer
+
+                        repeat(4) {
+                            jumpYPosArr.forEach {
+                                sendPacket(C04PacketPlayerPosition(x, y + it, z, false))
+                            }
+                            sendPacket(C04PacketPlayerPosition(x, y, z, false))
+                        }
+                        sendPacket(C04PacketPlayerPosition(x, y, z, true))
+                    }
+                }
+            }
+            "aac" -> {
+                thePlayer.motionY = 5 * damage.toDouble()
+            }
             "verus" -> {
-                // Note: you'll flag once or twice
-                sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.0001, thePlayer.posZ, false))
-                sendPacket(
-                    C06PacketPlayerPosLook(
-                        thePlayer.posX,
-                        thePlayer.posY,
-                        thePlayer.posZ,
-                        thePlayer.rotationYaw,
-                        thePlayer.rotationPitch,
-                        false
-                    )
-                )
-                sendPacket(
-                    C06PacketPlayerPosLook(
-                        thePlayer.posX,
-                        thePlayer.posY,
-                        thePlayer.posZ,
-                        thePlayer.rotationYaw,
-                        thePlayer.rotationPitch,
-                        true
-                    )
-                )
+                when (verusMode.lowercase()) {
+                    "default" -> {
+                        // Nota: você pode ser flagado uma ou duas vezes
+                        sendPacket(
+                            C04PacketPlayerPosition(
+                                thePlayer.posX,
+                                thePlayer.posY + 3.0001,
+                                thePlayer.posZ,
+                                false
+                            )
+                        )
+                        sendPacket(
+                            C06PacketPlayerPosLook(
+                                thePlayer.posX,
+                                thePlayer.posY,
+                                thePlayer.posZ,
+                                thePlayer.rotationYaw,
+                                thePlayer.rotationPitch,
+                                false
+                            )
+                        )
+                        sendPacket(
+                            C06PacketPlayerPosLook(
+                                thePlayer.posX,
+                                thePlayer.posY,
+                                thePlayer.posZ,
+                                thePlayer.rotationYaw,
+                                thePlayer.rotationPitch,
+                                true
+                            )
+                        )
+                    }
+                    "damage1" -> {
+                        sendPackets(
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.05, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.41999998688697815, thePlayer.posZ, true)
+                        )
+                    }
+                    "damage2" -> {
+                        sendPackets(
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.35, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
+                        )
+                    }
+                    "damage3" -> {
+                        sendPackets(
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 4, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
+                        )
+                    }
+                    "damage4" -> {
+                        sendPackets(
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 3.42, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true)
+                        )
+                    }
+                    "customdamage" -> {
+                        sendPackets(
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet1.toDouble(), thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet2.toDouble(), thePlayer.posZ, false),
+                            C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + packet3.toDouble(), thePlayer.posZ, true)
+                        )
+                    }
+                }
             }
         }
     }
-
 }


### PR DESCRIPTION
### Feature Update: Enhanced Damage Module

**Added:**
- **Fake Mode:** Introduced a new "Fake" mode to simulate false damage by sending entity status packets.
- **Verus Submodes:** Added multiple submodes under "Verus" including "Default", "Damage1", "Damage2", "Damage3", "Damage4", and "CustomDamage" for varied damage behaviors.
- **NCP Submodes:** Included "Glitch" and "JumpPacket" submodes under "NCP" for different exploit techniques.
- **Custom Damage Configurations:** Added configurable parameters (`packet1`, `packet2`, `packet3`) for the "CustomDamage" submode to allow precise damage manipulation.