### PR TITLE
fix(MCEF/accelerated-paint): disable NVIDIA support

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowserBackend.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowserBackend.kt
@@ -216,13 +216,18 @@ class CefBrowserBackend : BrowserBackend, EventListener {
             // we could not get this feature to work reliably on Intel GPUs.
             // On Intel GPU (Intel ARC), it does not work as well and is reported:
             // https://github.com/IGCIT/Intel-GPU-Community-Issue-Tracker-IGCIT/issues/1143
-            val isSupportedGpu = vendor.lowercase().contains("nvidia") ||
-                                 renderer.lowercase().contains("geforce") ||
-                                 renderer.lowercase().contains("quadro") ||
-                                 vendor.lowercase().contains("amd") ||
+
+            // Disable support for NVIDIA until we can get the dirty rects
+            // rendering to work properly.
+            // vendor.lowercase().contains("nvidia") ||
+            //                                 renderer.lowercase().contains("geforce") ||
+            //                                 renderer.lowercase().contains("quadro") ||
+
+            val isSupportedGpu = vendor.lowercase().contains("amd") ||
                                  renderer.lowercase().contains("radeon")
             if (!isSupportedGpu) {
-                logger.warn("GPU acceleration only supported on NVIDIA and AMD GPUs")
+                logger.warn("GPU acceleration only supported on AMD GPUs")
+//                logger.warn("GPU acceleration only supported on NVIDIA and AMD GPUs")
                 logger.info("Falling back to software rendering for browser")
                 return false
             }


### PR DESCRIPTION
Temporarily disables support for NVIDIA GPUs until we can find a reliable solution that works on NV drivers. AMD support works, though.