### PR TITLE
feat(Phase/Blink): allow box collisions after phasing

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/phase/modes/PhaseBlink.kt
@@ -75,7 +75,7 @@ object PhaseBlink : Choice("Blink") {
     private val tickPacketHandler = handler<TickPacketProcessEvent> {
         debugParameter("State") { state }
 
-        if (state == State.PHASING) {
+        if (state == State.WALKING) {
             try {
                 isInCollisionCheck = true
 
@@ -110,23 +110,27 @@ object PhaseBlink : Choice("Blink") {
             return@handler
         }
 
-        if (state == State.WAITING) {
-            try {
-                isInCollisionCheck = true
+        try {
+            isInCollisionCheck = true
+
+            if (state == State.WAITING) {
                 // Check if we should start phasing
                 if (player.doesCollideAt()) {
                     state = State.PHASING
                 }
-            } finally {
-                isInCollisionCheck = false
+            } else if (state == State.PHASING) {
+                if (!player.doesCollideAt()) {
+                    state = State.WALKING
+                }
             }
+        } finally {
+            isInCollisionCheck = false
         }
-
     }
 
     @Suppress("unused")
     private val boxHandler = handler<BlockShapeEvent> { event ->
-        if (isInCollisionCheck) {
+        if (isInCollisionCheck || state.boxCollisions) {
             return@handler
         }
 
@@ -155,11 +159,11 @@ object PhaseBlink : Choice("Blink") {
         event.action = when (event.packet) {
             is BlockUpdateS2CPacket, is BlockEventS2CPacket,
             is ChunkDeltaUpdateS2CPacket, is ChunkDataS2CPacket,
-            is ChunkSentS2CPacket -> {
+            is ChunkSentS2CPacket, is TitleS2CPacket -> {
                 Action.PASS
             }
 
-            else -> if (state == State.PHASING) {
+            else -> if (state == State.PHASING || state == State.WALKING) {
                 Action.QUEUE
             } else {
                 Action.PASS
@@ -168,10 +172,11 @@ object PhaseBlink : Choice("Blink") {
     }
 
 
-    private enum class State {
-        WAITING,
-        PHASING,
-        FLUSHING
+    private enum class State(val boxCollisions: Boolean) {
+        WAITING(false),
+        PHASING(false),
+        WALKING(true),
+        FLUSHING(true)
     }
 
 }


### PR DESCRIPTION
Introduces the walking state after phasing. Basically, it used to continue phasing in every block we walked into, which is a bit problematic if we want to go somewhere e.g. stairs. Now we only allow phasing once.

I hope no server uses a double layered wall with space in between.