### PR TITLE
refactor(legacy): abstract Event class

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/event/Event.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/event/Event.kt
@@ -5,9 +5,9 @@
  */
 package net.ccbluex.liquidbounce.event
 
-open class Event
+abstract class Event
 
-open class CancellableEvent : Event() {
+abstract class CancellableEvent : Event() {
 
     /**
      * Let you know if the event is cancelled


### PR DESCRIPTION
We should never create an instance of `Event`