### PR TITLE
refactor(SafeWalk): new on edge mode

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -131,12 +131,10 @@ fun ClientPlayerEntity.wouldBeCloseToFallOff(position: Vec3d): Boolean {
 fun ClientPlayerEntity.isCloseToEdge(
     directionalInput: DirectionalInput,
     distance: Double = 0.1,
-    pos: Vec3d = this.pos
+    pos: Vec3d = this.pos,
 ): Boolean {
     val alpha = (getMovementDirectionOfInput(this.yaw, directionalInput) + 90.0F).toRadians()
-
     val simulatedInput = SimulatedPlayer.SimulatedPlayerInput.fromClientPlayer(directionalInput)
-
     simulatedInput.set(
         jump = false,
         sneak = false
@@ -147,11 +145,9 @@ fun ClientPlayerEntity.isCloseToEdge(
     )
 
     simulatedPlayer.pos = pos
-
     simulatedPlayer.tick()
 
     val nextVelocity = simulatedPlayer.velocity
-
     val direction = if (nextVelocity.horizontalLengthSquared() > 0.003 * 0.003) {
         nextVelocity.multiply(1.0, 0.0, 1.0).normalize()
     } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/movement/DirectionalInput.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/movement/DirectionalInput.kt
@@ -29,6 +29,15 @@ data class DirectionalInput(
         right = movementSideways < 0.0
     )
 
+    fun invert(): DirectionalInput {
+        return DirectionalInput(
+            forwards = backwards,
+            backwards = forwards,
+            left = right,
+            right = left
+        )
+    }
+
     override fun equals(other: Any?): Boolean {
         return other is DirectionalInput &&
             forwards == other.forwards &&


### PR DESCRIPTION
This is a rewrite of the on-edge detection mode, which now checks when moving away from edges. There are also multiple modes to prevent falling, e.g., Stop, Center and Invert, as well as a timer to keep input for longer, and a sneak and jump option.

The Eagle On Ledge option has been removed as it is redundant given the [Eagle] module and settings. Simulate is removed as well (replaced by on edge).