### PR TITLE
fix(Aimbot): click detection

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
@@ -120,18 +120,17 @@ object ModuleAimbot : ClientModule("Aimbot", Category.COMBAT, aliases = arrayOf(
         val partialTicks = event.partialTicks
         val target = targetTracker.target ?: return@handler
 
-        renderEnvironmentForWorld(matrixStack) {
-            targetRenderer.render(this, target, partialTicks)
-        }
-
         if (IgnoreOpened.SCREEN !in ignores && mc.currentScreen != null) {
             return@handler
         }
 
-        if (IgnoreOpened.CONTAINER !in ignores
-            && (InventoryManager.isInventoryOpen || mc.currentScreen is HandledScreen<*>)
-        ) {
+        if (IgnoreOpened.CONTAINER !in ignores && (InventoryManager.isInventoryOpen ||
+                mc.currentScreen is HandledScreen<*>)) {
             return@handler
+        }
+
+        renderEnvironmentForWorld(matrixStack) {
+            targetRenderer.render(this, target, partialTicks)
         }
 
         val currentRotation = playerRotation ?: return@handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraRequirements.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
+import net.ccbluex.liquidbounce.utils.input.InputTracker.wasPressedRecently
 import net.minecraft.item.AxeItem
 import net.minecraft.item.Item
 import net.minecraft.item.MaceItem
@@ -34,7 +35,7 @@ enum class KillAuraRequirements(
     val meets: () -> Boolean
 ) : NamedChoice {
     CLICK("Click", {
-        mc.options.attackKey.isPressedOnAny
+        mc.options.attackKey.isPressedOnAny || mc.options.attackKey.wasPressedRecently(250)
     }),
     WEAPON("Weapon", {
         player.inventory.mainHandStack.item.isWeapon()


### PR DESCRIPTION
Aimbot was unhooking when we stopped pressing the mouse button which is a bit unfortunate when we are not using Auto Clicker but click spam instead. LiquidBounce now keeps track when we last clicked a mouse button.

Also, now stops target rendering when we are in an inventory.