### PR TITLE
feat(Binding): Ability to bind keys to mouse buttons

### DIFF
--- a/src-theme/src/integration/events.ts
+++ b/src-theme/src/integration/events.ts
@@ -19,6 +19,14 @@ export interface KeyboardKeyEvent {
     screen: Screen | undefined;
 }
 
+export interface MouseButtonEvent {
+    key: string;
+    button: number;
+    action: number;
+    mods: number;
+    screen: Screen | undefined;
+}
+
 export interface ScaleFactorChangeEvent {
     scaleFactor: number;
 }

--- a/src-theme/src/routes/clickgui/setting/KeySetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/KeySetting.svelte
@@ -4,7 +4,7 @@
     import {getPrintableKeyName} from "../../../integration/rest";
     import {createEventDispatcher} from "svelte";
     import {listen} from "../../../integration/ws";
-    import type {KeyboardKeyEvent} from "../../../integration/events";
+    import type {KeyboardKeyEvent, MouseButtonEvent} from "../../../integration/events";
 
     export let setting: ModuleSetting;
 
@@ -13,6 +13,7 @@
     const dispatch = createEventDispatcher();
     const UNKNOWN_KEY = "key.keyboard.unknown";
 
+    let isHovered = false;
     let binding = false;
     let printableKeyName = "";
 
@@ -59,10 +60,34 @@
 
         dispatch("change");
     });
+
+    listen("mouseButton", async (e: MouseButtonEvent) => {
+        if (e.screen === undefined || !e.screen.class.startsWith("net.ccbluex.liquidbounce") ||
+            !(e.screen.title === "ClickGUI" || e.screen.title === "VS-CLICKGUI")) {
+            return;
+        }
+
+        if (!binding || (e.button === 0 && isHovered)) {
+            return;
+        }
+
+        binding = false;
+
+        cSetting.value = e.key;
+
+        setting = {...cSetting};
+
+        dispatch("change");
+    })
 </script>
 
 <div class="setting">
-    <button class="change-bind" on:click={toggleBinding}>
+    <button
+            class="change-bind"
+            on:click={toggleBinding}
+            on:mouseenter={() => isHovered = true}
+            on:mouseleave={() => isHovered = false}
+    >
         {#if !binding}
             <div class="name">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}:</div>
 

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouse.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouse.java
@@ -25,9 +25,13 @@ import com.llamalad7.mixinextras.sugar.Local;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.*;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleZoom;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.Mouse;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.util.InputUtil;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -35,12 +39,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Mouse.class)
 public class MixinMouse {
 
+    @Shadow
+    @Final
+    private MinecraftClient client;
+
     /**
      * Hook mouse button event
      */
     @Inject(method = "onMouseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;getOverlay()Lnet/minecraft/client/gui/screen/Overlay;", shift = At.Shift.BEFORE, ordinal = 0))
     private void hookMouseButton(long window, int button, int action, int mods, CallbackInfo callbackInfo) {
-        EventManager.INSTANCE.callEvent(new MouseButtonEvent(button, action, mods));
+        EventManager.INSTANCE.callEvent(new MouseButtonEvent(
+                InputUtil.Type.MOUSE.createFromCode(button),
+                button,
+                action,
+                mods,
+                this.client.currentScreen
+        ));
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/WindowEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/WindowEvents.kt
@@ -34,7 +34,14 @@ class WindowResizeEvent(val width: Int, val height: Int) : Event()
 class FrameBufferResizeEvent(val width: Int, val height: Int) : Event()
 
 @Nameable("mouseButton")
-class MouseButtonEvent(val button: Int, val action: Int, val mods: Int) : Event()
+@WebSocketEvent
+class MouseButtonEvent(
+    val key: InputUtil.Key,
+    val button: Int,
+    val action: Int,
+    val mods: Int,
+    val screen: Screen? = null
+) : Event()
 
 @Nameable("mouseScroll")
 class MouseScrollEvent(val horizontal: Double, val vertical: Double) : Event()


### PR DESCRIPTION
now [bind] and [key] can be bound to mouse buttons

https://github.com/user-attachments/assets/859ffd5c-0a31-45ed-8289-1c942e792c0d

closes #5616 
closes #5509

# NOTE
to work well with [key] settings, I would recommend accepting this pull request #5614 because in it I handle [both events](https://github.com/CCBlueX/LiquidBounce/blob/64f541f271a9ec6577bcf8fb8e12a2ca33eb2ab6/src/main/kotlin/net/ccbluex/liquidbounce/config/types/KeyValue.kt#L33-#L46), from the keyboard and from the mouse