### PR TITLE
refactor(Rotations): remove camera option

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
@@ -20,9 +20,11 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.render;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleDroneControl;
-import net.ccbluex.liquidbounce.features.module.modules.render.*;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleCameraClip;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleFreeCam;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleFreeLook;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleQuickPerspectiveSwap;
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager;
-import net.ccbluex.liquidbounce.utils.aiming.RotationTarget;
 import net.ccbluex.liquidbounce.utils.aiming.features.MovementCorrection;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.Entity;
@@ -102,15 +104,12 @@ public abstract class MixinCamera {
             this.setRotation(screen.getCameraRotation().x, screen.getCameraRotation().y);
         }
 
-        RotationTarget rotationTarget = RotationManager.INSTANCE.getActiveRotationTarget();
-
+        var rotationTarget = RotationManager.INSTANCE.getActiveRotationTarget();
         var previousRotation = RotationManager.INSTANCE.getPreviousRotation();
         var currentRotation = RotationManager.INSTANCE.getCurrentRotation();
 
-        boolean shouldModifyRotation = ModuleRotations.INSTANCE.getRunning() && ModuleRotations.INSTANCE.getCamera()
-            || rotationTarget != null && rotationTarget.getMovementCorrection() == MovementCorrection.CHANGE_LOOK;
-
-        if (currentRotation == null || previousRotation == null || !shouldModifyRotation) {
+        var changeLook = rotationTarget != null && rotationTarget.getMovementCorrection() == MovementCorrection.CHANGE_LOOK;
+        if (currentRotation == null || previousRotation == null || !changeLook) {
             return;
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -74,11 +74,6 @@ object ModuleRotations : ClientModule("Rotations", Category.RENDER) {
      */
     private val smooth by float("Smooth", 0.0f, 0.0f..0.3f)
 
-    /**
-     * Changes the perspective of the camera to match the Rotation Manager perspective
-     * without changing the player perspective.
-     */
-    val camera by boolean("Camera", false)
     private val vectorLine by color("VectorLine", Color4b.WHITE.with(a = 0)) // alpha 0 means OFF
     private val vectorDot by color("VectorDot", Color4b(0x00, 0x80, 0xFF, 0x00))
 


### PR DESCRIPTION
The option would change the camera's perspective to match the rotation manager's perspective without changing the actual player rotation, which kept your movement intact.

However. It seems that so many people misunderstand this option and enable it without understanding what it does.