### PR TITLE
feat(KillAura): requirements (custom name)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
@@ -20,7 +20,7 @@ enum class KillAuraRequirements(
     WEAPON("Weapon", {
         player.inventory.mainHandStack.item.isWeapon()
     }),
-    NAME("VanillaName", {
+    VANILLA_NAME("VanillaName", {
         player.inventory.mainHandStack.customName == null
     });
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
@@ -19,6 +19,9 @@ enum class KillAuraRequirements(
     }),
     WEAPON("Weapon", {
         player.inventory.mainHandStack.item.isWeapon()
+    }),
+    NAME("Name", {
+        player.inventory.mainHandStack.customName == null
     });
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
@@ -20,7 +20,7 @@ enum class KillAuraRequirements(
     WEAPON("Weapon", {
         player.inventory.mainHandStack.item.isWeapon()
     }),
-    NAME("Name", {
+    NAME("VanillaName", {
         player.inventory.mainHandStack.customName == null
     });
 }


### PR DESCRIPTION
Adds a name check for custom named items, this is especially useful on practice servers which use custom named swords for queue menus.