### PR TITLE
fix(KillAura/FightBot): points not block-collision aware

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFightBot.kt
@@ -27,10 +27,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKi
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.render.engine.Color4b
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
-import net.ccbluex.liquidbounce.utils.entity.box
-import net.ccbluex.liquidbounce.utils.entity.isFallingToVoid
-import net.ccbluex.liquidbounce.utils.entity.rotation
-import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.ccbluex.liquidbounce.utils.entity.*
 import net.ccbluex.liquidbounce.utils.math.times
 import net.ccbluex.liquidbounce.utils.navigation.NavigationBaseConfigurable
 import net.minecraft.entity.Entity
@@ -94,7 +91,7 @@ object KillAuraFightBot : NavigationBaseConfigurable<CombatContext>(ModuleKillAu
                 return@select null
             }
 
-            if (TargetFilter.notWhenVoid && entity.isFallingToVoid()) {
+            if (TargetFilter.notWhenVoid && entity.doesNotCollideBelow()) {
                 return@select null
             }
 
@@ -212,6 +209,11 @@ object KillAuraFightBot : NavigationBaseConfigurable<CombatContext>(ModuleKillAu
             .mapNotNull { yaw ->
                 val rotation = Rotation(yaw = yaw.toFloat(), pitch = 0.0F)
                 val position = target.pos.add(rotation.directionVector * combatTarget.range.toDouble())
+
+                // Check if this point collides with a block
+                if (player.doesCollideAt(position)) {
+                    return@mapNotNull null
+                }
 
                 val isInAngle = rotation.angleTo(combatTarget.targetRotation) <= dangerousYawDiff
                 ModuleDebug.debugGeometry(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.Timer
-import net.ccbluex.liquidbounce.utils.entity.isFallingToVoid
+import net.ccbluex.liquidbounce.utils.entity.doesNotCollideBelow
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 
 internal object NoFallHypixelPacket : Choice("HypixelPacket") {
@@ -35,7 +35,7 @@ internal object NoFallHypixelPacket : Choice("HypixelPacket") {
         get() = ModuleNoFall.modes
 
     private fun voidCheck(): Boolean {
-        return (!player.isFallingToVoid() && !void || void)
+        return (!player.doesNotCollideBelow() && !void || void)
     }
 
     val repeatable = tickHandler {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallVulcanTP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallVulcanTP.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
-import net.ccbluex.liquidbounce.utils.entity.isFallingToVoid
+import net.ccbluex.liquidbounce.utils.entity.doesNotCollideBelow
 import net.ccbluex.liquidbounce.utils.entity.set
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
 
@@ -39,13 +39,14 @@ internal object NoFallVulcanTP : Choice("VulcanTP288") {
 
     private val voidThreshold by int("VoidLevel", 0, -256..0)
 
-    val packetHandler = handler<PacketEvent> {
-        val packet = it.packet
+    @Suppress("unused")
+    private val packetHandler = handler<PacketEvent> { event ->
+        val packet = event.packet
 
         if (packet is PlayerMoveC2SPacket && player.fallDistance in 2.5..50.0
             // Check if the player is falling into the void and set safety expand to 0.0 - otherwise,
             // the player will be teleported to the void and flag
-            && !player.isFallingToVoid(voidLevel = voidThreshold.toDouble(), safetyExpand = 0.0)) {
+            && !player.doesNotCollideBelow(until = voidThreshold.toDouble())) {
             // Rewrite the packet to make the server think we're on the ground
             packet.onGround = true
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -585,22 +585,28 @@ private fun LivingEntity.getHealthFromScoreboard(): Float? {
     return score.score.toFloat()
 }
 
+fun Entity.getBoundingBoxAt(pos: Vec3d): Box {
+    return boundingBox.offset(pos - this.pos)
+}
+
 /**
- * Check if the entity is likely falling to the void based on the current position and bounding box.
+ * Check if the entity collides with anything below his bounding box.
  */
-fun Entity.isFallingToVoid(voidLevel: Double = -64.0, safetyExpand: Double = 0.0): Boolean {
-    if (this.y < voidLevel || boundingBox.minY < voidLevel) {
+fun Entity.doesNotCollideBelow(until: Double = -64.0): Boolean {
+    if (this.y < until || boundingBox.minY < until) {
         return true
     }
 
-    // If there is no collision to void threshold, we do not want to teleport down.
-    val boundingBox = boundingBox
-        // Set the minimum Y to the void threshold to check for collisions below the player
-        .withMinY(voidLevel)
-        // Expand the bounding box to check if there might blocks to safely land on
-        .expand(safetyExpand, 0.0, safetyExpand)
-    return world.getBlockCollisions(this, boundingBox)
+    val offsetBb = boundingBox.withMinY(until)
+    return world.getBlockCollisions(this, offsetBb)
         .all(VoxelShapes.empty()::equals)
+}
+
+/**
+ * Check if the entity box collides with any block in the world at the given [pos].
+ */
+fun Entity.doesCollideAt(pos: Vec3d): Boolean {
+    return !world.getBlockCollisions(this, getBoundingBoxAt(pos)).all(VoxelShapes.empty()::equals)
 }
 
 /**


### PR DESCRIPTION
This caused Fight Bot to try to run into blocks. This is now fixed as it will now detect block collisions and avoid them.

![image](https://github.com/user-attachments/assets/92dfdb29-bdd6-48ab-b9ab-23d0c0ef4ed9)
