### PR TITLE
chore(ElytraTarget): ElytraRotationsAndAngleSmooth -> ElytraRotationProcessor

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/ElytraRotationProcessor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/ElytraRotationProcessor.kt
@@ -4,7 +4,7 @@ import net.ccbluex.liquidbounce.config.types.Configurable
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.features.module.modules.combat.elytratarget.ElytraRotationsAndAngleSmooth.ignoreKillAura
+import net.ccbluex.liquidbounce.features.module.modules.combat.elytratarget.ElytraRotationProcessor.ignoreKillAura
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.RotationTarget
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
@@ -27,7 +27,7 @@ private const val BASE_PITCH_SPEED = 35.0f
 private const val IDEAL_DISTANCE = 10
 
 @Suppress("MagicNumber")
-internal object ElytraRotationsAndAngleSmooth : Configurable("Rotations"), RotationProcessor, EventListener {
+internal object ElytraRotationProcessor : Configurable("Rotations"), RotationProcessor, EventListener {
     private val sharpRotations by boolean("Sharp", false)
     internal val ignoreKillAura by boolean("IgnoreKillAuraRotation", true)
     internal val look by boolean("Look", false)
@@ -141,7 +141,7 @@ internal object ElytraRotationsAndAngleSmooth : Configurable("Rotations"), Rotat
                 plan = RotationTarget(
                     rotation = it,
                     entity = target,
-                    processors = listOfNotNull(ElytraRotationsAndAngleSmooth),
+                    processors = listOfNotNull(ElytraRotationProcessor),
                     ticksUntilReset = 1,
                     resetThreshold = 1f,
                     considerInventory = true,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/ModuleElytraTarget.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/ModuleElytraTarget.kt
@@ -23,7 +23,7 @@ object ModuleElytraTarget : ClientModule("ElytraTarget", Category.COMBAT) {
     private val targetTracker = tree(TargetTracker())
 
     init {
-        tree(ElytraRotationsAndAngleSmooth)
+        tree(ElytraRotationProcessor)
         tree(AutoFirework)
     }
 
@@ -41,7 +41,7 @@ object ModuleElytraTarget : ClientModule("ElytraTarget", Category.COMBAT) {
 
     val canIgnoreKillAuraRotations get() =
         running
-        && ElytraRotationsAndAngleSmooth.ignoreKillAura
+        && ElytraRotationProcessor.ignoreKillAura
 
     fun isSameTargetRendering(target: LivingEntity) =
         running

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/TargetEntityMovementPrediction.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/TargetEntityMovementPrediction.kt
@@ -8,7 +8,7 @@ import net.minecraft.entity.LivingEntity
 import net.minecraft.util.math.Vec3d
 
 @Suppress("MaxLineLength", "MagicNumber")
-internal object TargetEntityMovementPrediction : ToggleableConfigurable(ElytraRotationsAndAngleSmooth, "Prediction", true) {
+internal object TargetEntityMovementPrediction : ToggleableConfigurable(ElytraRotationProcessor, "Prediction", true) {
     private val glidingOnly by boolean("GlidingOnly", true)
     private val multiplier by floatRange("Multiplier", 1f..1.1f, 0.5f..2f)
 


### PR DESCRIPTION
Because in commit https://github.com/CCBlueX/LiquidBounce/commit/3146b176d93d992a3ef22469455064a3f507ebb1 the AngleSmooth renamed to RotationProcessor