### PR TITLE
feat(Phase/Blink): automatic phase-in and phase-out 

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientConnection.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinClientConnection.java
@@ -51,7 +51,7 @@ public abstract class MixinClientConnection {
      */
     @Inject(method = "send(Lnet/minecraft/network/packet/Packet;)V", at = @At("HEAD"), cancellable = true)
     private void hookSendingPacket(Packet<?> packet, final CallbackInfo callbackInfo) {
-        final PacketEvent event = new PacketEvent(TransferOrigin.SEND, packet, true);
+        final PacketEvent event = new PacketEvent(TransferOrigin.OUTGOING, packet, true);
 
         EventManager.INSTANCE.callEvent(event);
 
@@ -83,7 +83,7 @@ public abstract class MixinClientConnection {
             return;
         }
 
-        final PacketEvent event = new PacketEvent(TransferOrigin.RECEIVE, packet, true);
+        final PacketEvent event = new PacketEvent(TransferOrigin.INCOMING, packet, true);
         EventManager.INSTANCE.callEvent(event);
         if (event.isCancelled()) {
             ci.cancel();

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/NetworkEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/NetworkEvents.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.event.events
 
 import io.netty.channel.ChannelPipeline
+import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.CancellableEvent
 import net.ccbluex.liquidbounce.event.Event
 import net.ccbluex.liquidbounce.utils.client.Nameable
@@ -40,6 +41,7 @@ class QueuePacketEvent(
     var action: PacketQueueManager.Action = PacketQueueManager.Action.FLUSH
 ) : Event()
 
-enum class TransferOrigin {
-    SEND, RECEIVE
+enum class TransferOrigin(override val choiceName: String) : NamedChoice {
+    INCOMING("Incoming"),
+    OUTGOING("Outgoing");
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/FakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/FakePlayer.kt
@@ -80,7 +80,7 @@ open class FakePlayer(
             setHealth(1.0f)
 
             val packet = EntityStatusS2CPacket(LivingEntity::class.java.cast(this), 35.toByte())
-            val event = PacketEvent(TransferOrigin.RECEIVE, packet, true)
+            val event = PacketEvent(TransferOrigin.INCOMING, packet, true)
             callEvent(event)
             if (!event.isCancelled) {
                 mc.execute { packet.apply(MinecraftClient.getInstance().networkHandler) }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleFakeLag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleFakeLag.kt
@@ -106,7 +106,7 @@ object ModuleFakeLag : ClientModule("FakeLag", Category.COMBAT) {
                     "FakeLag", "Unable to evade arrow. Blinking.",
                     NotificationEvent.Severity.INFO
                 )
-                PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.SEND }
+                PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.OUTGOING }
             } else if (evadingPacket.ticksToImpact != null) {
                 notification("FakeLag", "Trying to evade arrow...", NotificationEvent.Severity.INFO)
                 PacketQueueManager.flush(evadingPacket.idx + 1)
@@ -119,7 +119,7 @@ object ModuleFakeLag : ClientModule("FakeLag", Category.COMBAT) {
 
     @Suppress("unused", "ComplexCondition")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin != TransferOrigin.SEND || player.isDead || player.isTouchingWater
+        if (event.origin != TransferOrigin.OUTGOING || player.isDead || player.isTouchingWater
             || mc.currentScreen != null
         ) {
             return@handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/backtrack/ModuleBacktrack.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/backtrack/ModuleBacktrack.kt
@@ -104,7 +104,7 @@ object ModuleBacktrack : ClientModule("Backtrack", Category.COMBAT) {
 
     @Suppress("unused")
     private val packetHandler = handler<PacketEvent> { event ->
-        if (event.origin != TransferOrigin.RECEIVE || event.isCancelled) {
+        if (event.origin != TransferOrigin.INCOMING || event.isCancelled) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsBlink.kt
@@ -50,7 +50,7 @@ object CriticalsBlink : Choice("Blink") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND && !wouldDoCriticalHit(ignoreSprint = true) && enemyInRange) {
+        if (event.origin == TransferOrigin.OUTGOING && !wouldDoCriticalHit(ignoreSprint = true) && enemyInRange) {
             if (PacketQueueManager.isAboveTime(nextDelay.toLong())) {
                 nextDelay = delay.random()
                 return@handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -205,7 +205,7 @@ object KillAuraAutoBlock : ToggleableConfigurable(ModuleKillAura, "AutoBlocking"
 
     @Suppress("unused")
     private val blinkHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin != TransferOrigin.SEND) {
+        if (event.origin != TransferOrigin.OUTGOING) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
@@ -99,7 +99,7 @@ object ModuleVelocity : ClientModule("Velocity", Category.COMBAT, aliases = arra
                     }
                 }
 
-                val packetEvent = PacketEvent(TransferOrigin.RECEIVE, packet, false)
+                val packetEvent = PacketEvent(TransferOrigin.INCOMING, packet, false)
                 EventManager.callEvent(packetEvent)
 
                 if (!packetEvent.isCancelled) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
@@ -188,7 +188,7 @@ object ModuleClickTp : ClientModule("ClickTp", Category.EXPLOIT, aliases = array
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND && requiresLag) {
+        if (event.origin == TransferOrigin.OUTGOING && requiresLag) {
             event.action = PacketQueueManager.Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModulePingSpoof.kt
@@ -42,7 +42,7 @@ object ModulePingSpoof : ClientModule("PingSpoof", Category.EXPLOIT) {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (player.isDead || event.origin != TransferOrigin.RECEIVE) {
+        if (player.isDead || event.origin != TransferOrigin.INCOMING) {
             return@handler
         }
 
@@ -69,7 +69,7 @@ object ModulePingSpoof : ClientModule("PingSpoof", Category.EXPLOIT) {
         // this should not be a problem.
         val currentTime = System.currentTimeMillis()
         PacketQueueManager.flush { snapshot ->
-            snapshot.origin == TransferOrigin.RECEIVE && currentTime - snapshot.timestamp >= delay
+            snapshot.origin == TransferOrigin.INCOMING && currentTime - snapshot.timestamp >= delay
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerGrimSpectate.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerGrimSpectate.kt
@@ -81,7 +81,7 @@ internal object DisablerGrimSpectate : ToggleableConfigurable(ModuleDisabler, "G
             return@handler
         }
 
-        if (event.origin != TransferOrigin.RECEIVE) {
+        if (event.origin != TransferOrigin.INCOMING) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerSwingOrder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerSwingOrder.kt
@@ -48,7 +48,7 @@ internal object DisablerSwingOrder : ToggleableConfigurable(ModuleDisabler, "Swi
     }
 
     val packetHandler = handler<PacketEvent> { event ->
-        if (event.origin != TransferOrigin.SEND) {
+        if (event.origin != TransferOrigin.OUTGOING) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVerusExperimental.kt
@@ -19,7 +19,6 @@
 package net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disablers
 
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.QueuePacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
@@ -206,7 +205,7 @@ internal object DisablerVerusExperimental : ToggleableConfigurable(ModuleDisable
     private val fakeLagHandler = handler<QueuePacketEvent>(
         priority = EventPriorityConvention.SAFETY_FEATURE
     ) { event ->
-        if (event.origin != TransferOrigin.SEND || waitTime > System.currentTimeMillis()) {
+        if (event.origin != TransferOrigin.OUTGOING || waitTime > System.currentTimeMillis()) {
             return@handler
         }
 
@@ -247,7 +246,7 @@ internal object DisablerVerusExperimental : ToggleableConfigurable(ModuleDisable
     ) { event ->
         val packet = event.packet
 
-        if (waitTime > System.currentTimeMillis() || event.origin != TransferOrigin.SEND
+        if (waitTime > System.currentTimeMillis() || event.origin != TransferOrigin.OUTGOING
             || packet !is PlayerMoveC2SPacket) {
             return@handler
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/ModulePhase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/ModulePhase.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.phase
 
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.modes.PhaseBlink
 import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.modes.PhaseHypixel
 import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.modes.PhaseIntave
 
@@ -32,7 +33,7 @@ object ModulePhase : ClientModule("Phase", Category.EXPLOIT) {
 
     val mode = choices(
         "Mode", PhaseHypixel, arrayOf(
-            PhaseHypixel, PhaseIntave
+            PhaseHypixel, PhaseIntave, PhaseBlink
         )
     ).apply { tagBy(this) }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
@@ -108,6 +108,15 @@ object PhaseBlink : Choice("Blink") {
     }
 
     @Suppress("unused")
+    private val packetHandler = handler<PacketEvent> { event ->
+        val packet = event.packet
+
+        if (packet is PlayerPositionLookS2CPacket) {
+            ModulePhase.enabled = false
+        }
+    }
+
+    @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent>(
         priority = EventPriorityConvention.SAFETY_FEATURE
     ) { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.ModulePhase
+import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.modes.PhaseBlink.boxHandler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager.Action
@@ -46,15 +47,18 @@ object PhaseBlink : Choice("Blink") {
         get() = ModulePhase.mode
 
     private var maximumTicks by int("Maximum", 120, 1..300, "ticks")
-    private val origin by multiEnumChoice("Origin", TransferOrigin.OUTGOING)
 
-    private var isPhasing = false
-    private var isInCollisionCheck = false
+    private var state = State.WAITING
     private var currentTicks = 0
 
+    /**
+     * Pauses [boxHandler] when we are checking for collisions
+     */
+    private var isInCollisionCheck = false
+
     override fun enable() {
-        this.isPhasing = false
-        this.currentTicks = 0
+        state = State.WAITING
+        currentTicks = 0
         super.enable()
     }
 
@@ -62,32 +66,38 @@ object PhaseBlink : Choice("Blink") {
     private val tickHandler = handler<PlayerTickEvent> { event ->
         if (currentTicks > maximumTicks) {
             event.cancelEvent()
-        } else if (isPhasing) {
+        } else if (state == State.PHASING) {
             currentTicks++
         }
 
         debugParameter("Ticks") { currentTicks }
     }
 
+    /**
+     * [PlayerNetworkMovementTickEvent] on [EventState.PRE] lets us have the phased-in position,
+     * and start the blinking before sending out the [net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket].
+     */
     @Suppress("unused")
     private val movementTickHandler = handler<PlayerNetworkMovementTickEvent> { event ->
         if (event.state == EventState.POST) {
             return@handler
         }
 
-        debugParameter("Phasing") { isPhasing }
+        debugParameter("State") { state }
 
         try {
             isInCollisionCheck = true
 
-            if (!isPhasing) {
+            if (state == State.WAITING) {
+                // Check if we should start phasing
                 if (player.doesCollideAt()) {
-                    isPhasing = true
+                    state = State.PHASING
                 }
-            } else {
-                val positions = PacketQueueManager.positions
-                if (positions.none { pos -> player.doesCollideAt(pos) }) {
-                    isPhasing = false
+            } else if (state == State.PHASING) {
+                // Check if the collisions disappeared
+                if (PacketQueueManager.positions.none { pos -> player.doesCollideAt(pos) }) {
+                    state = State.FLUSHING
+                    PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.INCOMING }
                     ModulePhase.enabled = false
                 }
             }
@@ -120,17 +130,30 @@ object PhaseBlink : Choice("Blink") {
     private val fakeLagHandler = handler<QueuePacketEvent>(
         priority = EventPriorityConvention.SAFETY_FEATURE
     ) { event ->
-        if (isPhasing && origin.any { origin -> origin == event.origin }) {
-            event.action = when (event.packet) {
-                is BlockUpdateS2CPacket, is BlockEventS2CPacket,
-                is ChunkDeltaUpdateS2CPacket, is ChunkDataS2CPacket,
-                is ChunkSentS2CPacket -> {
-                    Action.PASS
-                }
+        if (state == State.WAITING) {
+            return@handler
+        }
 
-                else -> Action.QUEUE
+        event.action = when (event.packet) {
+            is BlockUpdateS2CPacket, is BlockEventS2CPacket,
+            is ChunkDeltaUpdateS2CPacket, is ChunkDataS2CPacket,
+            is ChunkSentS2CPacket -> {
+                Action.PASS
+            }
+
+            else -> if (state == State.PHASING) {
+                Action.QUEUE
+            } else {
+                Action.PASS
             }
         }
+    }
+
+
+    private enum class State {
+        WAITING,
+        PHASING,
+        FLUSHING
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
@@ -1,0 +1,127 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.exploit.phase.modes
+
+import net.ccbluex.liquidbounce.config.types.Choice
+import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.EventState
+import net.ccbluex.liquidbounce.event.events.*
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.exploit.phase.ModulePhase
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
+import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
+import net.ccbluex.liquidbounce.utils.client.PacketQueueManager.Action
+import net.ccbluex.liquidbounce.utils.entity.doesCollideAt
+import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.minecraft.network.packet.s2c.play.*
+import net.minecraft.util.shape.VoxelShapes
+
+/**
+ * Allows you to phase through blocks by blinking until the blocks disappear.
+ * For example, before a round start. It will wait until you your collision box collides with a box,
+ * then starts to blink until the box disappears.
+ *
+ * Similar with:
+ * [net.ccbluex.liquidbounce.features.module.modules.movement.ModuleFreeze]
+ */
+object PhaseBlink : Choice("Blink") {
+
+    override val parent: ChoiceConfigurable<*>
+        get() = ModulePhase.mode
+
+    private var maximumTicks by int("Maximum", 120, 1..300, "ticks")
+    private val origin by multiEnumChoice("Origin", TransferOrigin.OUTGOING)
+
+    private var isPhasing = false
+    private var isInCollisionCheck = false
+    private var currentTicks = 0
+
+    override fun enable() {
+        this.isPhasing = false
+        this.currentTicks = 0
+        super.enable()
+    }
+
+    @Suppress("unused")
+    private val tickHandler = handler<PlayerTickEvent> { event ->
+        if (currentTicks > maximumTicks) {
+            event.cancelEvent()
+        } else if (isPhasing) {
+            currentTicks++
+        }
+
+        debugParameter("Ticks") { currentTicks }
+    }
+
+    @Suppress("unused")
+    private val movementTickHandler = handler<PlayerNetworkMovementTickEvent> { event ->
+        if (event.state == EventState.POST) {
+            return@handler
+        }
+
+        debugParameter("Phasing") { isPhasing }
+
+        try {
+            isInCollisionCheck = true
+
+            if (!isPhasing) {
+                if (player.doesCollideAt()) {
+                    isPhasing = true
+                }
+            } else {
+                val positions = PacketQueueManager.positions
+                if (positions.none { pos -> player.doesCollideAt(pos) }) {
+                    isPhasing = false
+                    ModulePhase.enabled = false
+                }
+            }
+        } finally {
+            isInCollisionCheck = false
+        }
+    }
+
+    @Suppress("unused")
+    private val boxHandler = handler<BlockShapeEvent> { event ->
+        if (isInCollisionCheck) {
+            return@handler
+        }
+
+        if (event.pos.y >= player.pos.y || player.isSneaking && player.isOnGround) {
+            event.shape = VoxelShapes.empty()
+        }
+    }
+
+    @Suppress("unused")
+    private val fakeLagHandler = handler<QueuePacketEvent>(
+        priority = EventPriorityConvention.SAFETY_FEATURE
+    ) { event ->
+        if (isPhasing && origin.any { origin -> origin == event.origin }) {
+            event.action = when (event.packet) {
+                is BlockUpdateS2CPacket, is BlockEventS2CPacket,
+                is ChunkDeltaUpdateS2CPacket, is ChunkDataS2CPacket,
+                is ChunkSentS2CPacket -> {
+                    Action.PASS
+                }
+
+                else -> Action.QUEUE
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
@@ -62,6 +62,33 @@ object PhaseBlink : Choice("Blink") {
         super.enable()
     }
 
+    override fun disable() {
+        state = State.FLUSHING
+        // This is very important; otherwise the anti-cheat will know that we've
+        // started walking through a block before it disappeared
+        PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.INCOMING }
+        state = State.WAITING
+        super.disable()
+    }
+
+    @Suppress("unused")
+    private val tickPacketHandler = handler<TickPacketProcessEvent> {
+        debugParameter("State") { state }
+
+        if (state == State.PHASING) {
+            try {
+                isInCollisionCheck = true
+
+                // Check if the collisions disappeared
+                if (PacketQueueManager.positions.none { pos -> player.doesCollideAt(pos) }) {
+                    ModulePhase.enabled = false
+                }
+            } finally {
+                isInCollisionCheck = false
+            }
+        }
+    }
+
     @Suppress("unused")
     private val tickHandler = handler<PlayerTickEvent> { event ->
         if (currentTicks > maximumTicks) {
@@ -83,27 +110,18 @@ object PhaseBlink : Choice("Blink") {
             return@handler
         }
 
-        debugParameter("State") { state }
-
-        try {
-            isInCollisionCheck = true
-
-            if (state == State.WAITING) {
+        if (state == State.WAITING) {
+            try {
+                isInCollisionCheck = true
                 // Check if we should start phasing
                 if (player.doesCollideAt()) {
                     state = State.PHASING
                 }
-            } else if (state == State.PHASING) {
-                // Check if the collisions disappeared
-                if (PacketQueueManager.positions.none { pos -> player.doesCollideAt(pos) }) {
-                    state = State.FLUSHING
-                    PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.INCOMING }
-                    ModulePhase.enabled = false
-                }
+            } finally {
+                isInCollisionCheck = false
             }
-        } finally {
-            isInCollisionCheck = false
         }
+
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModulePacketLogger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModulePacketLogger.kt
@@ -79,7 +79,7 @@ object ModulePacketLogger : ClientModule("PacketLogger", Category.MISC) {
         }
 
         val text = Text.empty().formatted(Formatting.WHITE)
-        if (origin == TransferOrigin.RECEIVE) {
+        if (origin == TransferOrigin.INCOMING) {
             text.append(message("receive"))
         } else {
             text.append(message("send"))
@@ -182,7 +182,7 @@ object ModulePacketLogger : ClientModule("PacketLogger", Category.MISC) {
         override val choiceName: String,
         val origin: TransferOrigin,
     ) : NamedChoice {
-        CLIENT("Client", TransferOrigin.RECEIVE),
-        SERVER("Server", TransferOrigin.SEND)
+        CLIENT("Client", TransferOrigin.INCOMING),
+        SERVER("Server", TransferOrigin.OUTGOING)
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -20,7 +20,6 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
-import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
@@ -142,13 +141,13 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT) {
         override val parent: ChoiceConfigurable<Choice>
             get() = modes
 
-        private val origin by multiEnumChoice("Origin", Origin.OUTGOING)
+        private val origin by multiEnumChoice("Origin", TransferOrigin.OUTGOING)
 
         @Suppress("unused")
         private val fakeLagHandler = handler<QueuePacketEvent>(
             priority = EventPriorityConvention.SAFETY_FEATURE
         ) { event ->
-            if (origin.any { it.origin == event.origin }) {
+            if (origin.any { origin -> origin == event.origin }) {
                 event.action = Action.QUEUE
             }
         }
@@ -160,14 +159,14 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT) {
      */
     object Cancel : Choice("Cancel") {
 
-        private val origin by multiEnumChoice("Origin", Origin.OUTGOING)
+        private val origin by multiEnumChoice("Origin", TransferOrigin.OUTGOING)
 
         override val parent: ChoiceConfigurable<Choice>
             get() = modes
 
         @Suppress("unused")
         private val packetHandler = handler<PacketEvent> { event ->
-            if (origin.any { it.origin == event.origin }) {
+            if (origin.any { origin -> origin == event.origin }) {
                 event.cancelEvent()
             }
         }
@@ -195,11 +194,3 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT) {
 
 }
 
-@Suppress("unused")
-private enum class Origin(
-    override val choiceName: String,
-    val origin: TransferOrigin
-) : NamedChoice {
-    INCOMING("Incoming", TransferOrigin.RECEIVE),
-    OUTGOING("Outgoing", TransferOrigin.SEND);
-}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleInventoryMove.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleInventoryMove.kt
@@ -94,7 +94,7 @@ object ModuleInventoryMove : ClientModule("InventoryMove", Category.MOVEMENT) {
         private val fakeLagHandler = handler<QueuePacketEvent> { event ->
             val packet = event.packet
 
-            if (mc.currentScreen is HandledScreen<*> && event.origin == TransferOrigin.SEND) {
+            if (mc.currentScreen is HandledScreen<*> && event.origin == TransferOrigin.OUTGOING) {
                 event.action = when (packet) {
                     is ClickSlotC2SPacket,
                     is ButtonClickC2SPacket,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
@@ -107,7 +107,7 @@ internal object FlyEnderpearl : Choice("Enderpearl") {
     }
 
     val packetHandler = handler<PacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND && event.packet is TeleportConfirmC2SPacket
+        if (event.origin == TransferOrigin.OUTGOING && event.packet is TeleportConfirmC2SPacket
             && isABitAboveGround() && threwPearl) {
             threwPearl = false
             canFly = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
@@ -73,7 +73,7 @@ internal object FlyHycraftDamage : Choice("HycraftDamage") {
     private val packetHandler = handler<QueuePacketEvent> { event ->
         val packet = event.packet
 
-        if (event.origin != TransferOrigin.RECEIVE) {
+        if (event.origin != TransferOrigin.INCOMING) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
@@ -185,7 +185,7 @@ object FlyNcpClip : Choice("NcpClip") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (blink && shouldLag && event.origin == TransferOrigin.SEND) {
+        if (blink && shouldLag && event.origin == TransferOrigin.OUTGOING) {
             event.action = PacketQueueManager.Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3869Flat.kt
@@ -75,7 +75,7 @@ internal object FlyVerusB3869Flat : Choice("VerusB3896Flat") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND) {
+        if (event.origin == TransferOrigin.OUTGOING) {
             event.action = PacketQueueManager.Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkNoCheatPlus.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkNoCheatPlus.kt
@@ -72,7 +72,7 @@ internal object LiquidWalkNoCheatPlus : Choice("NoCheatPlus") {
     val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
 
-        if (event.origin == TransferOrigin.SEND && packet is PlayerMoveC2SPacket) {
+        if (event.origin == TransferOrigin.OUTGOING && packet is PlayerMoveC2SPacket) {
             if (!mc.options.sneakKey.isPressed &&
                 !player.isTouchingWater &&
                 standingOnWater() &&

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkVerusB3901.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/modes/LiquidWalkVerusB3901.kt
@@ -62,7 +62,7 @@ internal object LiquidWalkVerusB3901 : Choice("VerusB3901") {
     val packetHandler = handler<PacketEvent> { event ->
         val packet = event.packet
 
-        if (event.origin == TransferOrigin.SEND && packet is PlayerMoveC2SPacket) {
+        if (event.origin == TransferOrigin.OUTGOING && packet is PlayerMoveC2SPacket) {
             if (!mc.options.sneakKey.isPressed &&
                 !player.isTouchingWater &&
                 standingOnWater() &&

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlockingBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/blocking/NoSlowBlockingBlink.kt
@@ -17,7 +17,7 @@ internal object NoSlowBlockingBlink : Choice("Blink") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin != TransferOrigin.SEND || !player.isBlockAction) {
+        if (event.origin != TransferOrigin.OUTGOING || !player.isBlockAction) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowSharedInvalidHand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowSharedInvalidHand.kt
@@ -33,7 +33,7 @@ internal class NoSlowSharedInvalidHand(override val parent: ChoiceConfigurable<*
     private val packetHandler = handler<PacketEvent>(priority = EventPriorityConvention.READ_FINAL_STATE) { event ->
         val packet = event.packet
 
-        if (!event.isCancelled && event.origin == TransferOrigin.SEND && packet is PlayerInteractItemC2SPacket) {
+        if (!event.isCancelled && event.origin == TransferOrigin.OUTGOING && packet is PlayerInteractItemC2SPacket) {
             event.cancelEvent()
             sendPacketSilently(PlayerInteractItemC2SPacket(null, packet.sequence, packet.pitch, packet.yaw))
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
@@ -33,11 +33,11 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.Timer
-import net.ccbluex.liquidbounce.utils.client.chat
-import net.ccbluex.liquidbounce.utils.entity.*
+import net.ccbluex.liquidbounce.utils.entity.airTicks
+import net.ccbluex.liquidbounce.utils.entity.canStep
+import net.ccbluex.liquidbounce.utils.entity.withStrafe
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.stat.Stats
-import kotlin.math.round
 
 /**
  * Step module
@@ -250,7 +250,7 @@ object ModuleStep : ClientModule("Step", Category.MOVEMENT) {
 
         @Suppress("unused")
         private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-            if (event.origin == TransferOrigin.SEND && stepping) {
+            if (event.origin == TransferOrigin.OUTGOING && stepping) {
                 event.action = PacketQueueManager.Action.QUEUE
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.autododge.ModuleAutoDodge
+import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink.dummyPlayer
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager.Action
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager.positions
@@ -77,7 +78,7 @@ object ModuleBlink : ClientModule("Blink", Category.PLAYER) {
     }
 
     override fun disable() {
-        PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.SEND }
+        PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.OUTGOING }
         removeClone()
     }
 
@@ -91,7 +92,7 @@ object ModuleBlink : ClientModule("Blink", Category.PLAYER) {
     val packetHandler = handler<PacketEvent>(priority = EventPriorityConvention.MODEL_STATE) { event ->
         val packet = event.packet
 
-        if (event.isCancelled || event.origin != TransferOrigin.SEND) {
+        if (event.isCancelled || event.origin != TransferOrigin.OUTGOING) {
             return@handler
         }
 
@@ -136,7 +137,7 @@ object ModuleBlink : ClientModule("Blink", Category.PLAYER) {
             when (AutoResetOption.action) {
                 ResetAction.RESET -> PacketQueueManager.cancel()
                 ResetAction.BLINK -> {
-                    PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.SEND }
+                    PacketQueueManager.flush { snapshot -> snapshot.origin == TransferOrigin.OUTGOING }
                     dummyPlayer?.copyPositionAndRotation(player)
                 }
             }
@@ -150,7 +151,7 @@ object ModuleBlink : ClientModule("Blink", Category.PLAYER) {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND) {
+        if (event.origin == TransferOrigin.OUTGOING) {
             event.action = Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidBlinkMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidBlinkMode.kt
@@ -48,7 +48,7 @@ object AntiVoidBlinkMode : AntiVoidMode("Blink") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND && requiresLag) {
+        if (event.origin == TransferOrigin.OUTGOING && requiresLag) {
             event.action = Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallBlink.kt
@@ -138,7 +138,7 @@ internal object NoFallBlink : Choice("Blink") {
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin == TransferOrigin.SEND && blinkFall) {
+        if (event.origin == TransferOrigin.OUTGOING && blinkFall) {
             event.action = PacketQueueManager.Action.QUEUE
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldBlinkFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/features/ScaffoldBlinkFeature.kt
@@ -53,7 +53,7 @@ object ScaffoldBlinkFeature : ToggleableConfigurable(ModuleScaffold, "Blink", fa
 
     @Suppress("unused")
     private val fakeLagHandler = handler<QueuePacketEvent> { event ->
-        if (event.origin != TransferOrigin.SEND) {
+        if (event.origin != TransferOrigin.OUTGOING) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/NetworkUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/NetworkUtils.kt
@@ -156,9 +156,9 @@ fun handlePacket(packet: Packet<*>) =
 
 fun sendPacketSilently(packet: Packet<*>) {
     // hack fix for the packet handler not being called on Rotation Manager for tracking
-    val packetEvent = PacketEvent(TransferOrigin.SEND, packet, false)
+    val packetEvent = PacketEvent(TransferOrigin.OUTGOING, packet, false)
     RotationManager.packetHandler.handler(packetEvent)
-    ModulePacketLogger.onPacket(TransferOrigin.SEND, packet)
+    ModulePacketLogger.onPacket(TransferOrigin.OUTGOING, packet)
     mc.networkHandler?.connection?.send(packetEvent.packet, null)
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/PacketQueueManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/PacketQueueManager.kt
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
  * Allows to queue packets and flush them later on demand.
  *
  * Fires [QueuePacketEvent] to determine whether a packet should be queued or not. They can be
- * from origin [TransferOrigin.RECEIVE] or [TransferOrigin.SEND], but will be handled separately.
+ * from origin [TransferOrigin.INCOMING] or [TransferOrigin.OUTGOING], but will be handled separately.
  */
 object PacketQueueManager : EventListener {
 
@@ -75,8 +75,8 @@ object PacketQueueManager : EventListener {
             return@handler
         }
 
-        if (fireEvent(null, TransferOrigin.SEND) == Action.FLUSH) {
-            flush { snapshot -> snapshot.origin == TransferOrigin.SEND }
+        if (fireEvent(null, TransferOrigin.OUTGOING) == Action.FLUSH) {
+            flush { snapshot -> snapshot.origin == TransferOrigin.OUTGOING }
         }
     }
 
@@ -87,8 +87,8 @@ object PacketQueueManager : EventListener {
             return@handler
         }
 
-        if (fireEvent(null, TransferOrigin.RECEIVE) == Action.FLUSH) {
-            flush { snapshot -> snapshot.origin == TransferOrigin.RECEIVE }
+        if (fireEvent(null, TransferOrigin.INCOMING) == Action.FLUSH) {
+            flush { snapshot -> snapshot.origin == TransferOrigin.INCOMING }
         }
     }
 
@@ -246,8 +246,8 @@ object PacketQueueManager : EventListener {
 
     private fun flushSnapshot(snapshot: PacketSnapshot) {
         when (snapshot.origin) {
-            TransferOrigin.SEND -> sendPacketSilently(snapshot.packet)
-            TransferOrigin.RECEIVE -> handlePacket(snapshot.packet)
+            TransferOrigin.OUTGOING -> sendPacketSilently(snapshot.packet)
+            TransferOrigin.INCOMING -> handlePacket(snapshot.packet)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -605,7 +605,7 @@ fun Entity.doesNotCollideBelow(until: Double = -64.0): Boolean {
 /**
  * Check if the entity box collides with any block in the world at the given [pos].
  */
-fun Entity.doesCollideAt(pos: Vec3d): Boolean {
+fun Entity.doesCollideAt(pos: Vec3d = player.pos): Boolean {
     return !world.getBlockCollisions(this, getBoundingBoxAt(pos)).all(VoxelShapes.empty()::equals)
 }
 


### PR DESCRIPTION
As soon as we **start phasing**, e.g. walking horizontally through a block or sneaking vertically, the phase will start blinking. As soon as the blocks disappear or turn off the Phase module, we **stop phasing** and stop blinking. This allows us to blink to a position that was not accessible at the moment we started blinking.

Very similar to [ModuleFreeze]'s BalanceWarp option, where we can buffer ticks and release them once the blocks have disappeared. This mode works on Grim Anti-Cheat thanks to the fact that we flush incoming packets and pass their outgoing packets before flushing the original packets.

This is very useful for every game-mode that keeps players in a box before starting the game.