### PR TITLE
feat(HideAppearance): Clear client commands when destroy

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.event.EventManager.callEvent
 import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.command.CommandManager
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -126,6 +127,10 @@ object HideAppearance : EventListener {
     fun destructClient() {
         isHidingNow = true
         isDestructed = true
+
+        mc.inGameHud.chatHud.messageHistory.removeIf {
+            it.startsWith(CommandManager.Options.prefix)
+        }
 
         callEvent(ClientShutdownEvent)
         EventManager.unregisterAll()


### PR DESCRIPTION
it already implemented on wipeClient through calling `inGameHud.chatHud.clear(clearHistory: true)`, but this using in critical situations, (by myself, i using destroy client more often than wipe client when i'm in screenshare & cheat check) 