### PR TITLE
refactor(ConfigSystem): module exclude

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ConfigurableSerializer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ConfigurableSerializer.kt
@@ -87,7 +87,8 @@ class ConfigurableSerializer(
             /**
              * Do not include modules that are heavily user-personalised
              */
-            if (value.category == Category.RENDER || value.category == Category.CLIENT) {
+            if (value.category == Category.RENDER || value.category == Category.CLIENT ||
+                value.category == Category.FUN) {
                 return false
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleConsoleSpammer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleConsoleSpammer.kt
@@ -8,6 +8,10 @@ import net.ccbluex.liquidbounce.utils.client.chat
 
 object ModuleConsoleSpammer : ClientModule("ConsoleSpammer", Category.EXPLOIT, disableOnQuit = true) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     // Invalid Packet id, cannot bypass Velocity/BungeeCord
     // Allows you to bypass ViaVersion
     val data = byteArrayOf(7, 0, -49, -24, 11, 6, 0, 0)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleExtendedFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleExtendedFirework.kt
@@ -12,7 +12,7 @@ import net.minecraft.util.math.Vec3d
  * @author sqlerrorthing
  * @see net.ccbluex.liquidbounce.injection.mixins.minecraft.entity.projectile.MixinFireworkRocketEntity.hookExtendedFirework
  */
-object ModuleExtendedFirework : ClientModule("ExtendedFirework", Category.EXPLOIT) {
+object ModuleExtendedFirework : ClientModule("ExtendedFirework", Category.MOVEMENT) {
     private val mode = choices("Mode", Normal, arrayOf(Normal, Custom))
 
     internal object Normal : Multiplier("Normal") {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleKick.kt
@@ -35,6 +35,10 @@ import kotlin.random.Random
  */
 object ModuleKick : ClientModule("Kick", Category.EXPLOIT, disableActivation = true) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val mode by enumChoice("Mode", KickModeEnum.QUIT)
 
     override fun enable() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/dupe/ModuleDupe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/dupe/ModuleDupe.kt
@@ -28,6 +28,12 @@ import net.minecraft.item.Item
 
 object ModuleDupe : ClientModule("Dupe", Category.EXPLOIT, disableOnQuit = true, disableActivation = true) {
 
+    init {
+        // Dupe are very rare occurrences,
+        // and therefore we don't want them to be included in our auto config.
+        doNotIncludeAlways()
+    }
+
     override fun enable() {
         if (mc.isInSingleplayer) {
             chat(markAsError(message("singleplayer")))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/ModuleServerCrasher.kt
@@ -26,6 +26,12 @@ import net.ccbluex.liquidbounce.utils.client.chat
 
 object ModuleServerCrasher : ClientModule("ServerCrasher", Category.EXPLOIT, disableOnQuit = true) {
 
+    init {
+        // Server Crasher are very rare occurrences,
+        // and therefore we don't want them to be included in our auto config.
+        doNotIncludeAlways()
+    }
+
     override fun enable() {
         if (mc.isIntegratedServerRunning) {
             enabled = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
@@ -35,10 +35,12 @@ import net.ccbluex.liquidbounce.utils.client.logger
  */
 object ModuleAutoChatGame : ClientModule("AutoChatGame", Category.MISC) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val baseUrl by text("BaseUrl", OPENAI_BASE_URL)
-        .doNotIncludeAlways() // Keeps API key private
     private val openAiKey by text("OpenAiKey", "")
-        .doNotIncludeAlways() // Keeps API key private
     private val model by text("Model", "gpt-4o-mini") // GPT 4O Mini should be enough for this
     private val delayResponse by intRange("ReactionTime", 1000..5000, 0..10000,
         "ms")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleMiddleClickAction.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleMiddleClickAction.kt
@@ -48,6 +48,10 @@ object ModuleMiddleClickAction : ClientModule(
     aliases = arrayOf("FriendClicker", "MiddleClickPearl")
 ) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val mode = choices(this, "Mode", FriendClicker, arrayOf(FriendClicker, Pearl))
 
     override fun disable() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -37,6 +37,10 @@ import java.util.*
  */
 object ModuleNotifier : ClientModule("Notifier", Category.MISC) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val joinMessages by boolean("JoinMessages", true)
     private val joinMessageFormat by text("JoinMessageFormat", "%s joined")
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModulePacketLogger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModulePacketLogger.kt
@@ -56,6 +56,11 @@ object ModulePacketLogger : ClientModule("PacketLogger", Category.MISC) {
 
     private val classNames = ConcurrentHashMap<Class<out Packet<*>>, String>()
     private val fieldNames = ConcurrentHashMap<Field, String>()
+    
+    init {
+        // Do not include this module in the auto config, as this is for debugging purposes only.
+        doNotIncludeAlways()
+    }
 
     override fun disable() {
         classNames.clear()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleSpammer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleSpammer.kt
@@ -34,6 +34,10 @@ import kotlin.random.Random
  */
 object ModuleSpammer : ClientModule("Spammer", Category.MISC, disableOnQuit = true) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val delay by intRange("Delay", 2..4, 0..300, "secs")
     private val mps by intRange("MPS", 1..1, 1..500, "messages")
     private val message by textArray("Message", mutableListOf(
@@ -41,13 +45,10 @@ object ModuleSpammer : ClientModule("Spammer", Category.MISC, disableOnQuit = tr
         "I'm using LiquidBounce Nextgen and you should too!",
         "Check out LiquidBounce Nextgen - the best Minecraft client!",
         "Tired of losing? Try LiquidBounce Nextgen!",
-    )).doNotIncludeAlways()
+    ))
     private val pattern by enumChoice("Pattern", SpammerPattern.RANDOM)
-        .doNotIncludeAlways()
     private val messageConverterMode by enumChoice("MessageConverter", MessageConverterMode.LEET_CONVERTER)
-        .doNotIncludeAlways()
     private val customFormatter by boolean("CustomFormatter", false)
-        .doNotIncludeAlways()
 
     private var linear = 0
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleTargetLock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleTargetLock.kt
@@ -41,6 +41,10 @@ import kotlin.math.pow
  */
 object ModuleTargetLock : ClientModule("TargetLock", Category.MISC) {
 
+    init {
+        doNotIncludeAlways()
+    }
+
     private val mode = choices("Mode", Temporary, arrayOf(Temporary, Filter))
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/ModuleDebugRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/ModuleDebugRecorder.kt
@@ -13,7 +13,12 @@ import net.minecraft.text.HoverEvent
 import java.text.SimpleDateFormat
 import java.util.*
 
-object ModuleDebugRecorder : ClientModule("DebugRecorder", Category.MISC) {
+object ModuleDebugRecorder : ClientModule("DebugRecorder", Category.MISC, disableOnQuit = true) {
+
+    init {
+        // [Debug Recorder] is usually used by developers and testers and is not needed in the auto config.
+        doNotIncludeAlways()
+    }
 
     val modes = choices("Mode", GenericDebugRecorder, arrayOf(
         MinaraiCombatRecorder,


### PR DESCRIPTION
Clean up auto config with modules or values that should not be included in auto config.

Excludes:
- Auto Chat Game
- Console Spammer
- Debug Recorder
- Dupe
- Kick
- Middle Click Action
- Notifier
- Packet Logger
- Server Crasher
- Spammer
- Target Lock
+ [Fun Category]

Also:
Extended Firework was moved from Exploit to Movement.