### PR TITLE
fix(AutoLeave): totem logic

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/Sequence.kt
@@ -142,11 +142,12 @@ open class Sequence(val owner: EventListener, val handler: SuspendableHandler) {
 
     /**
      * Waits until the fixed amount of ticks ran out or the [breakLoop] says to continue.
+     * Returns true when we passed the time of [ticks] without breaking the loop.
      */
     suspend fun waitConditional(ticks: Int, breakLoop: BooleanSupplier = BooleanSupplier { false }): Boolean {
         // Don't wait if ticks is 0
         if (ticks == 0) {
-            return true
+            return !breakLoop.asBoolean
         }
 
         wait { if (breakLoop.asBoolean) 0 else ticks }


### PR DESCRIPTION
Auto Leave now will check if you are holding a totem. If not and you do that for longer than your [delay], you will leave the server. When switching to a delay below your [delay] the timer will reset. Also allows you to randomize the [delay] now.