### PR TITLE
refactor: close InputStream/Reader on decoding

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/util/GsonExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/util/GsonExtensions.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.config.gson.util
 
 import com.google.gson.*
-import com.google.gson.reflect.TypeToken
+import net.ccbluex.liquidbounce.config.gson.publicGson
 import java.io.InputStream
 import java.io.Reader
 
@@ -30,19 +30,20 @@ import java.io.Reader
  * Decode JSON content
  */
 inline fun <reified T> decode(stringJson: String): T =
-    Gson().fromJson(stringJson, object : TypeToken<T>() {}.type)
+    stringJson.reader().use(::decode)
 
 /**
- * Decode JSON content from an Input Stream
+ * Decode JSON content from an [InputStream] and close it
  */
 inline fun <reified T> decode(inputStream: InputStream): T =
-    decode(inputStream.bufferedReader())
+    inputStream.bufferedReader().use(::decode)
 
 /**
- * Decode JSON content from a Reader
+ * Decode JSON content from a [Reader] and close it
  */
-inline fun <reified T> decode(reader: Reader): T =
-    Gson().fromJson(reader, object : TypeToken<T>() {}.type)
+inline fun <reified T> decode(reader: Reader): T = reader.use {
+    publicGson.fromJson(reader, T::class.java)
+}
 
 fun String.toJsonPrimitive(): JsonPrimitive = JsonPrimitive(this)
 fun Char.toJsonPrimitive(): JsonPrimitive = JsonPrimitive(this)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/validation/HashValidator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/validation/HashValidator.kt
@@ -5,7 +5,6 @@ import net.ccbluex.liquidbounce.config.gson.util.decode
 import net.ccbluex.liquidbounce.utils.client.logger
 import org.apache.commons.codec.digest.DigestUtils
 import java.io.File
-import java.io.FileInputStream
 import kotlin.concurrent.thread
 
 private const val HASH_FILE_NAME = ".hash"
@@ -33,10 +32,7 @@ object HashValidator {
 
     private fun validateHashFile(hashFile: File) {
         val delete = runCatching {
-            val hashes = FileInputStream(hashFile).use {
-                decode<Map<String, String>>(it)
-            }
-
+            val hashes = decode<Map<String, String>>(hashFile.inputStream())
             shouldDelete(hashFile, hashes)
         }.onFailure {
             logger.warn("Invalid hash file ${hashFile.absolutePath}", it)
@@ -80,7 +76,7 @@ object HashValidator {
 
                 // Read the file, hash it and compare it to the hash in the hash file
                 // Use the InputStream, don't read the full file
-                val sha256Hex = DigestUtils.sha256Hex(resolveSibling.inputStream())
+                val sha256Hex = resolveSibling.inputStream().use(DigestUtils::sha256Hex)
 
                 if (!sha256Hex.equals(checkedFile.value, ignoreCase = true)) {
                     return true


### PR DESCRIPTION
Also use `publicGson` for decoding instead of creating new instances