### PR TITLE
fix(compatibility): recursive screen handling

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -58,6 +58,7 @@ import net.minecraft.util.hit.HitResult;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -214,6 +215,14 @@ public abstract class MixinMinecraftClient {
     }
 
     /**
+     * Fixes recursive screen opening,
+     * this is usually caused by another mod such as Lunar Client.
+     * Can also happen when opening a screen during [ScreenEvent].
+     */
+    @Unique
+    private boolean recursiveScreenOpening = false;
+
+    /**
      * Handle opening screens
      *
      * @param screen       to be opened (null = no screen at all)
@@ -221,9 +230,21 @@ public abstract class MixinMinecraftClient {
      */
     @Inject(method = "setScreen", at = @At("HEAD"), cancellable = true)
     private void hookScreen(Screen screen, CallbackInfo callbackInfo) {
-        ScreenEvent event = new ScreenEvent(screen);
-        EventManager.INSTANCE.callEvent(event);
-        if (event.isCancelled()) callbackInfo.cancel();
+        if (recursiveScreenOpening) {
+            return;
+        }
+
+        try {
+            recursiveScreenOpening = true;
+
+            var event = EventManager.INSTANCE.callEvent(new ScreenEvent(screen));
+            if (event.isCancelled()) {
+                callbackInfo.cancel();
+            }
+        } finally {
+            recursiveScreenOpening = false;
+        }
+
         // Who need this GUI?
         if (screen instanceof AccessibilityOnboardingScreen) {
             callbackInfo.cancel();


### PR DESCRIPTION
This is a known issue with newer versions of Lunar Client, which attempts to replace the existing screen with another one, which calls setScreen(...) over and over.

might fixes https://github.com/CCBlueX/LiquidBounce/issues/5861