### PR TITLE
feat: faster clickgui animations

### DIFF
--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -120,7 +120,7 @@
     {#if expanded && configurable}
         <div class="settings">
             {#each configurable.value as setting (setting.name)}
-                <GenericSetting skipAnimationDelay={true} {path} bind:setting on:change={updateModuleSettings}/>
+                <GenericSetting {path} bind:setting on:change={updateModuleSettings}/>
             {/each}
         </div>
     {/if}

--- a/src-theme/src/routes/clickgui/setting/ChoiceSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/ChoiceSetting.svelte
@@ -24,8 +24,6 @@
 
     $: setItem(thisPath, expanded.toString());
 
-    let skipAnimationDelay = false;
-
     function handleChange() {
         setting = { ...cSetting };
         dispatch("change");
@@ -33,7 +31,6 @@
 
     function toggleExpanded() {
         expanded = !expanded;
-        skipAnimationDelay = true;
     }
 </script>
 
@@ -47,7 +44,7 @@
                 name={$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}
                 on:change={handleChange}
             />
-            <ExpandArrow bind:expanded on:click={() => skipAnimationDelay = true} />
+            <ExpandArrow bind:expanded />
         </div>
     {:else}
         <div class="head">
@@ -63,7 +60,7 @@
     {#if expanded && nestedSettings.length > 0}
         <div class="nested-settings">
             {#each nestedSettings as setting (setting.name)}
-                <GenericSetting {skipAnimationDelay} path={thisPath} bind:setting={setting} on:change={handleChange} />
+                <GenericSetting path={thisPath} bind:setting={setting} on:change={handleChange} />
             {/each}
         </div>
     {/if}

--- a/src-theme/src/routes/clickgui/setting/ConfigurableSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/ConfigurableSetting.svelte
@@ -20,13 +20,11 @@
     }
 
     let expanded = localStorage.getItem(thisPath) === "true";
-    let skipAnimationDelay = false;
 
     $: setItem(thisPath, expanded.toString());
 
     function toggleExpanded() {
         expanded = !expanded;
-        skipAnimationDelay = true;
     }
 </script>
 
@@ -34,13 +32,13 @@
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div class="head" class:expanded on:contextmenu|preventDefault={toggleExpanded}>
         <div class="title">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}</div>
-        <ExpandArrow bind:expanded on:click={() => skipAnimationDelay = true} />
+        <ExpandArrow bind:expanded />
     </div>
 
     {#if expanded}
         <div class="nested-settings">
             {#each cSetting.value as setting (setting.name)}
-                <GenericSetting {skipAnimationDelay} path={thisPath} bind:setting on:change={handleChange}/>
+                <GenericSetting path={thisPath} bind:setting on:change={handleChange}/>
             {/each}
         </div>
     {/if}

--- a/src-theme/src/routes/clickgui/setting/MultiChooseSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/MultiChooseSetting.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {createEventDispatcher, onMount} from "svelte";
+    import {createEventDispatcher} from "svelte";
     import type {ModuleSetting, MultiChooseSetting,} from "../../../integration/types";
     import {slide} from "svelte/transition";
     import {convertToSpacedString, spaceSeperatedNames} from "../../../theme/theme_config";
@@ -41,20 +41,12 @@
     }
 
     let expanded = localStorage.getItem(thisPath) === "true";
-    let skipAnimationDelay = false;
 
     $: setItem(thisPath, expanded.toString());
 
     function toggleExpanded() {
         expanded = !expanded;
-        skipAnimationDelay = true;
     }
-
-    onMount(() => {
-        setTimeout(() => {
-            skipAnimationDelay = true;
-        }, 200)
-    });
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -63,10 +55,10 @@
     <div class="head" class:expanded on:contextmenu|preventDefault={toggleExpanded}>
         <div class="title">{$spaceSeperatedNames ? convertToSpacedString(cSetting.name) : cSetting.name}</div>
         <div class="amount">{cSetting.value.length}/{cSetting.choices.length}</div>
-        <ExpandArrow bind:expanded on:click={() => skipAnimationDelay = true}/>
+        <ExpandArrow bind:expanded/>
     </div>
 
-    {#if expanded && skipAnimationDelay}
+    {#if expanded}
         <div class="choices" transition:slide|global={{duration: 200, axis: "y"}}>
             {#each cSetting.choices as choice}
                 <div

--- a/src-theme/src/routes/clickgui/setting/TogglableSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/TogglableSetting.svelte
@@ -12,7 +12,6 @@
 
     const cSetting = setting as TogglableSetting;
     const thisPath = `${path}.${cSetting.name}`;
-    let skipAnimationDelay = false;
 
     const dispatch = createEventDispatcher();
 
@@ -31,7 +30,6 @@
 
     function toggleExpanded() {
         expanded = !expanded;
-        skipAnimationDelay = true;
     }
 </script>
 
@@ -44,7 +42,7 @@
                 bind:value={enabledSetting.value}
                 on:change={handleChange}
             />
-            <ExpandArrow bind:expanded on:click={() => skipAnimationDelay = true} />
+            <ExpandArrow bind:expanded />
         </div>
     {:else}
         <div class="head" class:expanded>
@@ -59,7 +57,7 @@
     {#if expanded}
         <div class="nested-settings">
             {#each nestedSettings as setting (setting.name)}
-                <GenericSetting {skipAnimationDelay} path={thisPath} bind:setting on:change={handleChange} />
+                <GenericSetting  path={thisPath} bind:setting on:change={handleChange} />
             {/each}
         </div>
     {/if}

--- a/src-theme/src/routes/clickgui/setting/common/GenericSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/common/GenericSetting.svelte
@@ -22,55 +22,45 @@
 
     export let setting: ModuleSetting;
     export let path: string;
-    export let skipAnimationDelay = false;
-
-    let ready = skipAnimationDelay;
-
-    onMount(() => {
-        setTimeout(() => {
-            ready = true;
-        }, 200)
-    });
 </script>
 
-{#if ready}
-    <div in:slide|global={{duration: 200, axis: "y"}} out:slide|global={{duration: 200, axis: "y"}}>
-        {#if setting.valueType === "BOOLEAN"}
-            <BooleanSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "CHOICE"}
-            <ChoiceSetting {path} bind:setting={setting} on:change/>
-        {:else if setting.valueType === "CHOOSE"}
-            <ChooseSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "MULTI_CHOOSE"}
-            <MultiChooseSetting {path} bind:setting={setting} on:change/>
-        {:else if setting.valueType === "TOGGLEABLE"}
-            <TogglableSetting {path} bind:setting={setting} on:change/>
-        {:else if setting.valueType === "INT"}
-            <IntSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "INT_RANGE"}
-            <IntRangeSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "FLOAT"}
-            <FloatSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "FLOAT_RANGE"}
-            <FloatRangeSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "CONFIGURABLE"}
-            <ConfigurableSetting {path} bind:setting={setting} on:change/>
-        {:else if setting.valueType === "COLOR"}
-            <ColorSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "TEXT"}
-            <TextSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "BLOCKS"}
-            <BlocksSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "TEXT_ARRAY"}
-            <TextArraySetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "BIND"}
-            <BindSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "VECTOR_I" || setting.valueType === "VECTOR_D" }
-            <VectorSetting bind:setting={setting} on:change/>
-        {:else if setting.valueType === "KEY"}
-            <KeySetting bind:setting={setting} on:change/>
-        {:else}
-            <div style="color: white">Unsupported setting {setting.valueType}</div>
-        {/if}
-    </div>
-{/if}
+
+<div in:slide|global={{duration: 200, axis: "y"}} out:slide|global={{duration: 200, axis: "y"}}>
+    {#if setting.valueType === "BOOLEAN"}
+        <BooleanSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "CHOICE"}
+        <ChoiceSetting {path} bind:setting={setting} on:change/>
+    {:else if setting.valueType === "CHOOSE"}
+        <ChooseSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "MULTI_CHOOSE"}
+        <MultiChooseSetting {path} bind:setting={setting} on:change/>
+    {:else if setting.valueType === "TOGGLEABLE"}
+        <TogglableSetting {path} bind:setting={setting} on:change/>
+    {:else if setting.valueType === "INT"}
+        <IntSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "INT_RANGE"}
+        <IntRangeSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "FLOAT"}
+        <FloatSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "FLOAT_RANGE"}
+        <FloatRangeSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "CONFIGURABLE"}
+        <ConfigurableSetting {path} bind:setting={setting} on:change/>
+    {:else if setting.valueType === "COLOR"}
+        <ColorSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "TEXT"}
+        <TextSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "BLOCKS"}
+        <BlocksSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "TEXT_ARRAY"}
+        <TextArraySetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "BIND"}
+        <BindSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "VECTOR_I" || setting.valueType === "VECTOR_D" }
+        <VectorSetting bind:setting={setting} on:change/>
+    {:else if setting.valueType === "KEY"}
+        <KeySetting bind:setting={setting} on:change/>
+    {:else}
+        <div style="color: white">Unsupported setting {setting.valueType}</div>
+    {/if}
+</div>

--- a/src-theme/src/routes/menu/common/setting/WrappedSetting.svelte
+++ b/src-theme/src/routes/menu/common/setting/WrappedSetting.svelte
@@ -65,7 +65,7 @@
     {#if expanded && value.value.length > 0}
         <div class="nested-settings" transition:fade|global={{ duration: 200, easing: quintOut }}>
             {#each value.value as setting, i (setting.name)}
-                <GenericSetting skipAnimationDelay={true} {path} bind:setting={value.value[i]} on:change/>
+                <GenericSetting {path} bind:setting={value.value[i]} on:change/>
             {/each}
         </div>
     {/if}


### PR DESCRIPTION
Currently, animations in the clickgui stack. Meaning, nested settings are expanded sequentially. This was done due to a bug in Svelte 4 and is now no longer necessary. Removing this system leads to much faster animations overall.

https://github.com/user-attachments/assets/02495827-bb34-4ea0-a7c7-9bc33b9ec987

