### PR TITLE
fix(RotationTarget): Clearing entity entry before returning

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationTarget.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationTarget.kt
@@ -37,7 +37,7 @@ import net.minecraft.entity.Entity
 @Suppress("LongParameterList")
 class RotationTarget(
     val rotation: Rotation,
-    val entity: Entity? = null,
+    var entity: Entity? = null,
     /**
      * The rotation processors which are being used to calculate the next rotation.
      * This list should start with [net.ccbluex.liquidbounce.utils.aiming.features.processors.anglesmooth.AngleSmooth]
@@ -76,6 +76,7 @@ class RotationTarget(
      */
     fun towards(currentRotation: Rotation, isResetting: Boolean): Rotation {
         if (isResetting) {
+            entity = null
             return process(currentRotation, player.rotation)
         }
 


### PR DESCRIPTION
The infamous SpinBot rotation issue is caused by the Minarai using rotationTarget.entity on unloaded / non targeted entities.
https://github.com/user-attachments/assets/403d5867-54d0-4fe8-b6e1-c69608ddf2c2
This PR fixes the issue, however I think the code may not be up to the code quality standard.