### PR TITLE
fix(Rotation): raycast fails when spot inside box

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/destroy/SubmoduleCrystalDestroyer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/destroy/SubmoduleCrystalDestroyer.kt
@@ -85,8 +85,7 @@ object SubmoduleCrystalDestroyer : ToggleableConfigurable(ModuleCrystalAura, "De
                 range = range.toDouble(),
                 wallsRange = wallsRange.toDouble(),
                 futureTarget = base,
-                prioritizeVisible = prioritizeVisibleFaces,
-                allowInside = true
+                prioritizeVisible = prioritizeVisibleFaces
             ) ?: return
 
         queueDestroy(rotation, target, base, eyePos, vec3d)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
@@ -295,16 +295,16 @@ fun raytraceBox(
     visibilityPredicate: VisibilityPredicate = BoxVisibilityPredicate(),
     rotationPreference: RotationPreference = LeastDifferencePreference.LEAST_DISTANCE_TO_CURRENT_ROTATION,
     futureTarget: Box? = null,
-    prioritizeVisible: Boolean = true,
-    allowInside: Boolean = false
+    prioritizeVisible: Boolean = true
 ): VecRotation? {
     val rangeSquared = range * range
     val wallsRangeSquared = wallsRange * wallsRange
 
     val preferredSpot = rotationPreference.getPreferredSpot(eyes, range)
-    var preferredSpotOnBox = box.raycast(eyes, preferredSpot).getOrNull()
-    if (preferredSpotOnBox == null && box.contains(eyes) && allowInside) {
-        preferredSpotOnBox = eyes
+    var preferredSpotOnBox = if (box.contains(eyes)) {
+        preferredSpot
+    } else {
+        box.raycast(eyes, preferredSpot).getOrNull()
     }
 
     if (preferredSpotOnBox != null) {
@@ -369,7 +369,12 @@ private fun considerSpot(
 ) {
     // Elongate the line so we have no issues with fp-precision
     val raycastTarget = (preferredSpot - eyes) * 2.0 + eyes
-    val spotOnBox = box.raycast(eyes, raycastTarget).getOrNull() ?: return
+
+    val spotOnBox = if (box.contains(raycastTarget)) {
+        raycastTarget
+    } else {
+        box.raycast(eyes, raycastTarget).getOrNull() ?: return
+    }
     val distance = eyes.squaredDistanceTo(spotOnBox)
 
     val visible = visibilityPredicate.isVisible(eyes, raycastTarget)
@@ -389,7 +394,7 @@ private fun considerSpot(
  *
  * Will return `true` if the player is inside the [box].
  */
-fun canSeeBox(eyes: Vec3d, box: Box, range: Double, wallsRange: Double, expectedTarget: BlockPos? = null, ): Boolean {
+fun canSeeBox(eyes: Vec3d, box: Box, range: Double, wallsRange: Double, expectedTarget: BlockPos? = null): Boolean {
     if (box.contains(eyes)) {
         return true
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
@@ -301,7 +301,7 @@ fun raytraceBox(
     val wallsRangeSquared = wallsRange * wallsRange
 
     val preferredSpot = rotationPreference.getPreferredSpot(eyes, range)
-    var preferredSpotOnBox = if (box.contains(eyes)) {
+    var preferredSpotOnBox = if (box.contains(preferredSpot)) {
         preferredSpot
     } else {
         box.raycast(eyes, preferredSpot).getOrNull()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationFinding.kt
@@ -301,7 +301,7 @@ fun raytraceBox(
     val wallsRangeSquared = wallsRange * wallsRange
 
     val preferredSpot = rotationPreference.getPreferredSpot(eyes, range)
-    var preferredSpotOnBox = if (box.contains(preferredSpot)) {
+    var preferredSpotOnBox = if (box.contains(eyes) && box.contains(preferredSpot)) {
         preferredSpot
     } else {
         box.raycast(eyes, preferredSpot).getOrNull()
@@ -370,7 +370,7 @@ private fun considerSpot(
     // Elongate the line so we have no issues with fp-precision
     val raycastTarget = (preferredSpot - eyes) * 2.0 + eyes
 
-    val spotOnBox = if (box.contains(raycastTarget)) {
+    val spotOnBox = if (box.contains(eyes) && box.contains(raycastTarget)) {
         raycastTarget
     } else {
         box.raycast(eyes, raycastTarget).getOrNull() ?: return


### PR DESCRIPTION
When we are inside a box, we cannot raycast to a point on the box. We should just use our preferred spot, since we are already inside the box and therefore aiming correctly anyway.