### PR TITLE
fix(BetterTab): possible arithmetic exception

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerListHud.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerListHud.java
@@ -119,7 +119,8 @@ public abstract class MixinPlayerListHud {
         }
 
         int playerCount = collectPlayerEntries().size();
-        int columns = MathHelper.ceil((double) playerCount / ModuleBetterTab.Limits.INSTANCE.getHeight());
+        int height = Math.max(1, ModuleBetterTab.Limits.INSTANCE.getHeight());
+        int columns = Math.max(1, MathHelper.ceil((double) playerCount / height));
         int rows = MathHelper.ceil((double) playerCount / columns);
         o.set(rows);
         p.set(columns);


### PR DESCRIPTION
Might fixes:

java.lang.ArithmeticException: / by zero
    at knot//net.minecraft.class_355.method_1919(class_355.java:176)
    at knot//net.minecraft.class_329.method_55804(class_329.java:402)
    at knot//net.fabricmc.fabric.impl.client.rendering.WrappedLayer.render(WrappedLayer.java:35)
    at knot//net.minecraft.class_9080.method_55813(class_9080.java:36)
    at knot//net.minecraft.class_9080.invokeRenderInternal(class_9080.java)
    at knot//net.fabricmc.fabric.impl.client.rendering.SubLayer.render(SubLayer.java:43)
    at knot//net.minecraft.class_9080.method_55813(class_9080.java:36)
    at knot//net.minecraft.class_9080.method_55809(class_9080.java:29)
    at knot//net.minecraft.class_329.method_1753(class_329.java:234)
    at knot//net.minecraft.class_757.method_3192(class_757.java:533)
    at knot//net.minecraft.class_310.method_1523(class_310.java:1341)
    at knot//net.minecraft.class_310.method_1514(class_310.java:922)
    at knot//net.minecraft.client.main.Main.main(Main.java:267)
    at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
    at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
    at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)

Location:
https://github.com/FabricMC/yarn/blob/4ade06f0e83392128f96e6ba4c23c0a291620514/mappings/net/minecraft/client/gui/hud/PlayerListHud.mapping#L36