### PR TITLE
fix(wipe): remove mod from unmodifiable list

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -20,6 +20,9 @@ package net.ccbluex.liquidbounce.features.misc
 
 import com.mojang.blaze3d.systems.RenderSystem
 import com.terraformersmc.modmenu.util.mod.Mod
+import kotlinx.coroutines.cancel
+import net.ccbluex.liquidbounce.LiquidBounce
+import net.ccbluex.liquidbounce.api.core.scope
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
@@ -132,6 +135,9 @@ object HideAppearance : EventListener {
             it.startsWith(CommandManager.Options.prefix)
         }
 
+        // Cancel all async tasks
+        scope.cancel()
+
         callEvent(ClientShutdownEvent)
         EventManager.unregisterAll()
 
@@ -158,14 +164,14 @@ object HideAppearance : EventListener {
         // Delete LiquidBounce folder and its content
         runCatching {
             ConfigSystem.rootFolder.deleteRecursively()
-        }
+        }.exceptionOrNull()?.printStackTrace()
 
-        // Delete JAR file
-        runCatching {
-            FabricLoaderImpl.INSTANCE.allMods.find {
-                it.metadata.id == "liquidbounce"
-            }?.let {
-                val origin = it.origin
+        FabricLoaderImpl.INSTANCE.allMods.find {
+            it.metadata.id == "liquidbounce"
+        }?.let { mod ->
+            // Delete JAR file
+            runCatching {
+                val origin = mod.origin
 
                 for (path in origin.paths) {
                     runCatching {
@@ -173,11 +179,11 @@ object HideAppearance : EventListener {
                     }
                 }
             }
-        }
 
-        // Remove from Fabric Loader Impl
-        runCatching {
-            FabricLoaderImpl.INSTANCE.mods.removeIf { it.metadata.id == "liquidbounce" }
+            // Remove from Fabric Loader Impl
+            runCatching {
+                FabricLoaderImpl.INSTANCE.modsInternal.remove(mod)
+            }.exceptionOrNull()?.printStackTrace()
         }
 
         // History clear

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.features.misc
 import com.mojang.blaze3d.systems.RenderSystem
 import com.terraformersmc.modmenu.util.mod.Mod
 import kotlinx.coroutines.cancel
-import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.api.core.scope
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.event.EventListener
@@ -164,7 +163,7 @@ object HideAppearance : EventListener {
         // Delete LiquidBounce folder and its content
         runCatching {
             ConfigSystem.rootFolder.deleteRecursively()
-        }.exceptionOrNull()?.printStackTrace()
+        }
 
         FabricLoaderImpl.INSTANCE.allMods.find {
             it.metadata.id == "liquidbounce"
@@ -183,7 +182,7 @@ object HideAppearance : EventListener {
             // Remove from Fabric Loader Impl
             runCatching {
                 FabricLoaderImpl.INSTANCE.modsInternal.remove(mod)
-            }.exceptionOrNull()?.printStackTrace()
+            }
         }
 
         // History clear


### PR DESCRIPTION
```
[00:01:34] [wipe-client/INFO] (Minecraft) [STDERR]: java.lang.UnsupportedOperationException
[00:01:34] [wipe-client/INFO] (Minecraft) [STDERR]: 	at java.base/java.util.Collections$UnmodifiableCollection.removeIf(Collections.java:1120)
[00:01:34] [wipe-client/INFO] (Minecraft) [STDERR]: 	at knot//net.ccbluex.liquidbounce.features.misc.HideAppearance.wipeClient$lambda$15(HideAppearance.kt:180)
[00:01:34] [wipe-client/INFO] (Minecraft) [STDERR]: 	at knot//kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```
`FabricLoaderImpl.INSTANCE.mods` is `UnmodifiableCollection`