### PR TITLE
feat(KillAura): requirements (requires click, requires weapon)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
@@ -1,0 +1,53 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
+
+import net.ccbluex.liquidbounce.config.types.Configurable
+import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
+import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
+import net.minecraft.item.AxeItem
+import net.minecraft.item.Item
+import net.minecraft.item.SwordItem
+
+object KillAuraRequirements : Configurable("Requirements") {
+
+    private val requiresClick by boolean("RequiresClick", false)
+    private val requiresWeapon by boolean("RequiresWeapon", false)
+
+    val requirementsMet: Boolean
+        get() {
+            if (requiresClick && !mc.options.attackKey.isPressedOnAny) {
+                return false
+            }
+
+            if (requiresWeapon && !player.inventory.mainHandStack.item.isWeapon()) {
+                return false
+            }
+
+            return true
+        }
+
+    /**
+     * Check if the item is a weapon.
+     */
+    fun Item.isWeapon() = !isOlderThanOrEqual1_8 && this is AxeItem || this is SwordItem
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -31,7 +31,6 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.CriticalsSelectionMode
 import net.ccbluex.liquidbounce.features.module.modules.combat.elytratarget.ModuleElytraTarget
-import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRequirements.requirementsMet
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.KillAuraRotationTiming.ON_TICK
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.KillAuraRotationTiming.SNAP
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.RaycastMode.*
@@ -98,6 +97,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
     // Target
     val targetTracker = tree(KillAuraTargetTracker)
+    val requirements = tree(KillAuraRequirements)
 
     // Rotation
     private val rotations = tree(KillAuraRotationsConfigurable)
@@ -115,7 +115,6 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
     init {
         tree(KillAuraAutoBlock)
-        tree(KillAuraRequirements)
     }
 
     // Target rendering
@@ -158,7 +157,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         val isInInventoryScreen =
             InventoryManager.isInventoryOpen || mc.currentScreen is GenericContainerScreen
 
-        val shouldResetTarget = player.isSpectator || player.isDead || !requirementsMet
+        val shouldResetTarget = player.isSpectator || player.isDead || !requirements.requirementsMet
 
         if (isInInventoryScreen && !ignoreOpenInventory || shouldResetTarget) {
             // Reset current target
@@ -191,7 +190,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             val hasUnblocked = KillAuraAutoBlock.stopBlocking()
 
             // Deal with fake swing when there is no target
-            if (KillAuraFailSwing.enabled && requirementsMet) {
+            if (KillAuraFailSwing.enabled && requirements.requirementsMet) {
                 if (hasUnblocked) {
                     waitTicks(KillAuraAutoBlock.tickOff)
                 }
@@ -201,7 +200,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
         }
 
         // Check if the module should (not) continue after the blocking state is updated
-        if (!requirementsMet) {
+        if (!requirements.requirementsMet) {
             return@tickHandler
         }
 


### PR DESCRIPTION
This introduces 'Requires Weapon' which allows you to stop KillAura from doing anything when you want to pot or anything else that requires you to stop temporarily.