### PR TITLE
feat: mineland fly disabler

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/ModuleDisabler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/ModuleDisabler.kt
@@ -41,6 +41,7 @@ object ModuleDisabler : ClientModule("Disabler", Category.EXPLOIT) {
         tree(DisablerVanillaSpeed)
         tree(DisablerSwingOrder)
         tree(DisablerLiveOverflow)
+        tree(DisablerMinelandFly)
         tree(DisablerVerusCombat)
         tree(DisablerVerusExperimental)
         tree(DisablerVerusScaffoldG)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerMinelandFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerMinelandFly.kt
@@ -1,0 +1,46 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disablers
+
+import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.PacketEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
+import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
+import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket
+
+/**
+ * Mineland Fly Disabler
+ */
+internal object DisablerMinelandFly : ToggleableConfigurable(ModuleDisabler, "MinelandFly", false) {
+
+    /**
+     * Respawning twice and cancelling transactions the second time lets
+     * you vanilla fly. Obviously, the server still won't send packets
+     * to you, so sadly you can't see where players are to attack them,
+     * however it is useful to get everyone's bed really fast or to travel
+     * long distances.
+     */
+    @Suppress("unused")
+    val packetHandler = handler<PacketEvent> { event ->
+        if (event.packet is CommonPingS2CPacket && ModuleFly.enabled) {
+            event.cancelEvent()
+        }
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerMinelandFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerMinelandFly.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
-import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket
+import net.minecraft.network.packet.c2s.common.CommonPongC2SPacket
 
 /**
  * Mineland Fly Disabler
@@ -39,7 +39,7 @@ internal object DisablerMinelandFly : ToggleableConfigurable(ModuleDisabler, "Mi
      */
     @Suppress("unused")
     val packetHandler = handler<PacketEvent> { event ->
-        if (event.packet is CommonPingS2CPacket && ModuleFly.enabled) {
+        if (event.packet is CommonPongC2SPacket && ModuleFly.enabled) {
             event.cancelEvent()
         }
     }


### PR DESCRIPTION
allows you to vanilla fly in mineland games where respawning is a thing.