### PR TITLE
chore(Disabler): remove Miniblox disabler (patched) & add a desync fix disabler

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -483,6 +483,17 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
             }
             player.setVelocity(0.0, 0.0, 0.0)
         }
+        // fixes movement desyncs, we need to send C0CInput packets with correct inputs.
+        if (miniblox) {
+            mc.netHandler.addToSendQueue(
+                C0CPacketInput(
+                    player.moveStrafing,
+                    player.moveForward,
+                    player.isJumping,
+                    player.isSneaking
+                )
+            )
+        }
     }
 
     val onUpdate = handler<UpdateEvent> {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Disabler.kt
@@ -108,7 +108,7 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
     private val verusExperimental by boolean("VerusExperimental", false)
     private val verusExpVoidTP by boolean("ExpVoidTP", false) { verusExperimental }
     private val verusExpVoidTPDelay by int("ExpVoidTPDelay", 1000, 0..30000) { verusExpVoidTP }
-    private val miniblox by boolean("Miniblox", false)
+    private val miniblox by boolean("MinibloxDesync", false)
     private var lastVoidTP = 0L
     private var cancelNext = 0
 
@@ -428,36 +428,16 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
                 debugMessage("VerusExp cancelled server position look")
             }
         }
-        // the disabler is really horrible yet simple,
-        // you just silently accept the setback and then go back to where you were before the setback
-        // Sorry Jucku that I didn't port it to nextgen
-        // TODO: make this better, also needs to handle respawning..
-        if (miniblox) {
-            if (packet is S08PacketPlayerPosLook && player.ticksExisted >= 100) {
-                event.cancelEvent()
-                // accept the new position & rotation
-                debugMessage("Set back, cancelled event & silently accepting new position")
-                sendPacket(
-                    C06PacketPlayerPosLook(
-                        packet.x,
-                        packet.y,
-                        packet.z,
-                        packet.yaw,
-                        packet.pitch,
-                        player.onGround
-                    ), false
+        // fixes movement desyncs, we need to send C0CInput packets with correct inputs.
+        if (miniblox && (packet is C04PacketPlayerPosition || packet is C05PacketPlayerLook)) {
+            sendPacket(
+                C0CPacketInput(
+                    player.moveStrafing,
+                    player.moveForward,
+                    player.isJumping,
+                    player.isSneaking
                 )
-                sendPacket(
-                    C06PacketPlayerPosLook(
-                        player.posX,
-                        player.posY,
-                        player.posZ,
-                        player.rotationYaw,
-                        player.rotationPitch,
-                        player.onGround
-                    ), false
-                )
-            }
+            )
         }
     }
 
@@ -482,17 +462,6 @@ object Disabler : Module("Disabler", Category.EXPLOIT) {
                 event.x += 0.095
             }
             player.setVelocity(0.0, 0.0, 0.0)
-        }
-        // fixes movement desyncs, we need to send C0CInput packets with correct inputs.
-        if (miniblox) {
-            mc.netHandler.addToSendQueue(
-                C0CPacketInput(
-                    player.moveStrafing,
-                    player.moveForward,
-                    player.isJumping,
-                    player.isSneaking
-                )
-            )
         }
     }
 


### PR DESCRIPTION
The new "prediction" anticheat (in quotes because you used to be able to have a infinite fly using 0.3 / 0.25 speed and 0 motion Y, that was patched, and there was 2 disablers found by other people, both were patched) patched the disabler.
The desync fix just sends a C0CInput packet with the correct movement properties.