### PR TITLE
chore: Feature Requests towards Nextgen only

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,17 +14,6 @@ body:
         - Provide as much context as possible in the details section. Include screenshots, screen recordings, links, references, or anything else you may consider relevant.
         - If you want to ask a question instead of requesting a feature, please use the [forum](https://forums.ccbluex.net/) instead.
 
-  - type: dropdown
-    attributes:
-      label: LiquidBounce Branch
-      description: Which edition of LiquidBounce does this feature request apply to?
-      options:
-        - Nextgen
-        - Legacy
-        - Both
-    validations:
-      required: true
-
   - type: textarea
     attributes:
       label: Describe your feature request.


### PR DESCRIPTION
This will be merged on 01/02/2025. After this date, all feature requests that are not for LiquidBounce Nextgen will be closed and new ones will NOT be accepted. Bug reports will still be allowed to be opened and worked on.

For a more detailed reason:

> Starting in February, I will be rejecting all feature requests for Legacy. 
> 
> Legacy is a far cry from what the name implies it should be. I can't and won't continue to compete with a client that is based on my work and distributed under the same name, and will now start adding more notices to Legacy itself about how it's planned to be abandoned.
> 
> I'm not going to immediately ask you to stop development, because I don't know what state LiquidBounce Legacy is in, which is probably not a good state - but continuing to add features to it at a rate that consistently breaks compatibility with every existing config, script, theme and all the reasons why people use LiquidBounce Legacy is not acceptable.
> 
> Another thing I've just noticed is that essentially LiquidBounce Legacy does not even include any way of knowing who developed it. There's no "Made by CCBlueX...", nor does the "Contributors" tab represent the actual contributors of Legacy (which is due to the fact that it pulls statistics from Nextgen instead).
> 
> I'm not 100% sure how I will add more notices to Legacy, but it has to be done, otherwise people will continue to think of Legacy as the LiquidBounce - even though it's not developed by us anymore.

For context: LiquidBounce Legacy was discontinued by our original development team in 2020. Since then it has only been developed by contributors and trusted project maintainers.