### PR TITLE
feat(Spider): polar mode

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.spider
 
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.SpiderPolar29thMarch2025
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.SpiderVanilla
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.SpiderVulcan288
 
@@ -31,6 +32,7 @@ object ModuleSpider : ClientModule("Spider", Category.MOVEMENT, aliases = arrayO
 
     internal val modes = choices("Mode", SpiderVanilla, arrayOf(
         SpiderVanilla,
+        SpiderPolar29thMarch2025,
         SpiderVulcan288
     ))
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderPolar29thMarch2025.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderPolar29thMarch2025.kt
@@ -1,0 +1,50 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes
+
+import net.ccbluex.liquidbounce.config.types.Choice
+import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.movement.spider.ModuleSpider
+import net.ccbluex.liquidbounce.utils.block.shrink
+
+/**
+ * Shrinks the block collision shape and allows you to walk on it.
+ * Might not work on every surface.
+ *
+ * @testedOn pika.host
+ * @anticheat Polar
+ */
+internal object SpiderPolar29thMarch2025 : Choice("Polar-29.03.2025") {
+
+    override val parent: ChoiceConfigurable<Choice>
+        get() = ModuleSpider.modes
+
+    @Suppress("unused")
+    private val boxHandler = handler<BlockShapeEvent> { event ->
+        if (event.pos.y >= player.pos.y) {
+            event.shape = event.shape.shrink(
+                x = 0.0001,
+                z = 0.0001
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
Shrinks the block collision shape and allows you to walk on it. Works on Polar anti-cheat.

![image](https://github.com/user-attachments/assets/6c1fd572-0f25-45d9-a98a-79f94e386f73)
