### PR TITLE
feat(KillAura): Target Selection Improvement

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -95,10 +95,27 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", Category.COMBAT) {
         get() = SilentHotbar.isSlotModifiedBy(ModuleAutoBuff) || player.isUsingItem && player.activeHand ==
             Hand.MAIN_HAND && player.activeItem.isConsumable
 
+    /**
+     * Check if the attack will break the shield
+     */
+    fun willBreakShield(): Boolean {
+        if (!this.running || isOlderThanOrEqual1_8) {
+            return false
+        }
+
+        // If we have an axe in our main hand, we will break the shield
+        if (player.mainHandStack.item is AxeItem) {
+            return true
+        }
+
+        // If we are not going to switch to an axe, we will not break the shield
+        return determineWeaponSlot(null, enforceShield = true)?.itemStack?.item is AxeItem
+    }
+
     @Suppress("unused")
     private val attackHandler = sequenceHandler<AttackEntityEvent> { event ->
         val entity = event.entity as? LivingEntity ?: return@sequenceHandler
-        val weaponSlot = determineWeaponSlot(entity) ?: return@sequenceHandler
+        val weaponSlot = determineWeaponSlot(entity)?.hotbarSlot ?: return@sequenceHandler
         val isOnSwitch = SilentHotbar.serversideSlot != weaponSlot
 
         if (isBusy) {
@@ -137,28 +154,28 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", Category.COMBAT) {
         determineWeaponSlot(entity)?.let { slot ->
             SilentHotbar.selectSlotSilently(
                 this,
-                slot,
+                slot.hotbarSlot,
                 switchBack
             )
         }
     }
 
-    private fun determineWeaponSlot(target: LivingEntity?): Int? {
+    private fun determineWeaponSlot(target: LivingEntity?, enforceShield: Boolean = false): HotbarItemSlot? {
         val itemCategorization = ItemCategorization(Slots.Hotbar)
+        val blockedByShield = enforceShield || !isOlderThanOrEqual1_8 &&
+            target?.blockedByShield(world.damageSources.playerAttack(player)) == true
 
         val bestSlot = Slots.Hotbar
-            .flatMap { itemCategorization.getItemFacets(it).filterIsInstance<WeaponItemFacet>() }
+            .flatMap { slot -> itemCategorization.getItemFacets(slot).filterIsInstance<WeaponItemFacet>() }
             .filter(
                 when {
-                    !isOlderThanOrEqual1_8 && target?.blockedByShield(world.damageSources.playerAttack(player)) == true
-                        -> againstShield.filter
-
+                    blockedByShield -> againstShield.filter
                     else -> preferredWeapon.filter
                 }
             )
             .maxOrNull()
 
-        return (bestSlot?.itemSlot as HotbarItemSlot?)?.hotbarSlot
+        return bestSlot?.itemSlot as HotbarItemSlot?
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -1,0 +1,145 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
+
+import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.rotationTiming
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.simulateInventoryClosing
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock
+import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions
+import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
+import net.ccbluex.liquidbounce.utils.aiming.utils.withFixedYaw
+import net.ccbluex.liquidbounce.utils.clicking.Clicker
+import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.client.network
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.entity.isBlockAction
+import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
+import net.ccbluex.liquidbounce.utils.inventory.openInventorySilently
+import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.Full
+
+object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, true) {
+
+    /**
+     * When missing a hit, Minecraft has a cooldown before you can attack again.
+     * This option will consider the cooldown before attacking again.
+     *
+     * This is useful for anti-cheats that detect if you are ignoring this cooldown.
+     * Applies to the FailSwing feature as well.
+     */
+    val considerMissCooldown by boolean("ConsiderMissCooldown", false)
+
+    val passesMissCooldown
+        get() = !considerMissCooldown || mc.attackCooldown <= 0
+
+    /**
+     * Prepare the environment for attacking an entity
+     *
+     * This means, we make sure we are not blocking, we are not using another item,
+     * and we are not in an inventory screen depending on the configuration.
+     */
+    suspend fun attack(sequence: Sequence, rotation: Rotation? = null, attack: () -> Boolean) {
+        if (!isGoingToClick) {
+            // If we are not going to click, we don't need to prepare the environment
+            return
+        }
+
+        val interactiveScene = InteractiveScene(sequence = sequence, rotation = rotation)
+        if (interactiveScene.prepare()) {
+            return
+        }
+
+        clicks {
+            if (!passesMissCooldown) {
+                return@clicks false
+            }
+
+            attack()
+        }
+
+        interactiveScene.unprepare()
+    }
+
+    /**
+     * Prepare the scene for e.g. attacking an entity.
+     */
+    private data class InteractiveScene(
+        val sequence: Sequence,
+        val rotation: Rotation?,
+        val isInInventoryScreen: Boolean = InventoryManager.isInventoryOpen,
+    ) {
+
+        @Suppress("CognitiveComplexMethod")
+        suspend fun prepare(): Boolean {
+            if (simulateInventoryClosing && isInInventoryScreen) {
+                network.sendPacket(CloseHandledScreenC2SPacket(0))
+            }
+
+            if (player.isBlockAction) {
+                if (!KillAuraAutoBlock.enabled && !ModuleMultiActions.mayCurrentlyAttackWhileUsing()) {
+                    return true
+                }
+
+                if (KillAuraAutoBlock.enabled && KillAuraAutoBlock.shouldUnblockToHit) {
+                    // Wait for the tick off time to be over, if it's not 0
+                    // Ideally this should not happen.
+                    if (KillAuraAutoBlock.stopBlocking(pauses = true) && KillAuraAutoBlock.tickOff > 0) {
+                        sequence.waitTicks(KillAuraAutoBlock.tickOff)
+                    }
+                }
+            } else if (player.isUsingItem && !ModuleMultiActions.mayCurrentlyAttackWhileUsing()) {
+                // return if it's not allowed to attack while the player is using another item that's not a shield
+                return true
+            }
+
+            if (rotationTiming == KillAuraRotationsConfigurable.KillAuraRotationTiming.ON_TICK && rotation != null) {
+                network.sendPacket(
+                    Full(
+                        player.x, player.y, player.z, rotation.yaw, rotation.pitch, player.isOnGround,
+                        player.horizontalCollision
+                    )
+                )
+            }
+            return false
+        }
+
+        fun unprepare() {
+            if (rotationTiming == KillAuraRotationsConfigurable.KillAuraRotationTiming.ON_TICK && rotation != null) {
+                network.sendPacket(
+                    Full(
+                        player.x, player.y, player.z, player.withFixedYaw(rotation), player.pitch, player.isOnGround,
+                        player.horizontalCollision
+                    )
+                )
+            }
+
+            if (simulateInventoryClosing && isInInventoryScreen) {
+                openInventorySilently()
+            }
+
+            // If the player was blocking before, we start blocking again after the attack if the tick on is 0
+            if (KillAuraAutoBlock.blockImmediate) {
+                KillAuraAutoBlock.startBlocking()
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRotationsConfigurable.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRotationsConfigurable.kt
@@ -1,0 +1,35 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
+
+import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
+
+object KillAuraRotationsConfigurable : RotationsConfigurable(ModuleKillAura, combatSpecific = true) {
+
+    val rotationTiming by enumChoice("RotationTiming", KillAuraRotationTiming.NORMAL)
+    val aimThroughWalls by boolean("ThroughWalls", false)
+
+    enum class KillAuraRotationTiming(override val choiceName: String) : NamedChoice {
+        NORMAL("Normal"),
+        SNAP("Snap"),
+        ON_TICK("OnTick")
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraTargetTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraTargetTracker.kt
@@ -1,0 +1,58 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
+
+import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
+import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.client.world
+import net.ccbluex.liquidbounce.utils.combat.TargetTracker
+import net.ccbluex.liquidbounce.utils.entity.wouldBlockHit
+import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.item.AxeItem
+
+object KillAuraTargetTracker : TargetTracker() {
+
+    /**
+     * Allows to ignore when the target is holding a shield,
+     * which would normally block attacks.
+     */
+    private val ignoreShield by boolean("IgnoreShield", true)
+
+    override fun validate(entity: LivingEntity): Boolean {
+        return super.validate(entity) && validateShield(entity)
+    }
+
+    /**
+     * Check if the entity is holding a shield and if the shield would block the attack.
+     */
+    private fun validateShield(entity: LivingEntity): Boolean {
+        if (ignoreShield || entity !is PlayerEntity || isOlderThanOrEqual1_8) {
+            return true
+        }
+
+        if (player.mainHandStack.item is AxeItem || ModuleAutoWeapon.willBreakShield()) {
+            return true
+        }
+
+        return !entity.blockedByShield(world.damageSources.playerAttack(player)) || !entity.wouldBlockHit(player)
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
 import com.google.gson.JsonObject
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.Sequence
-import net.ccbluex.liquidbounce.event.events.InputHandleEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.events.SprintEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
@@ -32,54 +31,42 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.CriticalsSelectionMode
 import net.ccbluex.liquidbounce.features.module.modules.combat.elytratarget.ModuleElytraTarget
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.KillAuraClicker.considerMissCooldown
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraClicker.passesMissCooldown
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.KillAuraRotationTiming.ON_TICK
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.KillAuraRotationTiming.SNAP
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.RaycastMode.*
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.RotationTimingMode.ON_TICK
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.RotationTimingMode.SNAP
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFailSwing
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFailSwing.dealWithFakeSwing
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFightBot
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.failedHits
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.hasFailedHit
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.renderFailedHits
-import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes.GenericDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.aiming.PointTracker
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
-import net.ccbluex.liquidbounce.utils.aiming.RotationsConfigurable
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.data.RotationWithVector
 import net.ccbluex.liquidbounce.utils.aiming.preference.LeastDifferencePreference
 import net.ccbluex.liquidbounce.utils.aiming.utils.facingEnemy
 import net.ccbluex.liquidbounce.utils.aiming.utils.raytraceBox
 import net.ccbluex.liquidbounce.utils.aiming.utils.raytraceEntity
-import net.ccbluex.liquidbounce.utils.aiming.utils.withFixedYaw
-import net.ccbluex.liquidbounce.utils.clicking.Clicker
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
-import net.ccbluex.liquidbounce.utils.combat.TargetTracker
 import net.ccbluex.liquidbounce.utils.combat.attack
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
-import net.ccbluex.liquidbounce.utils.entity.isBlockAction
 import net.ccbluex.liquidbounce.utils.entity.rotation
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
-import net.ccbluex.liquidbounce.utils.entity.wouldBlockHit
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
-import net.ccbluex.liquidbounce.utils.inventory.openInventorySilently
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.render.WorldTargetRenderer
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
-import net.minecraft.entity.player.PlayerEntity
-import net.minecraft.item.AxeItem
-import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
-import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.Full
+import kotlin.math.pow
 
 /**
  * KillAura module
@@ -88,26 +75,12 @@ import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.Full
  */
 object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
-    object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, true) {
-
-        /**
-         * When missing a hit, Minecraft has a cooldown before you can attack again.
-         * This option will consider the cooldown before attacking again.
-         *
-         * This is useful for anti-cheats that detect if you are ignoring this cooldown.
-         * Applies to the FailSwing feature as well.
-         */
-        val considerMissCooldown by boolean("ConsiderMissCooldown", false)
-
-    }
-
     // Attack speed
     val clickScheduler = tree(KillAuraClicker)
 
     // Range
     internal val range by float("Range", 4.2f, 1f..8f)
     private val scanExtraRange by float("ScanExtraRange", 3.0f, 0.0f..7.0f)
-
     internal val wallRange by float("WallRange", 3f, 0f..8f).onChange {
         if (it > range) {
             range
@@ -117,13 +90,10 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     }
 
     // Target
-    val targetTracker = tree(TargetTracker())
+    val targetTracker = tree(KillAuraTargetTracker)
 
     // Rotation
-    private val rotations = tree(object : RotationsConfigurable(this, combatSpecific = true) {
-        val rotationTimingMode by enumChoice("RotationTiming", RotationTimingMode.NORMAL)
-        val aimThroughWalls by boolean("ThroughWalls", false)
-    })
+    private val rotations = tree(KillAuraRotationsConfigurable)
 
     private val pointTracker = tree(PointTracker())
 
@@ -131,8 +101,9 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     internal val raycast by enumChoice("Raycast", TRACE_ALL)
     private val criticalsSelectionMode by enumChoice("Criticals", CriticalsSelectionMode.SMART)
     private val keepSprint by boolean("KeepSprint", true)
-    private val attackShielding by boolean("AttackShielding", false)
     private val requiresClick by boolean("RequiresClick", false)
+
+    // Inventory Handling
     internal val ignoreOpenInventory by boolean("IgnoreOpenInventory", true)
     internal val simulateInventoryClosing by boolean("SimulateInventoryClosing", true)
 
@@ -158,7 +129,8 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     private val canTargetEnemies
         get() = !requiresClick || mc.options.attackKey.isPressed
 
-    val renderHandler = handler<WorldRenderEvent> { event ->
+    @Suppress("unused")
+    private val renderHandler = handler<WorldRenderEvent> { event ->
         val matrixStack = event.matrixStack
 
         renderTarget(matrixStack, event.partialTicks)
@@ -177,7 +149,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     }
 
     @Suppress("unused")
-    val rotationUpdateHandler = handler<RotationUpdateEvent> {
+    private val rotationUpdateHandler = handler<RotationUpdateEvent> {
         // Make sure killaura-logic is not running while inventory is open
         val isInInventoryScreen =
             InventoryManager.isInventoryOpen || mc.currentScreen is GenericContainerScreen
@@ -191,7 +163,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         }
 
         // Update current target tracker to make sure you attack the best enemy
-        updateEnemySelection()
+        updateTarget()
 
         // Update Auto Weapon
         ModuleAutoWeapon.prepare(targetTracker.target)
@@ -211,6 +183,8 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             return@tickHandler
         }
 
+        ModuleDebug.debugParameter(ModuleKillAura, "Attack Cooldown", mc.attackCooldown)
+
         if (target == null) {
             val hasUnblocked = KillAuraAutoBlock.stopBlocking()
 
@@ -219,7 +193,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
                 if (hasUnblocked) {
                     waitTicks(KillAuraAutoBlock.tickOff)
                 }
-                dealWithFakeSwing(null)
+                dealWithFakeSwing(this, null)
             }
             return@tickHandler
         }
@@ -229,57 +203,61 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             return@tickHandler
         }
 
-        if (player.isSprinting && shouldBlockSprinting) {
-            player.isSprinting = false
-            return@tickHandler
-        }
-
-        // Determine if we should attack the target or someone else
-        val rotation = if (rotations.rotationTimingMode == ON_TICK) {
-            getSpot(target, range.toDouble(), PointTracker.AimSituation.FOR_NOW)?.rotation
-                ?: RotationManager.currentRotation ?: player.rotation
+        val rotation = if (rotations.rotationTiming == ON_TICK) {
+            getSpot(target, range.toDouble(), PointTracker.AimSituation.FOR_NOW)?.rotation?.normalize()
         } else {
-            RotationManager.currentRotation ?: player.rotation
-        }.normalize()
-        val chosenEntity: Entity
+            null
+        } ?: RotationManager.currentRotation ?: player.rotation
 
-        if (raycast != TRACE_NONE) {
-            // Check if between enemy and player is another entity
-            chosenEntity = raytraceEntity(range.toDouble(), rotation, filter = {
-                when (raycast) {
-                    TRACE_ONLYENEMY -> it.shouldBeAttacked()
-                    TRACE_ALL -> true
-                    else -> false
-                }
-            })?.entity ?: target
-
-            // Swap enemy if there is a better enemy (closer to the player crosshair)
-            if (chosenEntity is LivingEntity && chosenEntity.shouldBeAttacked() && chosenEntity != target) {
-                targetTracker.target = chosenEntity
+        val crosshairTarget = when {
+            raycast != TRACE_NONE -> {
+                raytraceEntity(range.toDouble(), rotation, filter = {
+                    when (raycast) {
+                        TRACE_ONLYENEMY -> it.shouldBeAttacked()
+                        TRACE_ALL -> true
+                        else -> false
+                    }
+                })?.entity ?: target
             }
-        } else {
-            chosenEntity = target
+            else -> target
         }
 
-        mightAttack(chosenEntity, rotation)
+        if (crosshairTarget is LivingEntity && crosshairTarget.shouldBeAttacked() && crosshairTarget != target) {
+            targetTracker.target = crosshairTarget
+        }
+
+        attackTarget(this, crosshairTarget, rotation)
     }
 
-    private suspend fun Sequence.mightAttack(chosenEntity: Entity, rotation: Rotation) {
+    val shouldBlockSprinting
+        get() = !ModuleElytraTarget.running
+            && criticalsSelectionMode.shouldStopSprinting(clickScheduler, targetTracker.target)
+
+    @Suppress("unused")
+    private val sprintHandler = handler<SprintEvent> { event ->
+        if (shouldBlockSprinting && (event.source == SprintEvent.Source.MOVEMENT_TICK ||
+                event.source == SprintEvent.Source.INPUT)) {
+            event.sprint = false
+        }
+    }
+
+    @Suppress("CognitiveComplexMethod")
+    private suspend fun attackTarget(sequence: Sequence, target: Entity, rotation: Rotation) {
         // Make it seem like we are blocking
         KillAuraAutoBlock.makeSeemBlock()
 
-        if (considerMissCooldown && mc.attackCooldown > 0) {
+        if (!passesMissCooldown) {
             return
         }
 
         // Are we actually facing the [chosenEntity]
-        val isFacingEnemy = facingEnemy(toEntity = chosenEntity, rotation = rotation,
+        val isFacingEnemy = facingEnemy(toEntity = target, rotation = rotation,
             range = range.toDouble(),
             wallsRange = wallRange.toDouble()) || ModuleElytraTarget.canIgnoreKillAuraRotations
 
-        ModuleDebug.debugParameter(ModuleKillAura, "isFacingEnemy", isFacingEnemy)
+        ModuleDebug.debugParameter(ModuleKillAura, "Is Facing Enemy", isFacingEnemy)
         ModuleDebug.debugParameter(ModuleKillAura, "Rotation", rotation)
-        ModuleDebug.debugParameter(ModuleKillAura, "Target", chosenEntity.nameForScoreboard)
+        ModuleDebug.debugParameter(ModuleKillAura, "Target", target.nameForScoreboard)
 
         // Check if our target is in range, otherwise deal with auto block
         if (!isFacingEnemy) {
@@ -294,36 +272,34 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             // Deal with fake swing
             if (KillAuraFailSwing.enabled) {
                 if (hasUnblocked) {
-                    waitTicks(KillAuraAutoBlock.tickOff)
+                    sequence.waitTicks(KillAuraAutoBlock.tickOff)
                 }
 
-                dealWithFakeSwing(chosenEntity)
+                dealWithFakeSwing(sequence, target)
             }
             return
         }
 
-        ModuleDebug.debugParameter(ModuleKillAura, "Good-Rotation", rotation)
+        ModuleDebug.debugParameter(ModuleKillAura, "Valid Rotation", rotation)
 
         // Attack enemy, according to the attack scheduler
-        if (clickScheduler.isGoingToClick && checkIfReadyToAttack(chosenEntity)) {
-            prepareAttackEnvironment(rotation) {
-                clickScheduler.clicks {
-                    // On each click, we check if we are still ready to attack
-                    if (!checkIfReadyToAttack(chosenEntity)) {
-                        return@clicks false
-                    }
-
-                    // Attack enemy
-                    chosenEntity.attack(true, keepSprint && !shouldBlockSprinting)
-                    KillAuraNotifyWhenFail.failedHitsIncrement = 0
-
-                    GenericDebugRecorder.recordDebugInfo(ModuleKillAura, "attackEntity", JsonObject().apply {
-                        add("player", GenericDebugRecorder.debugObject(player))
-                        add("targetPos", GenericDebugRecorder.debugObject(chosenEntity))
-                    })
-
-                    true
+        if (clickScheduler.isGoingToClick && validateAttack(target)) {
+            clickScheduler.attack(sequence, rotation) {
+                // On each click, we check if we are still ready to attack
+                if (!validateAttack(target)) {
+                    return@attack false
                 }
+
+                // Attack enemy
+                target.attack(true, keepSprint && !shouldBlockSprinting)
+                KillAuraNotifyWhenFail.failedHitsIncrement = 0
+
+                GenericDebugRecorder.recordDebugInfo(ModuleKillAura, "attackEntity", JsonObject().apply {
+                    add("player", GenericDebugRecorder.debugObject(player))
+                    add("targetPos", GenericDebugRecorder.debugObject(target))
+                })
+
+                true
             }
         } else if (KillAuraAutoBlock.tickOff > 0 && clickScheduler.isClickOnNextTick(KillAuraAutoBlock.tickOff)
             && KillAuraAutoBlock.shouldUnblockToHit) {
@@ -333,86 +309,80 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         }
     }
 
-    @Suppress("unused")
-    private val inputHandler = handler<InputHandleEvent> {
-        if (hasFailedHit) {
-            if (interaction.hasLimitedAttackSpeed()) {
-                mc.attackCooldown = 10
-            }
-
-            hasFailedHit = false
+    private fun updateTarget() {
+        // Determine aim situation based on click scheduler
+        val situation = when {
+            clickScheduler.isGoingToClick || clickScheduler.isClickOnNextTick(1)
+                -> PointTracker.AimSituation.FOR_NEXT_TICK
+            else -> PointTracker.AimSituation.FOR_THE_FUTURE
         }
-    }
+        ModuleDebug.debugParameter(ModuleKillAura, "AimSituation", situation)
 
-    /**
-     * Update enemy on target tracker
-     */
-    private fun updateEnemySelection() {
-        // Maximum range can be higher than the normal range, since we want to scan for enemies
-        // which are in our [scanExtraRange] as well
+        // Calculate maximum range based on enemy distance
         val maximumRange = if (targetTracker.closestSquaredEnemyDistance > range * range) {
             range + scanExtraRange
         } else {
             range
         }
 
-        // Find the newest target in range
-        updateTargetWithRange(maximumRange)
+        // Calculate squared maximum range once
+        val squaredMaxRange = maximumRange.pow(2)
+        val squaredNormalRange = range.pow(2)
+
+        // Find suitable target
+        val target = targetTracker.targets()
+            .filter { entity -> entity.squaredBoxedDistanceTo(player) <= squaredMaxRange }
+            .sortedBy { entity -> if (entity.squaredBoxedDistanceTo(player) <= squaredNormalRange) 0 else 1 }
+            .firstOrNull { entity -> processTarget(entity, maximumRange, situation) }
+
+        if (target == null) {
+            targetTracker.reset()
+
+            if (KillAuraFightBot.enabled) {
+                KillAuraFightBot.updateTarget()
+                RotationManager.setRotationTarget(
+                    rotations.toAimPlan(
+                        KillAuraFightBot.getMovementRotation(),
+                        considerInventory = !ignoreOpenInventory
+                    ),
+                    priority = Priority.IMPORTANT_FOR_USAGE_2,
+                    provider = ModuleKillAura
+                )
+            }
+
+        }
     }
 
-    private fun updateTargetWithRange(range: Float) {
-        val situation = when {
-            clickScheduler.isGoingToClick ||
-                clickScheduler.isClickOnNextTick(1) -> PointTracker.AimSituation.FOR_NEXT_TICK
+    private fun processTarget(
+        entity: LivingEntity,
+        maximumRange: Float,
+        situation: PointTracker.AimSituation
+    ): Boolean {
+        val (rotation, vec) = getSpot(entity, maximumRange.toDouble(), situation) ?: return false
+        val ticks = rotations.howLongToReach(rotation)
 
-            else -> PointTracker.AimSituation.FOR_THE_FUTURE
+        // Validate if we meet timing requirements
+        when (rotations.rotationTiming) {
+            SNAP -> if (!clickScheduler.isClickOnNextTick(ticks.coerceAtLeast(1))) return false
+            ON_TICK -> if (ticks > 1) return false
+            else -> { /* Other modes don't have special conditions */ }
         }
-        ModuleDebug.debugParameter(ModuleKillAura, "AimSituation", situation)
 
-        for (target in targetTracker.targets()) {
-            if (target.squaredBoxedDistanceTo(player) > range * range) {
-                continue
-            }
+        // Set target and rotation
+        targetTracker.target = entity
 
-            val spot = getSpot(target, range.toDouble(), situation) ?: continue
+        RotationManager.setRotationTarget(
+            rotations.toAimPlan(
+                rotation,
+                vec,
+                entity,
+                considerInventory = !ignoreOpenInventory
+            ),
+            priority = Priority.IMPORTANT_FOR_USAGE_2,
+            provider = this@ModuleKillAura
+        )
 
-            val ticks = rotations.howLongToReach(spot.rotation)
-            if (rotations.rotationTimingMode == SNAP && !clickScheduler.isClickOnNextTick(ticks.coerceAtLeast(1))
-                // On Tick can only be used if the distance is not too far compared to the turn speed
-                || rotations.rotationTimingMode == ON_TICK && ticks <= 1) {
-                continue
-            }
-
-            val (rotation, vec) = spot
-
-            targetTracker.target = target
-            RotationManager.setRotationTarget(
-                rotations.toAimPlan(
-                    rotation,
-                    vec,
-                    target,
-                    considerInventory = !ignoreOpenInventory
-                ),
-                priority = Priority.IMPORTANT_FOR_USAGE_2,
-                provider = this@ModuleKillAura
-            )
-            return
-        }
-        targetTracker.reset()
-
-        // Choose enemy for fight bot
-        if (KillAuraFightBot.enabled) {
-            targetTracker.selectFirst()
-
-            RotationManager.setRotationTarget(
-                rotations.toAimPlan(
-                    KillAuraFightBot.getMovementRotation(),
-                    considerInventory = !ignoreOpenInventory
-                ),
-                priority = Priority.IMPORTANT_FOR_USAGE_2,
-                provider = this@ModuleKillAura
-            )
-        }
+        return true
     }
 
     /**
@@ -479,88 +449,16 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         }
     }
 
-    private fun checkIfReadyToAttack(choosenEntity: Entity): Boolean {
-        val criticalHit = criticalsSelectionMode.isCriticalHit(choosenEntity)
-        val shielding = attackShielding || choosenEntity !is PlayerEntity || player.mainHandStack.item is AxeItem ||
-            !choosenEntity.wouldBlockHit(player)
-        val isInInventoryScreen =
-            InventoryManager.isInventoryOpen || mc.currentScreen is GenericContainerScreen
-        val missCooldown = considerMissCooldown && mc.attackCooldown > 0
-
-        return (criticalHit || ModuleElytraTarget.running) && shielding &&
-            !(isInInventoryScreen && !ignoreOpenInventory && !simulateInventoryClosing) && !missCooldown
-    }
-
     /**
-     * Prepare the environment for attacking an entity
-     *
-     * This means, we make sure we are not blocking, we are not using another item,
-     * and we are not in an inventory screen depending on the configuration.
+     * Check if we can attack the target at the current moment
      */
-    internal suspend fun Sequence.prepareAttackEnvironment(rotation: Rotation? = null, attack: () -> Unit) {
+    internal fun validateAttack(target: Entity? = null): Boolean {
+        val criticalHit = target == null || criticalsSelectionMode.isCriticalHit(target)
         val isInInventoryScreen =
             InventoryManager.isInventoryOpen || mc.currentScreen is GenericContainerScreen
 
-        if (simulateInventoryClosing && isInInventoryScreen) {
-            network.sendPacket(CloseHandledScreenC2SPacket(0))
-        }
-
-        if (player.isBlockAction) {
-            if (!KillAuraAutoBlock.enabled && !ModuleMultiActions.mayCurrentlyAttackWhileUsing()) {
-                return
-            }
-
-            if (KillAuraAutoBlock.enabled && KillAuraAutoBlock.shouldUnblockToHit) {
-                // Wait for the tick off time to be over, if it's not 0
-                // Ideally this should not happen.
-                if (KillAuraAutoBlock.stopBlocking(pauses = true) && KillAuraAutoBlock.tickOff > 0) {
-                    waitTicks(KillAuraAutoBlock.tickOff)
-                }
-            }
-        } else if (player.isUsingItem && !ModuleMultiActions.mayCurrentlyAttackWhileUsing()) {
-            return // return if it's not allowed to attack while the player is using another item that's not a shield
-        }
-
-        if (rotations.rotationTimingMode == ON_TICK && rotation != null) {
-            network.sendPacket(Full(player.x, player.y, player.z, rotation.yaw, rotation.pitch, player.isOnGround,
-                player.horizontalCollision))
-        }
-
-        attack()
-
-        if (rotations.rotationTimingMode == ON_TICK && rotation != null) {
-            network.sendPacket(
-                Full(player.x, player.y, player.z, player.withFixedYaw(rotation), player.pitch, player.isOnGround,
-                    player.horizontalCollision)
-            )
-        }
-
-        if (simulateInventoryClosing && isInInventoryScreen) {
-            openInventorySilently()
-        }
-
-        // If the player was blocking before, we start blocking again after the attack if the tick on is 0
-        if (KillAuraAutoBlock.blockImmediate) {
-            KillAuraAutoBlock.startBlocking()
-        }
-    }
-
-    val shouldBlockSprinting get() =
-        !ModuleElytraTarget.running
-        && criticalsSelectionMode.shouldStopSprinting(clickScheduler, targetTracker.target)
-
-    @Suppress("unused")
-    private val sprintHandler = handler<SprintEvent> { event ->
-        if (shouldBlockSprinting && (event.source == SprintEvent.Source.MOVEMENT_TICK ||
-                event.source == SprintEvent.Source.INPUT)) {
-            event.sprint = false
-        }
-    }
-
-    private enum class RotationTimingMode(override val choiceName: String) : NamedChoice {
-        NORMAL("Normal"),
-        SNAP("Snap"),
-        ON_TICK("OnTick")
+        return (criticalHit || ModuleElytraTarget.running) &&
+            !(isInInventoryScreen && !ignoreOpenInventory && !simulateInventoryClosing) && passesMissCooldown
     }
 
     enum class RaycastMode(override val choiceName: String) : NamedChoice {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFailSwing.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFailSwing.kt
@@ -21,20 +21,19 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.killaura.feature
 import net.ccbluex.liquidbounce.config.types.NoneChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraClicker.attack
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.KillAuraClicker.considerMissCooldown
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.prepareAttackEnvironment
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.validateAttack
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.Box
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.Sound
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
-import net.ccbluex.liquidbounce.utils.clicking.Clicker
 import net.ccbluex.liquidbounce.utils.combat.findEnemy
-import net.ccbluex.liquidbounce.utils.entity.boxedDistanceTo
-import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
-import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
+import net.ccbluex.liquidbounce.utils.entity.rotation
+import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.minecraft.entity.Entity
 import net.minecraft.util.Hand
 import net.minecraft.util.hit.HitResult
+import kotlin.math.pow
 
 internal object KillAuraFailSwing : ToggleableConfigurable(ModuleKillAura, "FailSwing", false) {
 
@@ -42,55 +41,41 @@ internal object KillAuraFailSwing : ToggleableConfigurable(ModuleKillAura, "Fail
      * Additional range for fail swing to work
      */
     private val additionalRange by float("AdditionalRange", 2f, 0f..10f)
-    val clicker = tree(Clicker(this, false))
     val mode = choices(this, "NotifyWhenFail", activeIndex = 1) {
         arrayOf(NoneChoice(it), Box, Sound)
     }.apply {
         doNotIncludeAlways()
     }
 
-    suspend fun Sequence.dealWithFakeSwing(target: Entity?) {
-        if (!enabled) {
+    suspend fun dealWithFakeSwing(sequence: Sequence, target: Entity?) {
+        if (!enabled || !validateAttack()) {
             return
         }
-
-        if (considerMissCooldown && mc.attackCooldown > 0) {
-            return
-        }
-
-        val isInInventoryScreen =
-            InventoryManager.isInventoryOpen || mc.currentScreen is GenericContainerScreen
-
-        if (isInInventoryScreen && !ModuleKillAura.ignoreOpenInventory && !ModuleKillAura.simulateInventoryClosing) {
-            return
-        }
-
-        val raycastType = mc.crosshairTarget?.type
 
         val range = ModuleKillAura.range + additionalRange
         val entity = target ?: world.findEnemy(0f..range) ?: return
+        val raycastType = mc.crosshairTarget?.type
 
-        if (entity.isRemoved || entity.boxedDistanceTo(player) > range || raycastType != HitResult.Type.MISS) {
+        if (entity.isRemoved || entity.squaredBoxedDistanceTo(player) > range.pow(2)
+            || raycastType != HitResult.Type.MISS) {
             return
         }
 
         // Make it seem like we are blocking
         KillAuraAutoBlock.makeSeemBlock()
 
-        if (clicker.isGoingToClick) {
-            prepareAttackEnvironment {
-                clicker.clicks {
-                    if (considerMissCooldown && mc.attackCooldown > 0) {
-                        return@clicks false
-                    }
-
-                    player.swingHand(Hand.MAIN_HAND)
-
-                    // Notify the user about the failed hit
-                    KillAuraNotifyWhenFail.notifyForFailedHit(entity, RotationManager.serverRotation)
-                    true
-                }
+        attack(sequence) {
+            // [this.crosshairTarget == null] results in a limited attack speed
+            if (interaction.hasLimitedAttackSpeed()) {
+                mc.attackCooldown = 10
             }
+
+            player.swingHand(Hand.MAIN_HAND)
+
+            // Notify the user about the failed hit
+            KillAuraNotifyWhenFail.notifyForFailedHit(entity, RotationManager.currentRotation
+                ?: player.rotation)
+            true
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
@@ -73,6 +73,9 @@ object KillAuraFightBot : NavigationBaseConfigurable<CombatContext>(ModuleKillAu
         tree(LeaderFollower)
     }
 
+    fun updateTarget() {
+        targetTracker.selectFirst()
+    }
 
     /**
      * Creates combat context

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraNotifyWhenFail.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraNotifyWhenFail.kt
@@ -41,7 +41,6 @@ import net.minecraft.util.math.Vec3d
 internal object KillAuraNotifyWhenFail {
 
     internal val failedHits = ArrayDeque<ObjectLongMutablePair<Vec3d>>()
-    var hasFailedHit = false
     var failedHitsIncrement = 0
 
     object Box : Choice("Box") {
@@ -67,7 +66,6 @@ internal object KillAuraNotifyWhenFail {
         get() = 50 * Box.fadeSeconds
 
     fun notifyForFailedHit(entity: Entity, rotation: Rotation) {
-        hasFailedHit = true
         failedHitsIncrement++
 
         when (mode.activeChoice) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/TargetTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/TargetTracker.kt
@@ -34,7 +34,7 @@ import net.minecraft.entity.player.PlayerEntity
 /**
  * A target tracker to choose the best enemy to attack
  */
-class TargetTracker(
+open class TargetTracker(
     defaultPriority: TargetPriority = TargetPriority.HEALTH,
     rangeValue: RangedValueProvider = NoneRangedValueProvider
 ) : TargetSelector(defaultPriority, rangeValue) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -345,7 +345,7 @@ fun getNearestPointOnSide(eyes: Vec3d, box: Box, side: Direction): Vec3d {
 
 }
 
-fun PlayerEntity.wouldBlockHit(source: PlayerEntity): Boolean {
+fun LivingEntity.wouldBlockHit(source: PlayerEntity): Boolean {
     if (!this.isBlocking) {
         return false
     }


### PR DESCRIPTION
Drastically improves the way KillAura selects targets when it is unable to break shields, either when no axe is selected or when we do not have Auto Weapon enabled with axe selection.

Often misunderstood. Shield Breaker is INTEGRATED with Auto Weapon. Select Axe for the [Blocked by Shield] option, and it will automatically break shields on attack if configured with at least 1 tick of on-time.