### PR TITLE
chore(MCEF): change to version v1.3.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ kotlin_version=2.1.0
 # https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/
 fabric_kotlin_version=1.13.0+kotlin.2.1.0
 # mcef
-mcef_version=1.4.1-1.21.4
+mcef_version=1.3.3-1.21.4
 # mc-authlib
 mc_authlib_version=1.4.1
 # Recommended mods


### PR DESCRIPTION
The newer CEF had problems updating the buffer properly e.g. on resize, which is now fixed by going back to the older version of CEF, which did not have this problem.