### PR TITLE
feat(ClickGUI): Dynamic precision of float values

### DIFF
--- a/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
@@ -19,9 +19,7 @@
     onMount(() => {
         let step = 0.01;
 
-        if (cSetting.range.to >= 1000) {
-            step = 1.0;
-        } else if (cSetting.range.to >= 100) {
+        if (cSetting.range.to > 100) {
             step = 0.1;
         } else if (cSetting.range.to <= 0.1) {
             step = 0.0001;

--- a/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
@@ -17,6 +17,18 @@
     let apiSlider: API;
 
     onMount(() => {
+        let step = 0.01;
+
+        if (cSetting.range.to >= 1000) {
+            step = 1.0;
+        } else if (cSetting.range.to >= 100) {
+            step = 0.1;
+        } else if (cSetting.range.to <= 0.1) {
+            step = 0.0001;
+        } else if (cSetting.range.to <= 1.0) {
+            step = 0.001;
+        }
+
         apiSlider = noUiSlider.create(slider, {
             start: [cSetting.value.from, cSetting.value.to],
             connect: true,
@@ -24,7 +36,11 @@
                 min: cSetting.range.from,
                 max: cSetting.range.to,
             },
-            step: 0.01,
+            step: step,
+            format: {
+                to: (value) => parseFloat(value.toFixed(4)), // Display up to 4 decimal places
+                from: (value) => parseFloat(value), // Convert back to float
+            }
         });
 
         apiSlider.on("update", values => {

--- a/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
@@ -17,6 +17,18 @@
     let apiSlider: API;
 
     onMount(() => {
+        let step = 0.01;
+
+        if (cSetting.range.to >= 1000) {
+            step = 1.0;
+        } else if (cSetting.range.to >= 100) {
+            step = 0.1;
+        } else if (cSetting.range.to <= 0.1) {
+            step = 0.0001;
+        } else if (cSetting.range.to <= 1.0) {
+            step = 0.001;
+        }
+
         apiSlider = noUiSlider.create(slider, {
             start: cSetting.value,
             connect: "lower",
@@ -24,7 +36,11 @@
                 min: cSetting.range.from,
                 max: cSetting.range.to,
             },
-            step: 0.01,
+            step: step,
+            format: {
+                to: (value) => parseFloat(value.toFixed(4)), // Display up to 4 decimal places
+                from: (value) => parseFloat(value), // Convert back to float
+            }
         });
 
         apiSlider.on("update", (values) => {

--- a/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
@@ -19,9 +19,7 @@
     onMount(() => {
         let step = 0.01;
 
-        if (cSetting.range.to >= 1000) {
-            step = 1.0;
-        } else if (cSetting.range.to >= 100) {
+        if (cSetting.range.to > 100) {
             step = 0.1;
         } else if (cSetting.range.to <= 0.1) {
             step = 0.0001;

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptSetting.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptSetting.kt
@@ -40,14 +40,14 @@ object ScriptSetting {
     @JvmName("float")
     fun float(value: PolyglotValue): RangedValue<Float> {
         val name = value.getMember("name").asString()
-        val default = value.getMember("default").asFloat()
+        val default = value.getMember("default").asDouble()
         val range = value.getMember("range").`as`(Array<Double>::class.java)
         val suffix = value.getMember("suffix")?.asString() ?: ""
 
         require(range.size == 2)
         return rangedValue(
             name,
-            default,
+            default.toFloat(),
             range.first().toFloat()..range.last().toFloat(),
             suffix,
             ValueType.FLOAT


### PR DESCRIPTION
- [X] Introduced dynamic precision of float values depending on the `max` value.
- [X] (ScriptAPI): Fixed the default value initialization of a float setting. It expected `Float` and regards `0.026` as `Double`, and there's no way to mark it as `Float` (`0.026F` and `0.026f` won't work in scripts).

---

Precision Table:
<details>

![image](https://github.com/user-attachments/assets/c76520f9-c5ab-4400-9e49-2b03c668146a)

</details>

---




Video: <details>

https://github.com/user-attachments/assets/613a40a0-0f43-4db6-abde-182b14a6cbf1

</details>

---

Script from the video:
<details>

```
const script = registerScript({
  name: "MyScript",
  version: "1.0.0",
  authors: ["My Name"]
});

script.registerModule({
  name: "MyModule",
  category: "Misc", // Movement, Combat, Render, ...
  description: "An example module created with LiquidBounce's script API.",
  settings: {
	mySetting1: Setting.float({
		name: "MySetting1",
		range: [0.025, 0.04],
		default: 0.026,
		suffix: "axolotls"
	}),
	mySetting2: Setting.float({
		name: "MySetting2",
		range: [0.15, 1],
		default: 0.35,
		suffix: "axolotls"
	}),
	mySetting3: Setting.float({
		name: "MySetting3",
		range: [1, 64],
		default: 10,
		suffix: "axolotls"
	}),
	mySetting4: Setting.floatRange({
		name: "MySetting4",
		range: [10, 1028],
		default: [15, 24],
		suffix: "axolotls"
	})
  }
}, (mod) => {
  mod.on("enable", () => {
	Client.displayChatMessage("§aAxolotls are great!");
  });
});
```

</details>
