### PR TITLE
feat: dynamically choose module description position in click gui

### DIFF
--- a/src-theme/src/routes/clickgui/Description.svelte
+++ b/src-theme/src/routes/clickgui/Description.svelte
@@ -7,13 +7,26 @@
     description.subscribe((v) => {
         data = v;
     });
+
+    let element: HTMLElement | null = null;
+    let left = 0;
+
+    $: {
+        if (data?.x !== undefined && element !== null) {
+            if (data.anchor === "left") {
+                left = data.x - element.clientWidth - 20;
+            } else {
+                left = data.x + 20;
+            }
+        }
+    }
 </script>
 
 {#key data}
     {#if data !== null}
         <div transition:fly|global={{duration: 200, x: -15}} class="description-wrapper"
-             style="top: {data.y}px; left: {data.x + 20}px;">
-            <div class="description">
+             style="top: {data.y}px; left: {left}px;" bind:this={element}>
+            <div class="description" class:right={data?.anchor === "left"}>
                 <div class="text">{data.description}</div>
             </div>
         </div>
@@ -47,6 +60,14 @@
       left: -8px;
       top: 50%;
       transform: translateY(-50%);
+    }
+
+    &.right {
+      &::before {
+        transform: translateY(-50%) rotate(180deg);
+        left: unset;
+        right: -8px;
+      }
     }
   }
 

--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -58,17 +58,35 @@
     }
 
     function setDescription() {
-        const y = (moduleNameElement?.getBoundingClientRect().top ?? 0) + ((moduleNameElement?.clientHeight ?? 0) / 2);
-        const x = moduleNameElement?.getBoundingClientRect().right ?? 0;
+        if (!moduleNameElement) return;
+
+        const boundingRect = moduleNameElement.getBoundingClientRect();
+        const y = (boundingRect.top + (moduleNameElement.clientHeight / 2)) * (2 / $scaleFactor);
+
         let moduleDescription = description;
         if (aliases.length > 0) {
             moduleDescription += ` (aka ${aliases.map(name => $spaceSeperatedNames ? convertToSpacedString(name) : name).join(", ")})`;
         }
-        descriptionStore.set({
-            x: x * (2 / $scaleFactor),
-            y: y * (2 / $scaleFactor),
-            description: moduleDescription
-        });
+
+        // If element is less than 300px from the right, display description on the left
+        if (window.innerWidth - boundingRect.right > 300) {
+            const x = boundingRect.right * (2 / $scaleFactor);
+            descriptionStore.set({
+                x,
+                y,
+                anchor: "right",
+                description: moduleDescription
+            });
+        } else {
+            const x = boundingRect.left * (2 / $scaleFactor);
+
+            descriptionStore.set({
+                x,
+                y,
+                anchor: "left",
+                description: moduleDescription
+            });
+        }
     }
 
     async function toggleExpanded() {

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -2,6 +2,7 @@ import {type Writable, writable} from "svelte/store";
 
 export interface TDescription {
     description: string;
+    anchor: "left" | "right",
     x: number;
     y: number;
 }


### PR DESCRIPTION
Currently, descriptions are always displayed on the left. Even when there is barely any space to the left of the panel. This pull request changes this behavior so that the description will be displayed to the right of the panel if there is little space on the left.

Addresses https://github.com/CCBlueX/LiquidBounce/issues/5297


https://github.com/user-attachments/assets/986d966e-74ac-4e3f-bbdf-7e22e528cf15

