### PR TITLE
feat(AutoArmor): Save Armor with low remaining durability

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/utils/client/vfp/VfpCompatibility.java
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/client/vfp/VfpCompatibility.java
@@ -150,17 +150,4 @@ public enum VfpCompatibility {
             return false;
         }
     }
-
-    public boolean isNewerThanOrEqual1_19_4() {
-        try {
-            var version = ViaFabricPlus.getImpl().getTargetVersion();
-
-            // Check if the version is older or equal than 1.19.4
-            return version.newerThanOrEqualTo(ProtocolVersion.v1_19_4);
-        } catch (Throwable throwable) {
-            LiquidBounce.INSTANCE.getLogger().error("Failed to check if 1.19.4", throwable);
-            return false;
-        }
-    }
-
 }

--- a/src/main/java/net/ccbluex/liquidbounce/utils/client/vfp/VfpCompatibility.java
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/client/vfp/VfpCompatibility.java
@@ -151,4 +151,16 @@ public enum VfpCompatibility {
         }
     }
 
+    public boolean isNewerThanOrEqual1_19_4() {
+        try {
+            var version = ViaFabricPlus.getImpl().getTargetVersion();
+
+            // Check if the version is older or equal than 1.19.4
+            return version.newerThanOrEqualTo(ProtocolVersion.v1_19_4);
+        } catch (Throwable throwable) {
+            LiquidBounce.INSTANCE.getLogger().error("Failed to check if 1.19.4", throwable);
+            return false;
+        }
+    }
+
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ArmorEvaluation.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ArmorEvaluation.kt
@@ -57,11 +57,20 @@ object ArmorEvaluation {
         return armorPiecesGroupedByType
     }
 
