### PR TITLE
fix(KillAura): unwanted shield unblock

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -207,6 +207,10 @@ object KillAuraAutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking"
     fun stopBlocking(pauses: Boolean = false): Boolean {
         if (!pauses) {
             blockVisual = false
+
+            if (mc.options.useKey.isPressed) {
+                return false
+            }
         }
 
         // We do not want the player to stop eating or else. Only when he blocks.


### PR DESCRIPTION
Fixes the shield being unblocked when holding it manually.