### PR TITLE
feat: temporary solution for broken AMD drivers

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -55,6 +55,7 @@ import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.liquidbounce.integration.theme.component.ComponentOverlay
 import net.ccbluex.liquidbounce.lang.LanguageManager
 import net.ccbluex.liquidbounce.render.FontManager
+import net.ccbluex.liquidbounce.render.HAS_AMD_VEGA_APU
 import net.ccbluex.liquidbounce.render.ui.ItemImageAtlas
 import net.ccbluex.liquidbounce.script.ScriptManager
 import net.ccbluex.liquidbounce.utils.aiming.PostRotationExecutor
@@ -231,6 +232,12 @@ object LiquidBounce : EventListener {
             }
 
             ItemImageAtlas
+
+            if (HAS_AMD_VEGA_APU) {
+                logger.info("AMD Vega iGPU detected, enabling different line smooth handling. " +
+                    "If you believe this is a mistake, please create an issue at " +
+                    "https://github.com/CCBlueX/LiquidBounce/issues.")
+            }
         }.onSuccess {
             logger.info("Successfully loaded client!")
         }.onFailure(ErrorHandler::fatal)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
@@ -86,31 +86,33 @@ object ModuleTracers : ClientModule("Tracers", Category.RENDER) {
                 .rotatePitch((-Math.toRadians(camera.pitch.toDouble())).toFloat())
                 .rotateYaw((-Math.toRadians(camera.yaw.toDouble())).toFloat())
 
-            for (entity in filteredEntities) {
-                if (entity !is LivingEntity) {
-                    continue
-                }
+            longLines {
+                for (entity in filteredEntities) {
+                    if (entity !is LivingEntity) {
+                        continue
+                    }
 
-                val dist = player.distanceTo(entity) * 2.0F
+                    val dist = player.distanceTo(entity) * 2.0F
 
-                val color = if (useDistanceColor) {
-                    Color4b(
-                        Color.getHSBColor(
-                            (dist.coerceAtMost(viewDistance) / viewDistance) * (120.0f / 360.0f),
-                            1.0f,
-                            1.0f
+                    val color = if (useDistanceColor) {
+                        Color4b(
+                            Color.getHSBColor(
+                                (dist.coerceAtMost(viewDistance) / viewDistance) * (120.0f / 360.0f),
+                                1.0f,
+                                1.0f
+                            )
                         )
-                    )
-                } else if (entity is PlayerEntity && FriendManager.isFriend(entity.gameProfile.name)) {
-                    Color4b.BLUE
-                } else {
-                    EntityTaggingManager.getTag(entity).color ?: modes.activeChoice.getColor(entity) ?: continue
-                }
+                    } else if (entity is PlayerEntity && FriendManager.isFriend(entity.gameProfile.name)) {
+                        Color4b.BLUE
+                    } else {
+                        EntityTaggingManager.getTag(entity).color ?: modes.activeChoice.getColor(entity)
+                    }
 
-                val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3()
+                    val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3()
 
-                withColor(color) {
-                    drawLines(eyeVector, pos, pos, pos + Vec3(0f, entity.height, 0f))
+                    withColor(color) {
+                        drawLines(eyeVector, pos, pos, pos + Vec3(0f, entity.height, 0f))
+                    }
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -201,6 +201,7 @@ inline fun WorldRenderEnvironment.withPositionRelativeToCamera(pos: Vec3d, draw:
 inline fun WorldRenderEnvironment.longLines(draw: RenderEnvironment.() -> Unit) {
     if (!HAS_AMD_VEGA_APU) {
         draw()
+        return
     }
 
     GL11C.glDisable(GL11C.GL_LINE_SMOOTH)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -43,6 +43,19 @@ import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
+/**
+ * This variable should be used when rendering long lines, meaning longer than ~2 in 3d.
+ * [WorldRenderEnvironment.longLines] is available for this.
+ *
+ * Context:
+ * For some reason, newer drivers for AMD Vega iGPUs (about end 2023 until now) fail to correctly smooth lines.
+ *
+ * This has to be removed or limited to old driver versions when AMD actually fixes the bug in their drivers.
+ * But as of now, 01.02.2025, they haven't.
+ */
+val HAS_AMD_VEGA_APU = GL11C.glGetString(GL11C.GL_RENDERER)?.startsWith("AMD Radeon(TM) RX Vega") ?: false &&
+    GL11C.glGetString(GL11C.GL_VENDOR) == "ATI Technologies Inc."
+
 val FULL_BOX = Box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
 val EMPTY_BOX = Box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
@@ -179,6 +192,22 @@ inline fun WorldRenderEnvironment.withPositionRelativeToCamera(pos: Vec3d, draw:
         } finally {
             pop()
         }
+    }
+}
+
+/**
+ * Disables [GL11C.GL_LINE_SMOOTH] if [HAS_AMD_VEGA_APU].
+ */
+inline fun WorldRenderEnvironment.longLines(draw: RenderEnvironment.() -> Unit) {
+    if (!HAS_AMD_VEGA_APU) {
+        draw()
+    }
+
+    GL11C.glDisable(GL11C.GL_LINE_SMOOTH)
+    try {
+        draw()
+    } finally {
+        GL11C.glEnable(GL11C.GL_LINE_SMOOTH)
     }
 }
 


### PR DESCRIPTION
For some reason, newer drivers for AMD Vega APUs (about end 2023 until now) fail to correctly smooth lines. With this pull request the client no longer tries to do so when the user has an AMD Vega APU.
Related issue: #3373 (Not fixed, as no smoothing is now applied at all, but much better than no tracers at all).
For an actual fix, see #4532 (not finished).