### PR TITLE
feat(ModMenu): Hide in mod menu when destructed | hiding appearance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,8 +116,10 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}"
 
+    // Mod menu
+    modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
+
     // Recommended mods (on IDE)
-    modRuntimeOnly "com.terraformersmc:modmenu:${project.mod_menu_version}"
     modImplementation "maven.modrinth:sodium:${project.sodium_version}"
     modImplementation "maven.modrinth:lithium:${project.lithium_version}"
 

--- a/src/main/java/net/ccbluex/liquidbounce/utils/client/modmenu/ModMenuCompatibility.java
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/client/modmenu/ModMenuCompatibility.java
@@ -1,0 +1,35 @@
+package net.ccbluex.liquidbounce.utils.client.modmenu;
+
+import com.terraformersmc.modmenu.ModMenu;
+import com.terraformersmc.modmenu.util.mod.Mod;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+public enum ModMenuCompatibility {
+    INSTANCE;
+
+    /**
+     * SAFETY: The method doesn't check if {@link ModMenu} is present and loaded
+     *
+     * @param id the modid to remove
+     * @return mod container in the {@link ModMenu} system
+     */
+    public final @Nullable Mod removeModUnchecked(@NotNull String id) {
+        var mod = ModMenu.MODS.remove(id);
+        var rootMod = ModMenu.ROOT_MODS.remove(id);
+
+        return mod == null ? rootMod : mod;
+    }
+
+    /**
+     * SAFETY: The method doesn't check if {@link ModMenu} is present and loaded
+     *
+     * @param id modid to associate the mod container
+     * @param mod mod container in the {@link ModMenu} system to add
+     */
+    public final void addModUnchecked(@NotNull String id, @NotNull Mod mod) {
+        ModMenu.MODS.put(id, mod);
+        ModMenu.ROOT_MODS.put(id, mod);
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -80,7 +80,7 @@ object HideAppearance : EventListener {
                 } else {
                     for ((id, container) in modContainersToHide) {
                         container?.let {
-                            ModMenuCompatibility.INSTANCE.addModUnchecked(id, container)
+                            ModMenuCompatibility.INSTANCE.addModUnchecked(id, it)
                         }
                     }
                 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -61,7 +61,7 @@ object HideAppearance : EventListener {
      * We set the default value is null.
      * And we'll provide the value after first removing the mod
      */
-    private val hidedModsContainer: MutableMap<String, Mod?> = arrayOf(
+    private val modContainersToHide: MutableMap<String, Mod?> = arrayOf(
         "liquidbounce", "mcef"
     ).associateWith { null }.toMutableMap()
 
@@ -74,12 +74,12 @@ object HideAppearance : EventListener {
 
             if (modMenuPresent) {
                 if (value) {
-                    for (id in hidedModsContainer.keys) {
-                        hidedModsContainer[id] = ModMenu.MODS.remove(id)
+                    for (id in modContainersToHide.keys) {
+                        modContainersToHide[id] = ModMenu.MODS.remove(id)
                         ModMenu.ROOT_MODS.remove(id)
                     }
                 } else {
-                    for ((id, container) in hidedModsContainer) {
+                    for ((id, container) in modContainersToHide) {
                         container?.let {
                             ModMenu.ROOT_MODS[id] = container
                             ModMenu.MODS[id] = container

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -54,7 +54,7 @@ object HideAppearance : EventListener {
 
     /**
      * These mods will be removed from ModMenu.
-     * When [isHidingNow] is tru
+     * When [isHidingNow] is true
      * Or added, if [isHidingNow] is false
      *
      * Because we don't know about the [Mod] container on each mod in this list

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -19,7 +19,6 @@
 package net.ccbluex.liquidbounce.features.misc
 
 import com.mojang.blaze3d.systems.RenderSystem
-import com.terraformersmc.modmenu.ModMenu
 import com.terraformersmc.modmenu.util.mod.Mod
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.event.EventListener
@@ -33,6 +32,7 @@ import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.client.modmenu.ModMenuCompatibility
 import net.fabricmc.loader.impl.FabricLoaderImpl
 import net.minecraft.SharedConstants
 import net.minecraft.client.util.Icons
@@ -75,14 +75,12 @@ object HideAppearance : EventListener {
             if (modMenuPresent) {
                 if (value) {
                     for (id in modContainersToHide.keys) {
-                        modContainersToHide[id] = ModMenu.MODS.remove(id)
-                        ModMenu.ROOT_MODS.remove(id)
+                        modContainersToHide[id] = ModMenuCompatibility.INSTANCE.removeModUnchecked(id)
                     }
                 } else {
                     for ((id, container) in modContainersToHide) {
                         container?.let {
-                            ModMenu.ROOT_MODS[id] = container
-                            ModMenu.MODS[id] = container
+                            ModMenuCompatibility.INSTANCE.addModUnchecked(id, container)
                         }
                     }
                 }


### PR DESCRIPTION
closes #5724

https://github.com/user-attachments/assets/f0a56be0-b2f0-462f-8d7b-25042f110bc7

If u have the [hide appearance](https://github.com/CCBlueX/LiquidBounce/blob/7d2cd965ece125ec5d6098f3154065ac1dcc4dfe/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/client/CommandClientAppearanceSubcommand.kt#L34) function, they does it incorrectly, because client still visible in the mod menu.

izuna, if u close the pr with words
> I'm not in favour of implementing a [...integration...] for every mod out there

I think, ViaVersion less popular, than ModMenu, and it integrated in the client. So, why u doesn't integrate ModMenu in the client?
However, ModMenu is in the [Recommended mods](https://github.com/CCBlueX/LiquidBounce/blob/nextgen/build.gradle#L120)