### PR TITLE
feat(legacy): horrible & shitty yet working Miniblox disabler

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -108,6 +108,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
     private val verusExperimental by boolean("VerusExperimental", false)
     private val verusExpVoidTP by boolean("ExpVoidTP", false) { verusExperimental }
     private val verusExpVoidTPDelay by int("ExpVoidTPDelay", 1000, 0..30000) { verusExpVoidTP }
+    private val miniblox by boolean("Miniblox", false)
     private var lastVoidTP = 0L
     private var cancelNext = 0
 
@@ -425,6 +426,40 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
                 cancelNext--
                 event.cancelEvent()
                 debugMessage("VerusExp canceled server position look")
+            }
+        }
+        // the disabler is really horrible yet simple,
+        // you just silently accept the setback and then go back to where you were before the setback
+        // TODO: make this better, also needs to handle respawning..
+        if (miniblox) {
+            if (packet is S08PacketPlayerPosLook) {
+                event.cancelEvent()
+                // accept the new position & rotation
+                debugMessage("Setbacked, cancelled event, now resyncing & silently accepting new position")
+                // TODO: does this make the disabler better?
+                sendPacket(
+                    C01PacketChatMessage("/resync")
+                )
+                sendPacket(
+                    C06PacketPlayerPosLook(
+                        packet.x,
+                        packet.y,
+                        packet.z,
+                        packet.yaw,
+                        packet.pitch,
+                        player.onGround
+                    )
+                )
+                sendPacket(
+                    C06PacketPlayerPosLook(
+                        player.posX,
+                        player.posY,
+                        player.posZ,
+                        player.rotationYaw,
+                        player.rotationPitch,
+                        player.onGround
+                    )
+                )
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -432,7 +432,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
         // you just silently accept the setback and then go back to where you were before the setback
         // TODO: make this better, also needs to handle respawning..
         if (miniblox) {
-            if (packet is S08PacketPlayerPosLook) {
+            if (packet is S08PacketPlayerPosLook && player.ticksExisted >= 100) {
                 event.cancelEvent()
                 // accept the new position & rotation
                 debugMessage("Setbacked, cancelled event, now resyncing & silently accepting new position")

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -430,16 +430,13 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
         }
         // the disabler is really horrible yet simple,
         // you just silently accept the setback and then go back to where you were before the setback
+        // Sorry Jucku that I didn't port it to nextgen
         // TODO: make this better, also needs to handle respawning..
         if (miniblox) {
             if (packet is S08PacketPlayerPosLook && player.ticksExisted >= 100) {
                 event.cancelEvent()
                 // accept the new position & rotation
-                debugMessage("Setbacked, cancelled event, now resyncing & silently accepting new position")
-                // TODO: does this make the disabler better?
-                sendPacket(
-                    C01PacketChatMessage("/resync")
-                )
+                debugMessage("Setbacked, cancelled event & silently accepting new position")
                 sendPacket(
                     C06PacketPlayerPosLook(
                         packet.x,


### PR DESCRIPTION
This also exists in Sigma Rebase.
This will probably not work for vanilla fly since Miniblox might lag you back more than 6 blocks or so, and the disabler would try to teleport you back, but there would be a big enough distance. You can probably also get desynced with this disabler, haven't experienced it yet since the FPS on Legacy for me is really horrible after deleting my config and reloading. (not sure why, I don't have a dedicated GPU like 99.99% of the people have)
can't wait for @1zun4 to port my changes to Nextgen and pull a reverse-LiquidSquid (stop putting my bypasses in ~~legacy~~nextgen horrible bad client 2038) (I'm not going to do that because I don't care)!!!
Also, the disabler module code is very big, I think legacy should probably move these into their own folders & files.