### PR TITLE
fix(Clicker): flawed attack cooldown handling

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.common.GlobalFramebuffer;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.*;
 import net.ccbluex.liquidbounce.features.misc.HideAppearance;
+import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoClicker;
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleNoMissCooldown;
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions;
@@ -283,6 +284,13 @@ public abstract class MixinMinecraftClient {
     private int injectNoMissCooldown(int original) {
         if (ModuleNoMissCooldown.INSTANCE.getRunning() && ModuleNoMissCooldown.INSTANCE.getRemoveAttackCooldown()) {
             return 0;
+        }
+
+        if (ModuleAutoClicker.AttackButton.INSTANCE.getRunning()) {
+            var clickAmount = ModuleAutoClicker.AttackButton.INSTANCE.getClicker().getClickAmount();
+            if (clickAmount != null && clickAmount > 0) {
+                return 0;
+            }
         }
 
         return original;

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientPlayerInteractionManager.java
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.network;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.*;
-import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoClicker;
 import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleAutoBow;
 import net.ccbluex.liquidbounce.features.module.modules.combat.crystalaura.trigger.triggers.ClientBlockBreakTrigger;
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar;
@@ -98,13 +97,6 @@ public abstract class MixinClientPlayerInteractionManager {
     @ModifyExpressionValue(method = "syncSelectedSlot", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I"))
     private int hookCustomSelectedSlot(int original) {
         return SilentHotbar.INSTANCE.getServersideSlot();
-    }
-
-    @Inject(method = "hasLimitedAttackSpeed", at = @At("HEAD"), cancellable = true)
-    private void injectAutoClicker(CallbackInfoReturnable<Boolean> cir) {
-        if (ModuleAutoClicker.Left.INSTANCE.getRunning()) {
-            cir.setReturnValue(false);
-        }
     }
 
     @Inject(method = "interactItem", at = @At("RETURN"))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -45,7 +45,7 @@ import net.minecraft.util.hit.EntityHitResult
 
 object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases = arrayOf("TriggerBot")) {
 
-    object Left : ToggleableConfigurable(this, "Attack", true) {
+    object AttackButton : ToggleableConfigurable(this, "Attack", true) {
 
         val clicker = tree(Clicker(this, mc.options.attackKey, true))
         internal val requiresNoInput by boolean("RequiresNoInput", false)
@@ -143,7 +143,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
 
     }
 
-    object Right : ToggleableConfigurable(this, "Use", false) {
+    object UseButton : ToggleableConfigurable(this, "Use", false) {
         val clicker = tree(Clicker(this, mc.options.useKey, false))
         internal val delayStart by boolean("DelayStart", false)
         internal val onlyBlock by boolean("OnlyBlock", false)
@@ -153,19 +153,19 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
     }
 
     init {
-        tree(Left)
-        tree(Right)
+        tree(AttackButton)
+        tree(UseButton)
     }
 
     val attack: Boolean
-        get() = mc.options.attackKey.isPressed || Left.requiresNoInput
+        get() = mc.options.attackKey.isPressed || AttackButton.requiresNoInput
 
     val use: Boolean
-        get() = mc.options.useKey.isPressed || Right.requiresNoInput
+        get() = mc.options.useKey.isPressed || UseButton.requiresNoInput
 
     @Suppress("unused")
     val tickHandler = tickHandler {
-        Left.run {
+        AttackButton.run {
             if (!enabled || !attack || !isWeaponSelected() || !isOnObjective()) {
                 return@run
             }
@@ -198,7 +198,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
             }
         }
 
-        Right.run {
+        UseButton.run {
             if (!enabled) return@run
 
             if (!use) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -47,7 +47,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
 
     object Left : ToggleableConfigurable(this, "Attack", true) {
 
-        val clicker = tree(Clicker(this, true))
+        val clicker = tree(Clicker(this, mc.options.attackKey, true))
         internal val requiresNoInput by boolean("RequiresNoInput", false)
         private val objectiveType by enumChoice("Objective", ObjectiveType.ANY)
         private val onItemUse by enumChoice("OnItemUse", Use.WAIT)
@@ -144,7 +144,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
     }
 
     object Right : ToggleableConfigurable(this, "Use", false) {
-        val clicker = tree(Clicker(this, false))
+        val clicker = tree(Clicker(this, mc.options.useKey, false))
         internal val delayStart by boolean("DelayStart", false)
         internal val onlyBlock by boolean("OnlyBlock", false)
         internal val requiresNoInput by boolean("RequiresNoInput", false)
@@ -192,7 +192,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
                 }
             }
 
-            clicker.clicks {
+            clicker.click {
                 KeyBinding.onKeyPressed(mc.options.attackKey.boundKey)
                 true
             }
@@ -216,7 +216,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
                 return@run
             }
 
-            clicker.clicks {
+            clicker.click {
                 KeyBinding.onKeyPressed(mc.options.useKey.boundKey)
                 true
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
@@ -67,7 +67,7 @@ object ModuleAutoShoot : ClientModule("AutoShoot", Category.COMBAT) {
     private val throwableType by enumChoice("ThrowableType", ThrowableType.EGG_AND_SNOWBALL)
     private val gravityType by enumChoice("GravityType", GravityType.AUTO).apply { tagBy(this) }
 
-    private val clicker = tree(Clicker(this, showCooldown = false))
+    private val clicker = tree(Clicker(this, mc.options.useKey, showCooldown = false))
 
     /**
      * The target tracker to find the best enemy to attack.
@@ -187,9 +187,9 @@ object ModuleAutoShoot : ClientModule("AutoShoot", Category.COMBAT) {
         }
 
         // Check if we are still aiming at the target
-        clicker.clicks {
+        clicker.click {
             if (player.isUsingItem || (considerInventory && InventoryManager.isInventoryOpen)) {
-                return@clicks false
+                return@click false
             }
 
             interaction.interactItem(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -19,7 +19,10 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
-import net.ccbluex.liquidbounce.event.events.*
+import net.ccbluex.liquidbounce.event.events.MovementInputEvent
+import net.ccbluex.liquidbounce.event.events.PacketEvent
+import net.ccbluex.liquidbounce.event.events.PlayerTickEvent
+import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
@@ -127,7 +130,7 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
         // We do not want to tickbase if killaura is not ready to attack
         val breakRequirement = {
             requiresKillAura && !(ModuleKillAura.running &&
-                ModuleKillAura.clickScheduler.isClickOnNextTick(bestTick))
+                ModuleKillAura.clickScheduler.willClickAt(bestTick))
         }
 
         if (breakRequirement()) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/ModuleCriticals.kt
@@ -189,7 +189,7 @@ object ModuleCriticals : ClientModule("Criticals", Category.COMBAT) {
             }
 
             // If we are about to do a critical hit, we should stop sprinting.
-            return target != null && clicker.isClickOnNextTick(1)
+            return target != null && clicker.willClickAt(1)
         }
 
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
@@ -117,6 +117,10 @@ object CriticalsJump : Choice("Jump") {
             return false
         }
 
+        if (player.isGliding) {
+            return false
+        }
+
         if (!allowsCriticalHit() || player.velocity.y < -0.08) {
             return false
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/AutoFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/AutoFirework.kt
@@ -46,7 +46,7 @@ internal object AutoFirework : ToggleableConfigurable(ModuleElytraTarget, "AutoF
         if (!KillAura.running
             || !syncCooldownWithKillAura
             || (
-                KillAura.clickScheduler.isGoingToClick
+                KillAura.clickScheduler.isClickTick
                 && KillAura.targetTracker.target
                     ?.squaredBoxedDistanceTo(player)
                     ?.takeIf { it >= KillAura.range * KillAura.range } != null
@@ -60,7 +60,7 @@ internal object AutoFirework : ToggleableConfigurable(ModuleElytraTarget, "AutoF
          * We can use the firework on the next tick.
          * After killaura performed the click
          */
-        return if (KillAura.clickScheduler.isGoingToClick) {
+        return if (KillAura.clickScheduler.isClickTick) {
             waitTicks(1)
             true
         } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -35,19 +35,7 @@ import net.ccbluex.liquidbounce.utils.inventory.openInventorySilently
 import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.Full
 
-object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, true) {
-
-    /**
-     * When missing a hit, Minecraft has a cooldown before you can attack again.
-     * This option will consider the cooldown before attacking again.
-     *
-     * This is useful for anti-cheats that detect if you are ignoring this cooldown.
-     * Applies to the FailSwing feature as well.
-     */
-    val considerMissCooldown by boolean("ConsiderMissCooldown", false)
-
-    val passesMissCooldown
-        get() = !considerMissCooldown || mc.attackCooldown <= 0
+object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, mc.options.attackKey, true) {
 
     /**
      * Prepare the environment for attacking an entity
@@ -56,7 +44,7 @@ object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, true) {
      * and we are not in an inventory screen depending on the configuration.
      */
     suspend fun attack(sequence: Sequence, rotation: Rotation? = null, attack: () -> Boolean) {
-        if (!isGoingToClick) {
+        if (!isClickTick) {
             // If we are not going to click, we don't need to prepare the environment
             return
         }
@@ -66,13 +54,7 @@ object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, true) {
             return
         }
 
-        clicks {
-            if (!passesMissCooldown) {
-                return@clicks false
-            }
-
-            attack()
-        }
+        click(attack)
 
         interactiveScene.unprepare()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -183,8 +183,6 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             return@tickHandler
         }
 
-        ModuleDebug.debugParameter(ModuleKillAura, "Attack Cooldown", mc.attackCooldown)
-
         if (target == null) {
             val hasUnblocked = KillAuraAutoBlock.stopBlocking()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -283,7 +283,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         ModuleDebug.debugParameter(ModuleKillAura, "Valid Rotation", rotation)
 
         // Attack enemy, according to the attack scheduler
-        if (clickScheduler.isGoingToClick && validateAttack(target)) {
+        if (clickScheduler.isClickTick && validateAttack(target)) {
             clickScheduler.attack(sequence, rotation) {
                 // On each click, we check if we are still ready to attack
                 if (!validateAttack(target)) {
@@ -301,7 +301,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
                 true
             }
-        } else if (KillAuraAutoBlock.tickOff > 0 && clickScheduler.isClickOnNextTick(KillAuraAutoBlock.tickOff)
+        } else if (KillAuraAutoBlock.tickOff > 0 && clickScheduler.willClickAt(KillAuraAutoBlock.tickOff)
             && KillAuraAutoBlock.shouldUnblockToHit) {
             KillAuraAutoBlock.stopBlocking(pauses = true)
         } else {
@@ -312,7 +312,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     private fun updateTarget() {
         // Determine aim situation based on click scheduler
         val situation = when {
-            clickScheduler.isGoingToClick || clickScheduler.isClickOnNextTick(1)
+            clickScheduler.isClickTick || clickScheduler.willClickAt(1)
                 -> PointTracker.AimSituation.FOR_NEXT_TICK
             else -> PointTracker.AimSituation.FOR_THE_FUTURE
         }
@@ -368,7 +368,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
             // If our click scheduler is not going to click the moment we reach the target,
             // we should not start aiming towards the target just yet.
-            SNAP -> if (!clickScheduler.isClickOnNextTick(ticks.coerceAtLeast(1))) {
+            SNAP -> if (!clickScheduler.willClickAt(ticks.coerceAtLeast(1))) {
                 return true
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
@@ -117,7 +117,7 @@ object KillAuraFightBot : NavigationBaseConfigurable<CombatContext>(ModuleKillAu
 
         // Otherwise handle combat movement
         val combatTarget = context.combatTarget ?: return null
-        return if (runawayOnCooldown && !clickScheduler.isClickOnNextTick()) {
+        return if (runawayOnCooldown && !clickScheduler.willClickAt()) {
             calculateRunawayPosition(context, combatTarget)
         } else {
             calculateAttackPosition(context, combatTarget)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
@@ -43,7 +43,7 @@ object ModuleTpAura : ClientModule("TpAura", Category.COMBAT, disableOnQuit = tr
 
     private val attackRange by float("AttackRange", 4.2f, 3f..5f)
 
-    val clicker = tree(Clicker(this, true))
+    val clicker = tree(Clicker(this, mc.options.attackKey, true))
     val mode = choices("Mode", AStarMode, arrayOf(AStarMode, ImmediateMode))
     val targetSelector = tree(TargetSelector(TargetPriority.HURT_TIME))
 
@@ -54,10 +54,10 @@ object ModuleTpAura : ClientModule("TpAura", Category.COMBAT, disableOnQuit = tr
     private val attackRepeatable = tickHandler {
         val position = desyncPlayerPosition ?: player.pos
 
-        clicker.clicks {
+        clicker.click {
             val enemy = targetSelector.targets().firstOrNull {
                 it.squaredBoxedDistanceTo(position) <= attackRange * attackRange
-            } ?: return@clicks false
+            } ?: return@click false
 
             enemy.attack(true, keepSprint = true)
             true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
@@ -53,7 +53,7 @@ object AStarMode : TpAuraChoice("AStar") {
     private val tickHandler = tickHandler {
         val (_, path) = pathCache ?: return@tickHandler
 
-        if (!clicker.isGoingToClick) {
+        if (!clicker.isClickTick) {
             return@tickHandler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -27,7 +27,7 @@ import kotlin.math.floor
 object ImmediateMode : TpAuraChoice("Immediate") {
 
     val repeatable = tickHandler {
-        if (!clicker.isGoingToClick) {
+        if (!clicker.isClickTick) {
             return@tickHandler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
@@ -48,7 +48,7 @@ import net.minecraft.util.math.MathHelper
  */
 object ModuleProjectilePuncher : ClientModule("ProjectilePuncher", Category.WORLD, aliases = arrayOf("AntiFireball")) {
 
-    private val clicker = tree(Clicker(ModuleProjectilePuncher, false))
+    private val clicker = tree(Clicker(ModuleProjectilePuncher, mc.options.attackKey, false))
 
     private val swing by boolean("Swing", true)
     private val range by float("Range", 3f, 3f..6f)
@@ -85,7 +85,7 @@ object ModuleProjectilePuncher : ClientModule("ProjectilePuncher", Category.WORL
             return@tickHandler
         }
 
-        clicker.clicks {
+        clicker.click {
             target.attack(swing)
             true
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
@@ -196,7 +196,7 @@ object ModuleScaffold : ClientModule("Scaffold", Category.WORLD) {
 
     object SimulatePlacementAttempts : ToggleableConfigurable(this, "SimulatePlacementAttempts", false) {
 
-        internal val clicker = tree(Clicker(ModuleScaffold, false, maxCps = 100))
+        internal val clicker = tree(Clicker(ModuleScaffold, mc.options.useKey, false, maxCps = 100))
         val failedAttemptsOnly by boolean("FailedAttemptsOnly", true)
     }
 
@@ -471,9 +471,9 @@ object ModuleScaffold : ClientModule("Scaffold", Category.WORLD) {
             arrayOf(Hand.MAIN_HAND, Hand.OFF_HAND).firstOrNull { isValidBlock(player.getStackInHand(it)) }
 
         if (simulatePlacementAttempts(currentCrosshairTarget, suitableHand) && player.moving
-            && SimulatePlacementAttempts.clicker.isGoingToClick
+            && SimulatePlacementAttempts.clicker.isClickTick
         ) {
-            SimulatePlacementAttempts.clicker.clicks {
+            SimulatePlacementAttempts.clicker.click {
                 doPlacement(currentCrosshairTarget!!, suitableHand!!, swingMode = swingMode)
                 true
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -28,7 +28,6 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.clicking.pattern.ClickPattern
 import net.ccbluex.liquidbounce.utils.clicking.pattern.patterns.*
-import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.minecraft.client.option.KeyBinding
@@ -113,8 +112,6 @@ open class Clicker<T>(
     fun willClickAt(tick: Int = 1) = getClickAmount(tick) > 0
 
     fun getClickAmount(tick: Int = 0): Int {
-        chat("Clicks: ${clickArray.get(tick)}")
-
         if (isEnforcedClick()) {
             return RNG.nextInt(clickArray.min(), clickArray.max())
                 .coerceAtLeast(1)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -161,6 +161,8 @@ open class Clicker<T>(
             debugParameter(this@Clicker, "Current Clicks", clicks)
             debugParameter(this@Clicker, "Peek Clicks", clickArray.get(1))
             debugParameter(this@Clicker, "Last Click Passed", lastClickPassed)
+            debugParameter(this@Clicker, "Attack Cooldown", mc.attackCooldown)
+            debugParameter(this@Clicker, "Item Cooldown", cooldown?.cooldownProgress() ?: 0.0f)
         }
 
         if (clicks == 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.utils.kotlin.random
 
-class ClickCooldown<T>(module: T) : ToggleableConfigurable(module, "Cooldown", true)
+class ItemCooldown<T>(module: T) : ToggleableConfigurable(module, "ItemCooldown", true, aliases = arrayOf("Cooldown"))
     where T : EventListener {
 
     private val minimumCooldown by floatRange(
@@ -32,7 +32,7 @@ class ClickCooldown<T>(module: T) : ToggleableConfigurable(module, "Cooldown", t
 
     private var nextCooldown = minimumCooldown.random()
 
-    fun readyToAttack(ticks: Int = 0) = !this.enabled || cooldownProgress(ticks) >= nextCooldown
+    fun isCooldownPassed(ticks: Int = 0) = !this.enabled || cooldownProgress(ticks) >= nextCooldown
 
     /**
      * Calculates the current cooldown progress.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -39,7 +39,7 @@ class ItemCooldown<T>(module: T) : ToggleableConfigurable(module, "ItemCooldown"
      *
      * This can be out of percentage range [0, 1] to allow for higher minimum cooldowns.
      */
-    private fun cooldownProgress(baseTime: Int = 0) =
+    fun cooldownProgress(baseTime: Int = 0) =
         (player.lastAttackedTicks + baseTime).toFloat() / player.attackCooldownProgressPerTick
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/RollingClickArray.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/RollingClickArray.kt
@@ -45,11 +45,12 @@ class RollingClickArray(private val cycleLength: Int, val iterations: Int) {
         head = 0
     }
 
-    /**
-     * Returns list of next cycle values
-     */
-    fun nextCycleList(): List<Int> {
-        return List(cycleLength) { get(it) }
+    fun max(): Int {
+        return array.maxOrNull() ?: 0
+    }
+
+    fun min(): Int {
+        return array.minOrNull() ?: 0
     }
 
     fun push(cycleArray: IntArray) {


### PR DESCRIPTION
The 'Consider Miss Cooldown' option was not working at all, because
1. When Auto Clicker was enabled, we would always have a cooldown of 0 due to a hacky patch by @mems01.
2. We did not mark the [KeyBinding] as pressed, when we clicked, so Minecraft automatically reset the attack cooldown back to zero.

Also:
- Cooldown is now renamed to Item Cooldown
- Consider Miss Cooldown is now renamed to Attack Cooldown (To follow the naming scheme).

Attack Cooldown integration is now tightly built into Clicker, which allows modules that rely on the [attackKey] to use the function as well. It's also enabled by default now.

This WILL decrease CPS on e.g. Auto Clicker when missing!