### PR TITLE
fix(MCEF): platform compatibility check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ kotlin_version=2.1.10
 # https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/
 fabric_kotlin_version=1.13.1+kotlin.2.1.10
 # mcef
-mcef_version=3.0.5-1.21.4
+mcef_version=3.0.6-1.21.4
 # mc-authlib
 mc_authlib_version=1.4.1
 # djl


### PR DESCRIPTION
In some occasions, the WMI query may fail to get the CPU architecture and instead of throwing an exception, it will assume a 32-bit architecture, so we now also check the system property to ensure compatibility.