### PR TITLE
Fix macOS blur issue

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHud.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHud.kt
@@ -39,7 +39,6 @@ import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.markAsError
 import net.ccbluex.liquidbounce.utils.entity.RenderedEntities
-import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.screen.DisconnectedScreen
 
 /**
@@ -67,10 +66,7 @@ object ModuleHud : ClientModule("HUD", Category.RENDER, state = true, hide = tru
     }
 
     val isBlurable
-        get() = blur && !(mc.options.hudHidden && mc.currentScreen == null) &&
-            // Only blur on Windows and Linux - Mac seems to have issues with it
-            // TODO: fix blur on macOS
-            !MinecraftClient.IS_SYSTEM_MAC
+        get() = blur && !(mc.options.hudHidden && mc.currentScreen == null)
 
     init {
         tree(Configurable("In-built", components as MutableList<Value<*>>))

--- a/src/main/resources/resources/liquidbounce/shaders/sobel.vert
+++ b/src/main/resources/resources/liquidbounce/shaders/sobel.vert
@@ -1,7 +1,7 @@
-#version 150
+#version 410 core
 
-in vec4 Position;
-in vec2 UV0;
+layout (location = 0) in vec4 Position;
+layout (location = 1) in vec2 UV0;
 
 out vec2 fragTexCoord;
 


### PR DESCRIPTION
As the [comment](https://github.com/CCBlueX/LiquidBounce/blob/3202df834d8c9608d37ff6c7da6bcd6cc7f4ea62/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleHud.kt#L71) says, 

> Only blur on Windows and Linux - Mac seems to have issues with it

I don't know what the principle is, but is solved anyway.

Tested on macOS 15.3