### PR TITLE
feat(ScriptAPI): timeout & interval

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.script.bindings.api
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
+import kotlinx.coroutines.*
+import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
+import org.graalvm.polyglot.Value
+
+@Suppress("unused")
+object ScriptAsyncApi : MinecraftShortcuts {
+
+    private val MainDispatcher = mc.asCoroutineDispatcher()
+
+    private val scope = CoroutineScope(MainDispatcher + SupervisorJob())
+
+    private var idCounter = 0
+
+    private val timeoutMap = Int2ObjectOpenHashMap<Job>()
+    private val intervalMap = Int2ObjectOpenHashMap<Job>()
+
+    @JvmName("setTimeout")
+    @Synchronized
+    fun setTimeout(callback: Value, delay: Long, vararg arguments: Any?): Int {
+        val id = ++idCounter
+        timeoutMap.put(id, scope.launch {
+            delay(delay)
+            callback.executeVoid(*arguments)
+        })
+        return id
+    }
+
+    @JvmName("clearTimeout")
+    @Synchronized
+    fun clearTimeout(id: Int) {
+        timeoutMap[id]?.cancel()
+        timeoutMap.remove(id)
+    }
+
+    @JvmName("setInterval")
+    @Synchronized
+    fun setInterval(callback: Value, delay: Long, vararg arguments: Any?): Int {
+        val id = ++idCounter
+        timeoutMap.put(id, scope.launch {
+            while (isActive) {
+                delay(delay)
+                callback.executeVoid(*arguments)
+            }
+        })
+        return id
+    }
+
+    @JvmName("clearInterval")
+    @Synchronized
+    fun clearInterval(id: Int) {
+        intervalMap[id]?.cancel()
+        intervalMap.remove(id)
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
 import org.graalvm.polyglot.Value
 import java.util.function.IntConsumer
 
-@Suppress("unused")
+@Suppress("SpreadOperator", "unused")
 object ScriptAsyncApi : MinecraftShortcuts {
 
     private val MainDispatcher = mc.asCoroutineDispatcher()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptAsyncApi.kt
@@ -21,9 +21,7 @@ package net.ccbluex.liquidbounce.script.bindings.api
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import kotlinx.coroutines.*
 import net.ccbluex.liquidbounce.features.module.MinecraftShortcuts
-import net.ccbluex.liquidbounce.utils.client.chat
 import org.graalvm.polyglot.Value
-import java.util.concurrent.atomic.AtomicInteger
 
 @Suppress("unused")
 object ScriptAsyncApi : MinecraftShortcuts {
@@ -32,36 +30,30 @@ object ScriptAsyncApi : MinecraftShortcuts {
 
     private val scope = CoroutineScope(MainDispatcher + SupervisorJob())
 
-    private var idCounter = AtomicInteger(0)
+    private var idCounter = 0
 
     private val timeoutMap = Int2ObjectOpenHashMap<Job>()
     private val intervalMap = Int2ObjectOpenHashMap<Job>()
 
     @JvmName("setTimeout")
-    @Synchronized
     fun setTimeout(callback: Value, delay: Long, vararg arguments: Any?): Int {
-        val id = idCounter.incrementAndGet()
+        val id = ++idCounter
         timeoutMap.put(id, scope.launch {
             delay(delay)
             callback.executeVoid(*arguments)
             timeoutMap.remove(id)
         })
-        chat("Debug: setTimeout id=$id")
         return id
     }
 
     @JvmName("clearTimeout")
-    @Synchronized
     fun clearTimeout(id: Int) {
-        timeoutMap[id]?.cancel()
-        timeoutMap.remove(id)
-        chat("Debug: clearTimeout id=$id")
+        timeoutMap.remove(id)?.cancel()
     }
 
     @JvmName("setInterval")
-    @Synchronized
     fun setInterval(callback: Value, delay: Long, vararg arguments: Any?): Int {
-        val id = idCounter.incrementAndGet()
+        val id = ++idCounter
         intervalMap.put(id, scope.launch {
             while (isActive) {
                 delay(delay)
@@ -69,16 +61,12 @@ object ScriptAsyncApi : MinecraftShortcuts {
                 intervalMap.remove(id)
             }
         })
-        chat("Debug: setInterval id=$id")
         return id
     }
 
     @JvmName("clearInterval")
-    @Synchronized
     fun clearInterval(id: Int) {
-        intervalMap[id]?.cancel()
-        intervalMap.remove(id)
-        chat("Debug: clearInterval id=$id")
+        intervalMap.remove(id)?.cancel()
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
@@ -58,7 +58,10 @@ object ScriptContextProvider {
         putMember("UnsafeThread", ScriptUnsafeThread)
 
         // timeout and interval functions
-        putMember("AsyncApi", ScriptAsyncApi)
+        putMember("setTimeout", ScriptAsyncApi.setTimeout)
+        putMember("clearTimeout", ScriptAsyncApi.clearTimeout)
+        putMember("setInterval", ScriptAsyncApi.setInterval)
+        putMember("clearInterval", ScriptAsyncApi.clearInterval)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
@@ -58,10 +58,7 @@ object ScriptContextProvider {
         putMember("UnsafeThread", ScriptUnsafeThread)
 
         // timeout and interval functions
-        putMember("setTimeout", ScriptAsyncApi::setTimeout)
-        putMember("clearTimeout", ScriptAsyncApi::clearTimeout)
-        putMember("setInterval", ScriptAsyncApi::setInterval)
-        putMember("clearInterval", ScriptAsyncApi::clearInterval)
+        putMember("AsyncApi", ScriptAsyncApi)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/api/ScriptContextProvider.kt
@@ -56,6 +56,12 @@ object ScriptContextProvider {
         putMember("ReflectionUtil", ScriptReflectionUtil())
         putMember("ParameterValidator", ScriptParameterValidator(bindings))
         putMember("UnsafeThread", ScriptUnsafeThread)
+
+        // timeout and interval functions
+        putMember("setTimeout", ScriptAsyncApi::setTimeout)
+        putMember("clearTimeout", ScriptAsyncApi::clearTimeout)
+        putMember("setInterval", ScriptAsyncApi::setInterval)
+        putMember("clearInterval", ScriptAsyncApi::clearInterval)
     }
 
 }


### PR DESCRIPTION
Note: body of `callback` will be always executed on the main thread (render thread).
example:
```js
const id = setTimeout(() => {
    Client.displayChatMessage("1111");
}, 5000);

clearTimeout(id);
```

Note: the Kotlin auto-generated `FunctionN` interfaces don't have `@FunctionalInterface` annotation, so it can't be cast by Polyglot.