### PR TITLE
fix: frame limit out of game uncapped

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInactivityFpsLimiter.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInactivityFpsLimiter.java
@@ -18,24 +18,21 @@
  */
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.render;
 
+import net.ccbluex.liquidbounce.utils.render.RefreshRateKt;
 import net.minecraft.client.option.InactivityFpsLimiter;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(InactivityFpsLimiter.class)
 public abstract class MixinInactivityFpsLimiter {
 
-    @Shadow
-    private int maxFps;
-
     /**
      * Removes frame rate limit
      */
     @ModifyConstant(method = "update", constant = @Constant(intValue = 60))
     private int getFramerateLimit(int original) {
-        return maxFps;
+        return RefreshRateKt.getRefreshRate();
     }
 
 }


### PR DESCRIPTION
This fixes an issue where the FPS of the main menu and other menus would be uncapped when not in-game, resulting in the main menu being drawn at, say, 2400 FPS. The FPS limit is now capped at the refresh rate, which is also the FPS at which the JCEF client is drawn, giving the appropriate smooth feel without wasting performance on unused frames.