### PR TITLE
feat(api): lookup alive endpoint

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -23,6 +23,7 @@ import com.mojang.blaze3d.systems.RenderSystem
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
+import net.ccbluex.liquidbounce.api.core.ApiConfig
 import net.ccbluex.liquidbounce.api.core.scope
 import net.ccbluex.liquidbounce.api.models.auth.ClientAccount
 import net.ccbluex.liquidbounce.api.services.client.ClientUpdate.gitInfo
@@ -256,6 +257,10 @@ object LiquidBounce : EventListener {
      * which do not rely on the main thread.
      */
     private fun initializeResources() = runBlocking {
+        logger.info("Initializing API...")
+        // Lookup API config
+        ApiConfig.config
+
         listOf(
             scope.async {
                 // Load translations

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/ApiConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/ApiConfig.kt
@@ -44,8 +44,8 @@ class ApiConfig(
             // as they are vulnerable to MITM attacks and data leaks.
             // A VPN or a proxy can be used to secure the connection.
             // TODO: Because we cannot request confirmation from the user, we should not use this URL at all.
-            //   The only way to use this URL is to set the system property `net.ccbluex.liquidbounce.api.url` to this URL
-            //   which the LiquidLauncher does when the user has confirmed it.
+            //   The only way to use this URL is to set the property `net.ccbluex.liquidbounce.api.url` to
+            //   this URL which the LiquidLauncher does when the user has confirmed it.
             // "http://nossl.api.liquidbounce.net"
         )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/ApiConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/ApiConfig.kt
@@ -18,23 +18,105 @@
  */
 package net.ccbluex.liquidbounce.api.core
 
-const val API_V1_ENDPOINT = "https://api.liquidbounce.net/api/v1"
-const val API_V3_ENDPOINT = "https://api.liquidbounce.net/api/v3"
+import net.ccbluex.liquidbounce.utils.client.logger
+import org.apache.commons.lang3.RandomStringUtils
 
-const val CLIENT_CDN = "https://cloud.liquidbounce.net/LiquidBounce"
+class ApiConfig(
+    val url: String,
+    @Suppress("unused")
+    val secure: Boolean = url.startsWith("https://"),
+    val sessionToken: String
+) {
 
-const val AUTH_BASE_URL = "https://auth.liquidbounce.net/application/o"
-const val AUTH_AUTHORIZE_URL = "$AUTH_BASE_URL/authorize/"
-const val AUTH_CLIENT_ID = "J2hzqzCxch8hfOPRFNINOZV5Ma4X4BFdZpMjAVEW"
+    val apiEndpointV1 = "$url/api/v1"
+    val apiEndpointV3 = "$url/api/v3"
 
-/**
- * This makes sense because we want forks to be able to use this API and not only the official client.
- * It also allows us to use API endpoints for legacy on other branches.
- */
-const val API_BRANCH = "nextgen"
+    companion object {
 
-private const val AVATAR_BASE_URL = "https://avatar.liquidbounce.net/avatar"
-const val AVATAR_UUID_URL = "$AVATAR_BASE_URL/%s/100"
-const val AVATAR_USERNAME_URL = "$AVATAR_BASE_URL/%s"
+        /**
+         * API URLs for LiquidBounce
+         */
+        private val API_URLS = arrayOf(
+            "https://api.liquidbounce.net",
+            "https://api.ccbluex.net",
+
+            // Non-secure connection requires additional confirmation from the user,
+            // as they are vulnerable to MITM attacks and data leaks.
+            // A VPN or a proxy can be used to secure the connection.
+            // TODO: Because we cannot request confirmation from the user, we should not use this URL at all.
+            //   The only way to use this URL is to set the system property `net.ccbluex.liquidbounce.api.url` to this URL
+            //   which the LiquidLauncher does when the user has confirmed it.
+            // "http://nossl.api.liquidbounce.net"
+        )
+
+        const val CLIENT_CDN = "https://cloud.liquidbounce.net/LiquidBounce"
+
+        const val AUTH_BASE_URL = "https://auth.liquidbounce.net/application/o"
+        const val AUTH_AUTHORIZE_URL = "$AUTH_BASE_URL/authorize/"
+        const val AUTH_CLIENT_ID = "J2hzqzCxch8hfOPRFNINOZV5Ma4X4BFdZpMjAVEW"
+
+        /**
+         * This makes sense because we want forks to be able to use this API and not only the official client.
+         * It also allows us to use API endpoints for legacy on other branches.
+         */
+        const val API_BRANCH = "nextgen"
+
+        private const val AVATAR_BASE_URL = "https://avatar.liquidbounce.net/avatar"
+        const val AVATAR_UUID_URL = "$AVATAR_BASE_URL/%s/100"
+        const val AVATAR_USERNAME_URL = "$AVATAR_BASE_URL/%s"
+
+        /**
+         * Defines the API environment for LiquidBounce.
+         * This should be initialized before the API is used through [net.ccbluex.liquidbounce.LiquidBounce].
+         */
+        val config by AsyncLazy<ApiConfig> {
+            lookup()
+        }
+
+        suspend fun lookup(): ApiConfig {
+            val sessionToken = System.getProperty(
+                "net.ccbluex.liquidbounce.api.token",
+                RandomStringUtils.secure().nextAlphanumeric(16)
+            )
+            logger.info("API Session Token: $sessionToken")
+
+            // We trust LiquidLauncher to have found the correct API URL
+            val propertyUrl = System.getProperty("net.ccbluex.liquidbounce.api.url")
+            if (propertyUrl != null) {
+                logger.info("Using API URL from system property: $propertyUrl")
+                return ApiConfig(propertyUrl, sessionToken = sessionToken)
+            }
+
+            // Try API urls until we find one that works
+            logger.info("Looking up available API endpoints...")
+            for (url in API_URLS) {
+                try {
+                    // Throws [HttpException] when not successful
+                    HttpClient.request(url, HttpMethod.GET)
+
+                    logger.info("API endpoint '$url' is available")
+                    return ApiConfig(
+                        url,
+                        sessionToken = sessionToken
+                    )
+                } catch (e: HttpException) {
+                    logger.debug("API endpoint '$url' returned status code: ${e.code}")
+                } catch (e: Exception) {
+                    logger.error("Failed to connect to API endpoint '$url'", e)
+                }
+            }
+
+            logger.error("No API endpoints are available, using default: ${API_URLS[0]}")
+            return ApiConfig(
+                API_URLS[0],
+                sessionToken = sessionToken
+            )
+        }
+
+    }
 
 
+
+
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
@@ -18,9 +18,11 @@
  */
 package net.ccbluex.liquidbounce.api.core
 
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.AVATAR_USERNAME_URL
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.AVATAR_UUID_URL
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import okhttp3.Headers
 import okhttp3.RequestBody
-import org.apache.commons.lang3.RandomStringUtils
 import java.util.*
 
 fun formatAvatarUrl(uuid: UUID?, username: String): String {
@@ -30,9 +32,6 @@ fun formatAvatarUrl(uuid: UUID?, username: String): String {
         AVATAR_USERNAME_URL.format(username)
     }
 }
-
-
-val SESSION_TOKEN: String = RandomStringUtils.randomAlphanumeric(16)
 
 /**
  * Base API class
@@ -50,7 +49,7 @@ abstract class BaseApi(protected val baseUrl: String) {
         crossinline headers: Headers.Builder.() -> Unit = {},
         body: RequestBody? = null
     ): T = HttpClient.request("$baseUrl$endpoint", method, headers = {
-        add("X-Session-Token", SESSION_TOKEN)
+        add("X-Session-Token", config.sessionToken)
         headers(this)
     }, body = body).parse()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/auth/AuthenticationApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/auth/AuthenticationApi.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.api.services.auth
 
-import net.ccbluex.liquidbounce.api.core.AUTH_BASE_URL
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.AUTH_BASE_URL
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.api.core.asForm
 import net.ccbluex.liquidbounce.api.models.auth.TokenResponse

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/auth/OAuthClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/auth/OAuthClient.kt
@@ -24,8 +24,8 @@ import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.*
-import net.ccbluex.liquidbounce.api.core.AUTH_AUTHORIZE_URL
-import net.ccbluex.liquidbounce.api.core.AUTH_CLIENT_ID
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.AUTH_AUTHORIZE_URL
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.AUTH_CLIENT_ID
 import net.ccbluex.liquidbounce.api.core.withScope
 import net.ccbluex.liquidbounce.api.models.auth.ClientAccount
 import net.ccbluex.liquidbounce.api.models.auth.OAuthSession

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cdn/ClientCdn.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cdn/ClientCdn.kt
@@ -20,8 +20,8 @@
  */
 package net.ccbluex.liquidbounce.api.services.cdn
 
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.CLIENT_CDN
 import net.ccbluex.liquidbounce.api.core.BaseApi
-import net.ccbluex.liquidbounce.api.core.CLIENT_CDN
 import net.ccbluex.liquidbounce.api.core.utf8Lines
 import net.ccbluex.liquidbounce.api.models.cdn.IpcConfiguration
 import okio.BufferedSource

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/client/ClientApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/client/ClientApi.kt
@@ -18,15 +18,15 @@
  */
 package net.ccbluex.liquidbounce.api.services.client
 
-import net.ccbluex.liquidbounce.api.core.API_BRANCH
-import net.ccbluex.liquidbounce.api.core.API_V1_ENDPOINT
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.API_BRANCH
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.api.models.client.AutoSettings
 import net.ccbluex.liquidbounce.api.models.client.Build
 import net.ccbluex.liquidbounce.api.models.client.MessageOfTheDay
 import java.io.Reader
 
-object ClientApi : BaseApi(API_V1_ENDPOINT) {
+object ClientApi : BaseApi(config.apiEndpointV1) {
 
     suspend fun requestNewestBuildEndpoint(branch: String = API_BRANCH, release: Boolean = false) =
         get<Build>("/version/newest/$branch${if (release) "/release" else ""}")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CapeApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CapeApi.kt
@@ -18,11 +18,11 @@
  */
 package net.ccbluex.liquidbounce.api.services.cosmetics
 
-import net.ccbluex.liquidbounce.api.core.API_V1_ENDPOINT
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.minecraft.client.texture.NativeImageBackedTexture
 
-object CapeApi : BaseApi(API_V1_ENDPOINT) {
+object CapeApi : BaseApi(config.apiEndpointV1) {
     suspend fun getCape(name: String) =
         get<NativeImageBackedTexture>("/cape/name/$name")
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CosmeticApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CosmeticApi.kt
@@ -18,12 +18,12 @@
  */
 package net.ccbluex.liquidbounce.api.services.cosmetics
 
-import net.ccbluex.liquidbounce.api.core.API_V3_ENDPOINT
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.api.models.cosmetics.Cosmetic
 import java.util.*
 
-object CosmeticApi : BaseApi(API_V3_ENDPOINT) {
+object CosmeticApi : BaseApi(config.apiEndpointV3) {
 
     suspend fun getCarriers() =
         get<Set<String>>("/cosmetics/carriers")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/user/UserApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/user/UserApi.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.api.services.user
 
 import com.google.gson.JsonObject
-import net.ccbluex.liquidbounce.api.core.API_V3_ENDPOINT
+import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.api.core.toRequestBody
 import net.ccbluex.liquidbounce.api.models.auth.OAuthSession
@@ -31,7 +31,7 @@ import java.util.*
 /**
  * API for user-related endpoints that require authentication
  */
-object UserApi : BaseApi(API_V3_ENDPOINT) {
+object UserApi : BaseApi(config.apiEndpointV3) {
 
     suspend fun getUserInformation(session: OAuthSession) = get<UserInformation>(
         "/oauth/user",


### PR DESCRIPTION
Also uses the net.ccbluex.liquidbounce.api.url property to allow the LiquidLauncher to pass a ready to use URL.