### PR TITLE
fix: Contributors in fabric.mod.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
         env:
           CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           arguments: genSources build -x test -x detekt
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,27 +23,50 @@ import groovy.json.JsonSlurper
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 def getContributors(repoOwner, repoName) {
-    def url = "https://api.github.com/repos/${repoOwner}/${repoName}/stats/contributors"
-    def connection = (HttpURLConnection) new URI(url).toURL().openConnection()
+    HttpURLConnection connection = null
 
-    connection.requestMethod = "GET"
-    connection.connectTimeout = 5000
-    connection.readTimeout = 5000
+    try {
+        String githubToken = System.getenv("GITHUB_TOKEN")
 
-    connection.setRequestProperty("User-Agent", "LiquidBounce-App")
+        connection = "https://api.github.com/repos/${repoOwner}/${repoName}/contributors?per_page=100".toURL().openConnection().with {
+            it as HttpURLConnection
+        }.tap {
+            requestMethod = "GET"
+            connectTimeout = 5000
+            readTimeout = 5000
+            setRequestProperty("User-Agent", "LiquidBounce-App")
+            setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+            setRequestProperty("Accept", "application/vnd.github+json")
 
-    if (200 <= connection.responseCode && connection.responseCode <= 299) {
-        def response = connection.inputStream.text
-        def json = new JsonSlurper().parseText(response)
-        return json[]
-                .collect { it['author']['login'] }
-                .findAll { !(it as String).contains("dependabot") }
-                .reversed()
+            if (githubToken?.trim()) {
+                setRequestProperty("Authorization", "Bearer ${githubToken}")
+            }
+        }
 
-    } else {
-        def error = connection.errorStream?.text ?: "No response details"
-        logger.log(LogLevel.ERROR, "Failed to collect contributors, github api responsed invalid status code: ${connection.responseCode}\n${error}")
+        def responseCode = connection.responseCode
+
+        if (responseCode in 200..299) {
+            String responseText = connection.inputStream.withReader { it.text }
+            try {
+                def contributors = new JsonSlurper().parseText(responseText)
+                        .collect { it["login"] }
+                        .findAll { it && !(it as String).contains("[bot]") }
+
+                return contributors
+            } catch (Exception parseError) {
+                logger.log(LogLevel.ERROR, "Failed to parse GitHub API response", parseError)
+                return []
+            }
+        } else {
+            String errorDetails = connection.errorStream?.withReader { it.text } ?: "No error details"
+            logger.log(LogLevel.ERROR, "GitHub API request failed (HTTP ${responseCode}): ${errorDetails}")
+            return []
+        }
+    } catch (Exception globalError) {
+        logger.log(LogLevel.ERROR, "Failed to fetch contributors: ${globalError.message}", globalError)
         return []
+    } finally {
+        connection?.disconnect()
     }
 }
 


### PR DESCRIPTION
a long time ago I added the ability to collect all the contributors of this repository and put them in fabric.mod.json
but it was a little broken (I didn't notice), but now I got around to fixing it.


also to increase ratelimits I get `GITHUB_TOKEN` from `secrets.GITHUB_TOKEN` (if it is not there - I send a request without it)