### PR TITLE
fix(Keybinding): attack pressing check

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
@@ -40,6 +40,7 @@ import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.combat.TargetPriority
 import net.ccbluex.liquidbounce.utils.combat.TargetTracker
 import net.ccbluex.liquidbounce.utils.entity.rotation
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.render.WorldTargetRenderer
 import net.minecraft.client.gui.screen.ingame.HandledScreen
@@ -87,12 +88,12 @@ object ModuleAimbot : ClientModule("Aimbot", Category.COMBAT, aliases = arrayOf(
     private val tickHandler = handler<RotationUpdateEvent> { _ ->
         playerRotation = player.rotation
 
-        if (mc.options.attackKey.isPressed) {
+        if (mc.options.attackKey.isPressedOnAny) {
             clickTimer.reset()
         }
 
         if (OnClick.enabled && (clickTimer.hasElapsed(OnClick.delayUntilStop * 50L)
-        || !mc.options.attackKey.isPressed && ModuleAutoClicker.running)) {
+        || !mc.options.attackKey.isPressedOnAny && ModuleAutoClicker.running)) {
             targetRotation = null
             return@handler
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.CriticalsSelectionMode
 import net.ccbluex.liquidbounce.utils.clicking.Clicker
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.minecraft.client.option.KeyBinding
 import net.minecraft.entity.Entity
 import net.minecraft.item.AxeItem
@@ -158,10 +159,10 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
     }
 
     val attack: Boolean
-        get() = mc.options.attackKey.isPressed || AttackButton.requiresNoInput
+        get() = mc.options.attackKey.isPressedOnAny || AttackButton.requiresNoInput
 
     val use: Boolean
-        get() = mc.options.useKey.isPressed || UseButton.requiresNoInput
+        get() = mc.options.useKey.isPressedOnAny || UseButton.requiresNoInput
 
     @Suppress("unused")
     val tickHandler = tickHandler {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/aimbot/DroneControlScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/aimbot/DroneControlScreen.kt
@@ -8,6 +8,7 @@ import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.client.toDegrees
 import net.ccbluex.liquidbounce.utils.entity.box
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.ccbluex.liquidbounce.utils.math.geometry.NormalizedPlane
 import net.ccbluex.liquidbounce.utils.math.plus
 import net.ccbluex.liquidbounce.utils.render.WorldToScreen
@@ -113,7 +114,7 @@ class DroneControlScreen : Screen("BowAimbot Control Panel".asText()) {
     override fun mouseMoved(mouseX: Double, mouseY: Double) {
         val focusedEntity = this.focusedEntity
 
-        if (mc.options.sneakKey.isPressed && focusedEntity != null) {
+        if (mc.options.sneakKey.isPressedOnAny && focusedEntity != null) {
             val rot = Rotation.lookingAt(point = focusedEntity.entity.box.center, from = this.cameraPos)
 
             this.cameraRotation = Vec2f(rot.yaw, rot.pitch)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -58,6 +58,7 @@ import net.ccbluex.liquidbounce.utils.combat.attack
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.rotation
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager.isInventoryOpen
 import net.ccbluex.liquidbounce.utils.inventory.isInContainerScreen
@@ -128,7 +129,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     }
 
     private val canTargetEnemies
-        get() = !requiresClick || mc.options.attackKey.isPressed
+        get() = !requiresClick || mc.options.attackKey.isPressedOnAny
 
     @Suppress("unused")
     private val renderHandler = handler<WorldRenderEvent> { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -43,6 +43,7 @@ import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEquals1_7_10
 import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.isBlockAction
 import net.ccbluex.liquidbounce.utils.entity.rotation
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.ccbluex.liquidbounce.utils.input.shouldSwingHand
 import net.minecraft.item.ItemStack
 import net.minecraft.item.consume.UseAction
@@ -210,7 +211,7 @@ object KillAuraAutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking"
         if (!pauses) {
             blockVisual = false
 
-            if (mc.options.useKey.isPressed) {
+            if (mc.options.useKey.isPressedOnAny) {
                 return false
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
@@ -32,6 +32,7 @@ import net.ccbluex.liquidbounce.utils.entity.lastRotation
 import net.ccbluex.liquidbounce.utils.entity.prevPos
 import net.ccbluex.liquidbounce.utils.entity.rotation
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 
 /**
  * Records combat behavior
@@ -49,7 +50,7 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
             return@tickHandler
         }
 
-        if (recordWhenClicking && !mc.options.attackKey.isPressed) {
+        if (recordWhenClicking && !mc.options.attackKey.isPressedOnAny) {
             return@tickHandler
         }
 


### PR DESCRIPTION
Due to the fact that e.g. Auto Clicker will fake not pressing the button, we have to use [isPressedOnAny] instead which uses our own [InputTracker] instead of the Minecraft's one.