### PR TITLE
fix(ScriptModule): call `RefreshArrayListEvent` on tag change

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.script.bindings.features
 
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.event.*
+import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.script.PolyglotScript
@@ -34,9 +35,15 @@ class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) :
 
     private val events = hashMapOf<String, (Any?) -> Unit>()
     private val _values = linkedMapOf<String, Value<*>>()
-    private var _tag: String? = null
-    override val tag: String?
-        get() = _tag
+    override var tag: String? = null
+        set(value) {
+            if (field == null) {
+                field = value
+                return
+            }
+            field = value
+            EventManager.callEvent(RefreshArrayListEvent)
+        }
 
     private var _description: String? = null
     override var description: Supplier<String?> = Supplier { _description ?: "" }
@@ -56,7 +63,7 @@ class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) :
         }
 
         if (moduleObject.containsKey("tag")) {
-            _tag = moduleObject["tag"] as String
+            tag = moduleObject["tag"] as String
         }
 
         if (moduleObject.containsKey("description")) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
@@ -37,12 +37,9 @@ class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) :
     private val _values = linkedMapOf<String, Value<*>>()
     override var tag: String? = null
         set(value) {
-            if (field == null) {
-                field = value
-                return
-            }
             field = value
-            EventManager.callEvent(RefreshArrayListEvent)
+            if (field != null)
+                EventManager.callEvent(RefreshArrayListEvent)
         }
 
     private var _description: String? = null


### PR DESCRIPTION
This fixes tags not updating due to `tag` not having a setter which needs to call `RefreshArrayListEvent` and actually update it.
```js
/// api_version=3
var script = registerScript({
	name: "TestScript",
	version: "0.0.1",
	authors: ["LiquidBounceNextgen"]
});

script.registerModule({
	name: "TestModule",
	category: "Fun",
	description: "Testing ArrayList module \"tags\"",
	tag: "Retoggle me!"
}, function (mod) {
	mod.on("enable", function () {
		const tag = Math.random().toString();
		Client.displayChatMessage(`Old tag: ${mod.tag}, New tag: ${tag}`);
		mod.tag = tag; // this will never update since `tag` just pulls from `_tag`, which is private so we can't set it, and I couldn't get `tagBy` to work
	})
})
```
Same script, but for Legacy (doesn't support `var` :vomiting_face:):
```js
/// api_version=2
var script = registerScript({
    name: "TestScript",
    version: "0.0.1",
    authors: ["LiquidBounceNextgen"] 
});

script.registerModule({
	name: "TestModule",
	category: "Fun",
	description: "Testing ArrayList module \"tags\"",
	tag: "Retoggle me!"	
}, function(mod) {
	mod.on("enable", function(enable) {
		var tag = Math.random().toString();
		Chat.print("Old tag: " + mod.tag + ", New tag: " + tag);
		mod.tag = tag;
	})
})
```

and yes, it does actually work as expected on legacy:


[Screencast From 2025-03-22 23-35-47.webm](https://github.com/user-attachments/assets/0779f8e2-5703-4c5a-99a9-b5ba0f70cece)