-    fun getArmorComparatorFor(currentKit: Map<EquipmentSlot, ArmorPiece?>, durabilityThreshold: Int = Int.MIN_VALUE): ArmorComparator {
-        return getArmorComparatorForParameters(ArmorKitParameters.getParametersForSlots(currentKit), durabilityThreshold)
+    fun getArmorComparatorFor(
+        currentKit: Map<EquipmentSlot, ArmorPiece?>,
+        durabilityThreshold: Int = Int.MIN_VALUE
+    ): ArmorComparator {
+        return getArmorComparatorForParameters(
+            ArmorKitParameters.getParametersForSlots(currentKit),
+            durabilityThreshold
+        )
     }
 
-    fun getArmorComparatorForParameters(currentParameters: ArmorKitParameters, durabilityThreshold: Int = Int.MIN_VALUE): ArmorComparator {
+    fun getArmorComparatorForParameters(
+        currentParameters: ArmorKitParameters,
+        durabilityThreshold: Int = Int.MIN_VALUE
+    ): ArmorComparator {
         return ArmorComparator(EXPECTED_DAMAGE, currentParameters, durabilityThreshold)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ArmorEvaluation.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ArmorEvaluation.kt
@@ -15,7 +15,8 @@ object ArmorEvaluation {
     private const val EXPECTED_DAMAGE: Float = 6.0F
 
     fun findBestArmorPieces(
-        slots: List<ItemSlot> = Slots.All
+        slots: List<ItemSlot> = Slots.All,
+        durabilityThreshold: Int = Int.MIN_VALUE
     ): Map<EquipmentSlot, ArmorPiece?> {
         val armorPiecesGroupedByType = groupArmorByType(slots)
 
@@ -26,7 +27,7 @@ object ArmorEvaluation {
 
         // Run some passes in which we try to find best armor pieces based on the parameters of the last pass
         for (ignored in 0 until 2) {
-            val comparator = getArmorComparatorFor(currentBestPieces)
+            val comparator = getArmorComparatorFor(currentBestPieces, durabilityThreshold)
 
             currentBestPieces = armorPiecesGroupedByType.mapValues { it.value.maxWithOrNull(comparator) }
         }
@@ -56,12 +57,12 @@ object ArmorEvaluation {
         return armorPiecesGroupedByType
     }
 
-    fun getArmorComparatorFor(currentKit: Map<EquipmentSlot, ArmorPiece?>): ArmorComparator {
-        return getArmorComparatorForParameters(ArmorKitParameters.getParametersForSlots(currentKit))
+    fun getArmorComparatorFor(currentKit: Map<EquipmentSlot, ArmorPiece?>, durabilityThreshold: Int = Int.MIN_VALUE): ArmorComparator {
+        return getArmorComparatorForParameters(ArmorKitParameters.getParametersForSlots(currentKit), durabilityThreshold)
     }
 
-    fun getArmorComparatorForParameters(currentParameters: ArmorKitParameters): ArmorComparator {
-        return ArmorComparator(EXPECTED_DAMAGE, currentParameters)
+    fun getArmorComparatorForParameters(currentParameters: ArmorKitParameters, durabilityThreshold: Int = Int.MIN_VALUE): ArmorComparator {
+        return ArmorComparator(EXPECTED_DAMAGE, currentParameters, durabilityThreshold)
     }
 
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -29,16 +29,22 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
      */
     @Suppress("unused")
     private val armorAutoSaveHandler = tickHandler {
-        if (player.isCreative || player.isSpectator) {
-            return@tickHandler
-        }
+        val conditions = booleanArrayOf(
+            // Module checks
+            ModuleAutoArmor.running,
+            AutoArmorSaveArmor.enabled,
 
-        if (!ModuleAutoArmor.running || !AutoArmorSaveArmor.enabled) {
-            return@tickHandler
-        }
+            // Game modes
+            !player.isSpectator,
+            !player.isCreative,
 
-        // the module will save armor automatically if open inventory isn't required
-        if (!ModuleAutoArmor.inventoryConstraints.requiresOpenInventory || !autoOpen) {
+            // The module will automatically save armor if opening the inventory isn't required.
+            ModuleAutoArmor.inventoryConstraints.requiresOpenInventory,
+            autoOpen
+        )
+
+        // All conditions must be met for this feature to work.
+        if (conditions.any { it == false }) {
             return@tickHandler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -1,8 +1,122 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.utils.client.isNewerThanOrEqual1_19_4
+import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
+import net.ccbluex.liquidbounce.utils.item.durability
+import net.ccbluex.liquidbounce.utils.item.type
+import net.minecraft.client.gui.screen.ingame.HandledScreen
+import net.minecraft.client.gui.screen.ingame.InventoryScreen
+import net.minecraft.item.ArmorItem
 
 object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor", true) {
     val durabilityThreshold by int("DurabilityThreshold", 24, 0..100)
-    val autoOpen by boolean("AutoOpenInventory", true)
+    private val autoOpen by boolean("AutoOpenInventory", true)
+
+    private var hasOpenedInventory = false
+
+    /**
+     * Opens the inventory to save armor (as if the player has opened it manually) if the following conditions are met:
+     * - The module is told to save armor and there is a replacement :)
+     * - The inventory constraints require open inventory
+     * (Otherwise, the inventory will be open automatically in a silent way and the armor will be saved)
+     * - There is no replacement from the hotbar
+     * (If there are some pieces that can be replaced by the pieces from the hotbar,
+     * they will be used first, without opening the inventory)
+     */
+    @Suppress("unused")
+    private val armorAutoSaveHandler = tickHandler {
+        if (!ModuleAutoArmor.running || !AutoArmorSaveArmor.enabled) {
+            return@tickHandler
+        }
+
+        // the module will save armor automatically if open inventory isn't required
+        if (!ModuleAutoArmor.inventoryConstraints.requiresOpenInventory || !autoOpen) {
+            return@tickHandler
+        }
+
+        val armorToEquipWithSlots = ArmorEvaluation
+            .findBestArmorPieces(durabilityThreshold = durabilityThreshold)
+            .values
+            .filterNotNull()
+            .filter { !it.isAlreadyEquipped && it.itemSlot.itemStack.item is ArmorItem }
+
+        val hasAnyHotBarReplacement = ModuleAutoArmor.useHotbar && isNewerThanOrEqual1_19_4 &&
+            armorToEquipWithSlots.any { it.itemSlot is HotbarItemSlot }
+
+        // the new pieces from the hotbar have a higher priority
+        // due to the replacement speed (it's much faster, it makes sense to replace them first),
+        // so it waits until all pieces from hotbar are replaced
+        if (hasAnyHotBarReplacement) {
+            return@tickHandler
+        }
+
+        val playerArmor = player.inventory.armor.filter { it.item is ArmorItem }
+        val armorToEquip = armorToEquipWithSlots.map { it.itemSlot.itemStack.item as ArmorItem }
+
+        val hasArmorToReplace = playerArmor.any { armorStack ->
+            armorStack.durability <= durabilityThreshold &&
+                armorToEquip.any { it.type() == (armorStack.item as ArmorItem).type() }
+        }
+
+        // closes the inventory if the armor is replaced.
+        closeInventory(hasArmorToEquip = armorToEquip.isNotEmpty())
+
+        // tries to close the previous screen and open the inventory
+        openInventory(hasArmorToReplace = hasArmorToReplace)
+    }
+
+    /**
+     * Waits and closes the inventory after the armor is replaced.
+     */
+    private suspend fun Sequence.closeInventory(hasArmorToEquip: Boolean) {
+        if (!hasOpenedInventory || hasArmorToEquip) {
+            return
+        }
+
+        this@AutoArmorSaveArmor.hasOpenedInventory = false
+        waitTicks(ModuleAutoArmor.inventoryConstraints.closeDelay.random())
+
+        // the current screen might change while the module is waiting
+        if (mc.currentScreen is InventoryScreen) {
+            player.closeHandledScreen()
+        }
+    }
+
+    /**
+     * Closes the previous game screen and opens the inventory.
+     */
+    private suspend fun Sequence.openInventory(hasArmorToReplace : Boolean) {
+        while (hasArmorToReplace && mc.currentScreen !is InventoryScreen) {
+
+            if (mc.currentScreen is HandledScreen<*>) {
+                // closes chests/crating tables/etc.
+                // TODO: well, it doesn't... :(
+                //  When the player is in a chest/anvil/crafting table/etc.,
+                //  hasArmorToReplace is always false...
+                //  The server simply doesn't let the player know anything new about his armor :/
+                //  the client knows only the state of the armor before opening the screen,
+                //  the client doesn't receive any updates on the armor slots until the screen is closed.
+                //  However, the client still gets updates on the armor of other players :/
+
+                // TODO: since the client get no updates on the armor while a chest/crating table/etc. is open,
+                //  try to approximately track the durability of the player's armor manually
+                //  when the player receives damage and chest/crating table/etc. is open :)
+                player.closeHandledScreen()
+            } else if (mc.currentScreen != null) {
+                // closes ClickGUI, game chat, etc. to save some armor :)
+                mc.currentScreen!!.close()
+            }
+
+            waitTicks(1)    // TODO: custom delay?
+
+            // again, the current screen might change while the module is waiting
+            if (mc.currentScreen == null) {
+                mc.setScreen(InventoryScreen(player))
+                hasOpenedInventory = true
+            }
+        }
+    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -66,7 +66,6 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
         prevArmor = player.armor
 
         // closes the current screen so that the armor slots are synced again
-        // TODO: if possible, make it close the screen only if there is a replacement
         if (hasLostArmorPiece) {
             player.closeHandledScreen()
             return@tickHandler
@@ -127,14 +126,14 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
         while (hasArmorToReplace && mc.currentScreen !is InventoryScreen) {
 
             if (mc.currentScreen is HandledScreen<*>) {
-                // closes chests/crating tables/etc.
+                // closes chests/crating tables/etc. (it never happens)
                 player.closeHandledScreen()
             } else if (mc.currentScreen != null) {
                 // closes ClickGUI, game chat, etc. to save some armor :)
                 mc.currentScreen!!.close()
             }
 
-            waitTicks(1)    // TODO: custom delay?
+            waitTicks(1)
 
             // again, the current screen might change while the module is waiting
             if (mc.currentScreen == null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -1,0 +1,8 @@
+package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
+
+import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
+
+object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor", true) {
+    val durabilityThreshold by int("DurabilityThreshold", 24, 0..100)
+    val autoOpen by boolean("AutoOpenInventory", true)
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -1,9 +1,9 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 
+import net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor.ModuleAutoArmor.UseHotbar
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.tickHandler
-import net.ccbluex.liquidbounce.utils.client.isNewerThanOrEqual1_19_4
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.item.durability
 import net.ccbluex.liquidbounce.utils.item.type
@@ -83,8 +83,11 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
             .filterNotNull()
             .filter { !it.isAlreadyEquipped && it.itemSlot.itemStack.item is ArmorItem }
 
-        val hasAnyHotBarReplacement = ModuleAutoArmor.useHotbar && isNewerThanOrEqual1_19_4 &&
+        val hasAnyHotBarReplacement = booleanArrayOf(
+            UseHotbar.enabled,
+            UseHotbar.canReplaceEquippedArmor,
             armorToEquipWithSlots.any { it.itemSlot is HotbarItemSlot }
+        ).all { it }
 
         // the new pieces from the hotbar have a higher priority
         // due to the replacement speed (it's much faster, it makes sense to replace them first),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -85,7 +85,7 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
 
         val hasAnyHotBarReplacement = booleanArrayOf(
             UseHotbar.enabled,
-            UseHotbar.canReplaceEquippedArmor,
+            UseHotbar.canSwapArmor,
             armorToEquipWithSlots.any { it.itemSlot is HotbarItemSlot }
         ).all { it }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -20,21 +20,16 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor.AutoArmorSaveArmor.durabilityThreshold
 import net.ccbluex.liquidbounce.utils.client.isNewerThanOrEqual1_19_4
 import net.ccbluex.liquidbounce.utils.inventory.ArmorItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.*
 import net.ccbluex.liquidbounce.utils.item.ArmorPiece
-import net.ccbluex.liquidbounce.utils.item.durability
 import net.ccbluex.liquidbounce.utils.item.isNothing
-import net.ccbluex.liquidbounce.utils.item.type
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
-import net.minecraft.client.gui.screen.ingame.HandledScreen
-import net.minecraft.client.gui.screen.ingame.InventoryScreen
-import net.minecraft.item.ArmorItem
 import net.minecraft.item.Items
 
 /**
@@ -44,113 +39,26 @@ import net.minecraft.item.Items
  */
 object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
 
-    private val inventoryConstraints = tree(PlayerInventoryConstraints())
+    val inventoryConstraints = tree(PlayerInventoryConstraints())
 
     /**
-     * Should the module use the hotbar to equip armor pieces.
+     * Should the module use the hotbar to equip armor pieces?
      * If disabled, it will only use inventory moves.
      */
-    private val useHotbar by boolean("Hotbar", true)
-    private var hasOpenedInventory = false
+    val useHotbar by boolean("Hotbar", true)
 
     init {
         tree(AutoArmorSaveArmor)
     }
 
-    /**
-     * Opens the inventory to save armor (as if the player has opened it manually) if the following conditions are met:
-     * - The module is told to save armor and there is a replacement :)
-     * - The inventory constraints require open inventory
-     * (Otherwise, the inventory will be open automatically in a silent way and the armor will be saved)
-     * - There is no replacement from the hotbar
-     * (If there are some pieces that can be replaced by the pieces from the hotbar,
-     * they will be used first, without opening the inventory)
-     */
     @Suppress("unused")
-    private val armorAutoSaveHandler = tickHandler {
-        if (!AutoArmorSaveArmor.enabled) {
-            return@tickHandler
-        }
-
-        // the module will save armor automatically if open inventory isn't required
-        if (!inventoryConstraints.requiresOpenInventory || !AutoArmorSaveArmor.autoOpen) {
-            return@tickHandler
-        }
-
-        val armorToEquipWithSlots = ArmorEvaluation
-            .findBestArmorPieces(durabilityThreshold = AutoArmorSaveArmor.durabilityThreshold)
-            .values
-            .filterNotNull()
-            .filter { !it.isAlreadyEquipped && it.itemSlot.itemStack.item is ArmorItem }
-
-        val hasAnyHotBarReplacement = useHotbar && isNewerThanOrEqual1_19_4 && armorToEquipWithSlots.any { it.itemSlot is HotbarItemSlot }
-        if (hasAnyHotBarReplacement) {
-            // the new pieces from the hotbar have a higher priority
-            // due to the replacement speed (it's much faster, it makes sense to replace them first),
-            // so it waits until all pieces from hotbar are replaced
-            return@tickHandler
-        }
-
-        val playerArmor = player.inventory.armor.filter { it.item is ArmorItem }
-        val armorToEquip = armorToEquipWithSlots.map { it.itemSlot.itemStack.item as ArmorItem }
-
-        val hasArmorToReplace = playerArmor.any { armorStack ->
-            armorStack.durability <= AutoArmorSaveArmor.durabilityThreshold &&
-                armorToEquip.any { it.type() == (armorStack.item as ArmorItem).type() }
-        }
-
-        // closes the inventory after the armor is replaced
-        if (hasOpenedInventory && armorToEquip.isEmpty()) {
-            hasOpenedInventory = false
-            waitTicks(inventoryConstraints.closeDelay.random())
-
-            // the current screen might change while the module is waiting
-            if (mc.currentScreen is InventoryScreen) {
-                player.closeHandledScreen()
-            }
-        }
-
-        // tries to close the previous screen and open the inventory
-        while (hasArmorToReplace && mc.currentScreen !is InventoryScreen) {
-
-            if (mc.currentScreen is HandledScreen<*>) {
-                // closes chests/crating tables/etc.
-                // TODO: well, it doesn't... :(
-                //  When the player is in a chest/anvil/crafting table/etc.,
-                //  hasArmorToReplace is always false...
-                //  The server simply doesn't let the player know anything new about his armor :/
-                //  the client knows only the state of the armor before opening the screen,
-                //  the client doesn't receive any updates on the armor slots until the screen is closed.
-                //  However, the client still gets updates on the armor of other players :/
-
-                // TODO: since the client get no updates on the armor while a chest/crating table/etc. is open,
-                //  try to approximately track the durability of the player's armor manually
-                //  when the player receives damage and chest/crating table/etc. is open :)
-                player.closeHandledScreen()
-            } else if (mc.currentScreen != null) {
-                // closes ClickGUI, game chat, etc. to save some armor :)
-                mc.currentScreen!!.close()
-            }
-
-            waitTicks(1)    // TODO: custom delay?
-
-            // again, the current screen might change while the module is waiting
-            if (mc.currentScreen == null) {
-                mc.setScreen(InventoryScreen(player))
-                hasOpenedInventory = true
-            }
-        }
-    }
-
     private val scheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
         // Filter out already equipped armor pieces
-        val durabilityThreshold = if (AutoArmorSaveArmor.enabled) { AutoArmorSaveArmor.durabilityThreshold } else Int.MIN_VALUE
+        val durabilityThreshold = if (AutoArmorSaveArmor.enabled) { durabilityThreshold } else Int.MIN_VALUE
 
         val armorToEquip = ArmorEvaluation
             .findBestArmorPieces(durabilityThreshold = durabilityThreshold)
-            .values.filterNotNull().filter {
-                !it.isAlreadyEquipped
-            }
+            .values.filterNotNull().filter { !it.isAlreadyEquipped }
 
         for (armorPiece in armorToEquip) {
             event.schedule(
@@ -175,13 +83,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
             return null
         }
 
-        return if (!stackInArmor.isNothing()) {
-            // Clear current armor
-            performMoveOrHotbarClick(armorPiece, isInArmorSlot = true)
-        } else {
-            // Equip new armor
-            performMoveOrHotbarClick(armorPiece, isInArmorSlot = false)
-        }
+        return performMoveOrHotbarClick(armorPiece, isInArmorSlot = !stackInArmor.isNothing())
     }
 
     /**
@@ -199,7 +101,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
         isInArmorSlot: Boolean
     ): InventoryAction {
         val inventorySlot = armorPiece.itemSlot
-        val armorPieceSlot = if (isInArmorSlot) {ArmorItemSlot(armorPiece.entitySlotId)} else {inventorySlot}
+        val armorPieceSlot = if (isInArmorSlot) { ArmorItemSlot(armorPiece.entitySlotId) } else { inventorySlot }
 
         val canTryHotbarMove = (!isInArmorSlot || isNewerThanOrEqual1_19_4) && useHotbar && !InventoryManager.isInventoryOpen
         if (inventorySlot is HotbarItemSlot && canTryHotbarMove) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -54,7 +54,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
     @Suppress("unused")
     private val scheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
         // Filter out already equipped armor pieces
-        val durabilityThreshold = if (AutoArmorSaveArmor.enabled) { durabilityThreshold } else Int.MIN_VALUE
+        val durabilityThreshold = if (AutoArmorSaveArmor.enabled) durabilityThreshold else Int.MIN_VALUE
 
         val armorToEquip = ArmorEvaluation
             .findBestArmorPieces(durabilityThreshold = durabilityThreshold)
@@ -101,7 +101,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
         isInArmorSlot: Boolean
     ): InventoryAction {
         val inventorySlot = armorPiece.itemSlot
-        val armorPieceSlot = if (isInArmorSlot) { ArmorItemSlot(armorPiece.entitySlotId) } else { inventorySlot }
+        val armorPieceSlot = if (isInArmorSlot) ArmorItemSlot(armorPiece.entitySlotId) else inventorySlot
 
         val canTryHotbarMove = (!isInArmorSlot || isNewerThanOrEqual1_19_4) && useHotbar && !InventoryManager.isInventoryOpen
         if (inventorySlot is HotbarItemSlot && canTryHotbarMove) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -23,9 +23,9 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.utils.client.isNewerThanOrEqual1_19_4
 import net.ccbluex.liquidbounce.utils.inventory.ArmorItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
-import net.ccbluex.liquidbounce.utils.inventory.ItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.*
 import net.ccbluex.liquidbounce.utils.item.ArmorPiece
 import net.ccbluex.liquidbounce.utils.item.durability
@@ -57,6 +57,15 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
         tree(AutoArmorSaveArmor)
     }
 
+    /**
+     * Opens the inventory to save armor (as if the player has opened it manually) if the following conditions are met:
+     * - The module is told to save armor and there is a replacement :)
+     * - The inventory constraints require open inventory
+     * (Otherwise, the inventory will be open automatically in a silent way and the armor will be saved)
+     * - There is no replacement from the hotbar
+     * (If there are some pieces that can be replaced by the pieces from the hotbar,
+     * they will be used first, without opening the inventory)
+     */
     @Suppress("unused")
     private val armorAutoSaveHandler = tickHandler {
         if (!AutoArmorSaveArmor.enabled) {
@@ -68,14 +77,22 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
             return@tickHandler
         }
 
-        val armorToEquip = ArmorEvaluation
+        val armorToEquipWithSlots = ArmorEvaluation
             .findBestArmorPieces(durabilityThreshold = AutoArmorSaveArmor.durabilityThreshold)
             .values
             .filterNotNull()
             .filter { !it.isAlreadyEquipped && it.itemSlot.itemStack.item is ArmorItem }
-            .map { it.itemSlot.itemStack.item as ArmorItem }
+
+        val hasAnyHotBarReplacement = useHotbar && isNewerThanOrEqual1_19_4 && armorToEquipWithSlots.any { it.itemSlot is HotbarItemSlot }
+        if (hasAnyHotBarReplacement) {
+            // the new pieces from the hotbar have a higher priority
+            // due to the replacement speed (it's much faster, it makes sense to replace them first),
+            // so it waits until all pieces from hotbar are replaced
+            return@tickHandler
+        }
 
         val playerArmor = player.inventory.armor.filter { it.item is ArmorItem }
+        val armorToEquip = armorToEquipWithSlots.map { it.itemSlot.itemStack.item as ArmorItem }
 
         val hasArmorToReplace = playerArmor.any { armorStack ->
             armorStack.durability <= AutoArmorSaveArmor.durabilityThreshold &&
@@ -105,6 +122,10 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
                 //  the client knows only the state of the armor before opening the screen,
                 //  the client doesn't receive any updates on the armor slots until the screen is closed.
                 //  However, the client still gets updates on the armor of other players :/
+
+                // TODO: since the client get no updates on the armor while a chest/crating table/etc. is open,
+                //  try to approximately track the durability of the player's armor manually
+                //  when the player receives damage and chest/crating table/etc. is open :)
                 player.closeHandledScreen()
             } else if (mc.currentScreen != null) {
                 // closes ClickGUI, game chat, etc. to save some armor :)
@@ -123,8 +144,10 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
 
     private val scheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
         // Filter out already equipped armor pieces
+        val durabilityThreshold = if (AutoArmorSaveArmor.enabled) { AutoArmorSaveArmor.durabilityThreshold } else Int.MIN_VALUE
+
         val armorToEquip = ArmorEvaluation
-            .findBestArmorPieces(durabilityThreshold = AutoArmorSaveArmor.durabilityThreshold)
+            .findBestArmorPieces(durabilityThreshold = durabilityThreshold)
             .values.filterNotNull().filter {
                 !it.isAlreadyEquipped
             }
@@ -152,15 +175,12 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
             return null
         }
 
-        val inventorySlot = armorPiece.itemSlot
-        val armorPieceSlot = ArmorItemSlot(armorPiece.entitySlotId)
-
         return if (!stackInArmor.isNothing()) {
             // Clear current armor
-            performMoveOrHotbarClick(armorPieceSlot, isInArmorSlot = true)
+            performMoveOrHotbarClick(armorPiece, isInArmorSlot = true)
         } else {
             // Equip new armor
-            performMoveOrHotbarClick(inventorySlot, isInArmorSlot = false)
+            performMoveOrHotbarClick(armorPiece, isInArmorSlot = false)
         }
     }
 
@@ -175,21 +195,24 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
      * @return True if a move occurred.
      */
     private fun performMoveOrHotbarClick(
-        slot: ItemSlot,
+        armorPiece: ArmorPiece,
         isInArmorSlot: Boolean
     ): InventoryAction {
-        val canTryHotbarMove = !isInArmorSlot && useHotbar && !InventoryManager.isInventoryOpen
-        if (slot is HotbarItemSlot && canTryHotbarMove) {
-            return UseInventoryAction(slot)
+        val inventorySlot = armorPiece.itemSlot
+        val armorPieceSlot = if (isInArmorSlot) {ArmorItemSlot(armorPiece.entitySlotId)} else {inventorySlot}
+
+        val canTryHotbarMove = (!isInArmorSlot || isNewerThanOrEqual1_19_4) && useHotbar && !InventoryManager.isInventoryOpen
+        if (inventorySlot is HotbarItemSlot && canTryHotbarMove) {
+            return UseInventoryAction(inventorySlot)
         }
 
         // Should the item be just thrown out of the inventory
         val shouldThrow = isInArmorSlot && !hasInventorySpace()
 
         return if (shouldThrow) {
-            ClickInventoryAction.performThrow(screen = null, slot)
+            ClickInventoryAction.performThrow(screen = null, armorPieceSlot)
         } else {
-            ClickInventoryAction.performQuickMove(screen = null, slot)
+            ClickInventoryAction.performQuickMove(screen = null, armorPieceSlot)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -47,9 +47,9 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
      */
     object UseHotbar : ToggleableConfigurable(this, "Hotbar", true) {
         /**
-         * Defines whether the [UseHotbar] option supports the new mechanic from MC 1.19.4+.
+         * Defines whether the [UseHotbar] option supports the armor swap from MC 1.19.4+.
          */
-        val canReplaceEquippedArmor by boolean("CanReplaceEquippedArmor", false)
+        val canSwapArmor by boolean("CanSwapArmor", false)
     }
 
     init {
@@ -116,7 +116,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
         val canTryHotbarMove = booleanArrayOf(
             UseHotbar.enabled,
             !InventoryManager.isInventoryOpen,
-            (!isInArmorSlot || UseHotbar.canReplaceEquippedArmor)
+            (!isInArmorSlot || UseHotbar.canSwapArmor)
         ).all { it }
 
         if (inventorySlot is HotbarItemSlot && canTryHotbarMove) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -53,7 +53,7 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
 
     @Suppress("unused")
     private val scheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
-        if (player.isCreative || player.isSpectator) {
+        if (player.isSpectator) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -53,6 +53,10 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
 
     @Suppress("unused")
     private val scheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
+        if (player.isCreative || player.isSpectator) {
+            return@handler
+        }
+
         // Filter out already equipped armor pieces
         val durabilityThreshold = if (AutoArmorSaveArmor.enabled) durabilityThreshold else Int.MIN_VALUE
 
@@ -103,7 +107,9 @@ object ModuleAutoArmor : ClientModule("AutoArmor", Category.COMBAT) {
         val inventorySlot = armorPiece.itemSlot
         val armorPieceSlot = if (isInArmorSlot) ArmorItemSlot(armorPiece.entitySlotId) else inventorySlot
 
-        val canTryHotbarMove = (!isInArmorSlot || isNewerThanOrEqual1_19_4) && useHotbar && !InventoryManager.isInventoryOpen
+        val canTryHotbarMove = (!isInArmorSlot || isNewerThanOrEqual1_19_4)
+            && useHotbar && !InventoryManager.isInventoryOpen
+
         if (inventorySlot is HotbarItemSlot && canTryHotbarMove) {
             return UseInventoryAction(inventorySlot)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
@@ -115,6 +115,14 @@ val isOlderThanOrEqual1_11_1: Boolean
         logger.error("Failed to check if the server is using 1.11.1", it)
     }.getOrDefault(false)
 
+val isNewerThanOrEqual1_19_4: Boolean
+    get() = runCatching {
+        // Check if the ViaFabricPlus mod is loaded - prevents from causing too many exceptions
+        usesViaFabricPlus && VfpCompatibility.INSTANCE.isNewerThanOrEqual1_19_4
+    }.onFailure {
+        logger.error("Failed to check if the server is using 1.19.4", it)
+    }.getOrDefault(false)
+
 fun selectProtocolVersion(protocolId: Int) {
     // Check if the ViaFabricPlus mod is loaded - prevents from causing too many exceptions
     if (usesViaFabricPlus) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
@@ -115,14 +115,6 @@ val isOlderThanOrEqual1_11_1: Boolean
         logger.error("Failed to check if the server is using 1.11.1", it)
     }.getOrDefault(false)
 
-val isNewerThanOrEqual1_19_4: Boolean
-    get() = runCatching {
-        // Check if the ViaFabricPlus mod is loaded - prevents from causing too many exceptions
-        usesViaFabricPlus && VfpCompatibility.INSTANCE.isNewerThanOrEqual1_19_4
-    }.onFailure {
-        logger.error("Failed to check if the server is using 1.19.4", it)
-    }.getOrDefault(false)
-
 fun selectProtocolVersion(protocolId: Int) {
     // Check if the ViaFabricPlus mod is loaded - prevents from causing too many exceptions
     if (usesViaFabricPlus) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryUtils.kt
@@ -85,7 +85,7 @@ class PlayerInventoryConstraints : InventoryConstraints() {
      * Sad.
      * :(
      */
-    private val requiresOpenInventory by boolean("RequiresInventoryOpen", false)
+    val requiresOpenInventory by boolean("RequiresInventoryOpen", false)
 
     override fun passesRequirements(action: InventoryAction) =
         super.passesRequirements(action) &&

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
@@ -90,7 +90,6 @@ class ArmorComparator(
     private val expectedDamage: Float,
     private val armorKitParametersForSlot: ArmorKitParameters,
     private val durabilityThreshold : Int = Int.MIN_VALUE
-
 ) : Comparator<ArmorPiece> {
     companion object {
         private val DAMAGE_REDUCTION_ENCHANTMENTS: Array<RegistryKey<Enchantment>> = arrayOf(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
@@ -81,10 +81,16 @@ class ArmorKitParameters(
  * @property armorKitParametersForSlot armor (i.e. iron with Protection II vs plain diamond) behaves differently based
  * on the other armor pieces. Thus, the expected defense points and toughness have to be provided. Since those are
  * dependent on the other armor pieces, the armor parameters have to be provided slot-wise.
+ * @property durabilityThreshold the minimum durability an armor piece must have to be prioritized for use.
+ * If an armor piece's remaining durability is lower than this threshold,
+ * the piece is not prioritized anymore, and it can be replaced with another piece
+ * so that this piece can be preserved.
  */
 class ArmorComparator(
     private val expectedDamage: Float,
-    private val armorKitParametersForSlot: ArmorKitParameters
+    private val armorKitParametersForSlot: ArmorKitParameters,
+    private val durabilityThreshold : Int = Int.MIN_VALUE
+
 ) : Comparator<ArmorPiece> {
     companion object {
         private val DAMAGE_REDUCTION_ENCHANTMENTS: Array<RegistryKey<Enchantment>> = arrayOf(
@@ -103,18 +109,10 @@ class ArmorComparator(
             Enchantments.UNBREAKING
         )
         private val OTHER_ENCHANTMENT_PER_LEVEL = floatArrayOf(3.0f, 1.0f, 0.1f, 0.05f, 0.01f)
-
-        /**
-         * The minimum durability an armor piece must have to be prioritized for use.
-         * If an armor piece's remaining durability is lower than this threshold,
-         * the piece is not prioritized anymore, and it can be replaced with another piece
-         * so that this piece can be preserved.
-         */
-        const val DURABILITY_THRESHOLD = 24
     }
 
     private val comparator = ComparatorChain(
-        compareBy { it.itemSlot.itemStack.durability > DURABILITY_THRESHOLD },
+        compareBy { it.itemSlot.itemStack.durability > durabilityThreshold },
         compareByDescending { round(getThresholdedDamageReduction(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { round(getEnchantmentThreshold(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { it.itemSlot.itemStack.getEnchantmentCount() },

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
@@ -110,11 +110,11 @@ class ArmorComparator(
          * the piece is not prioritized anymore, and it can be replaced with another piece
          * so that this piece can be preserved.
          */
-        private const val DURABILITY_THRESHOLD = 24
+        const val DURABILITY_THRESHOLD = 24
     }
 
     private val comparator = ComparatorChain(
-        compareBy { it.itemSlot.itemStack.maxDamage - it.itemSlot.itemStack.damage > DURABILITY_THRESHOLD },
+        compareBy { it.itemSlot.itemStack.durability > DURABILITY_THRESHOLD },
         compareByDescending { round(getThresholdedDamageReduction(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { round(getEnchantmentThreshold(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { it.itemSlot.itemStack.getEnchantmentCount() },

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ArmorComparator.kt
@@ -103,9 +103,18 @@ class ArmorComparator(
             Enchantments.UNBREAKING
         )
         private val OTHER_ENCHANTMENT_PER_LEVEL = floatArrayOf(3.0f, 1.0f, 0.1f, 0.05f, 0.01f)
+
+        /**
+         * The minimum durability an armor piece must have to be prioritized for use.
+         * If an armor piece's remaining durability is lower than this threshold,
+         * the piece is not prioritized anymore, and it can be replaced with another piece
+         * so that this piece can be preserved.
+         */
+        private const val DURABILITY_THRESHOLD = 24
     }
 
     private val comparator = ComparatorChain(
+        compareBy { it.itemSlot.itemStack.maxDamage - it.itemSlot.itemStack.damage > DURABILITY_THRESHOLD },
         compareByDescending { round(getThresholdedDamageReduction(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { round(getEnchantmentThreshold(it.itemSlot.itemStack).toDouble(), 3) },
         compareBy { it.itemSlot.itemStack.getEnchantmentCount() },

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
@@ -149,6 +149,9 @@ fun ItemStack.getSharpnessDamage(level: Int = sharpnessLevel) = if (level == 0) 
 val ItemStack.attackSpeed: Float
     get() = item.getAttributeValue(EntityAttributes.ATTACK_SPEED)
 
+val ItemStack.durability
+    get() = this.maxDamage - this.damage
+
 private fun Item.getAttributeValue(attribute: RegistryEntry<EntityAttribute>): Float {
     val attribInstance = EntityAttributeInstance(attribute) {}
 


### PR DESCRIPTION
The same as #5600 but without merge commits.

Should close #5591, at least temporarily.

Changes:
- [x] Modified the armor evaluation. A piece with low durability (lower than a durability threshold) is considered to be worse than any piece with enough durability.
- [x] The durability threshold can be configured in ClickGUI. <details>
![image](https://github.com/user-attachments/assets/99ff35fa-8bae-469d-ba82-e5597ad399c5)</details>
- [x] If inventory constraints require open inventory, the module can open it automatically to save armor.
 - [ ] Unfortunately, if there is a chest/shulker box/furnace/etc. opened by the player, it won't be closed to save armor. It will be closed only after the player eventually loses an armor piece. (The client doesn't get updates on the armor in such cases, meaning that the module simply can't know when it needs to save armor)
- [x] Added 1.19.4 hotbar armor swap support that can also be used to save armor.

Here are a couple of videos showing how this can work:
https://youtu.be/qOqIsQRQdso
https://youtu.be/PeVot8f-uUE