### PR TITLE
chore(mcef): bump version to 1.3.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ kotlin_version=2.1.0
 # https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/
 fabric_kotlin_version=1.13.0+kotlin.2.1.0
 # mcef
-mcef_version=1.3.4-1.21.4
+mcef_version=1.3.5-1.21.4
 # mc-authlib
 mc_authlib_version=1.4.1
 # Recommended mods


### PR DESCRIPTION
It now tries different hosts to download MCEF resources if the download fails. The hosts are:
- https://api.liquidbounce.net/
- https://api.ccbluex.net/
- http://nossl.api.liquidbounce.net/