### PR TITLE
fix(BufferSpeed): head block doing the opposite

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BufferSpeed.kt
@@ -155,7 +155,7 @@ object BufferSpeed : Module("BufferSpeed", Category.MOVEMENT) {
             }
             legitHop = true
 
-            if (headBlock && blockPos.up(2).block == Blocks.air) {
+            if (headBlock && blockPos.up(2).block != Blocks.air) {
                 boost(headBlockBoost)
                 return@handler
             }


### PR DESCRIPTION
This bug is as old as 2020, where it looks like the check was inverted to check if there was a block of air above the player, instead of checking if there was NOT a block of air above.