### PR TITLE
fix(AntiVoid): repeating to rescue on failure

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidFlagMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidFlagMode.kt
@@ -30,7 +30,7 @@ object AntiVoidFlagMode : AntiVoidMode("Flag") {
     override val parent: ChoiceConfigurable<*>
         get() = ModuleAntiVoid.mode
 
-    override fun fix(): Boolean {
+    override fun rescue(): Boolean {
         if (player.fallDistance >= fallDistance) {
             player.setPosition(player.pos.add(0.0, 0.42, 0.0))
             return true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidGhostBlockMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidGhostBlockMode.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid.isLikelyFalling
-import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid.nonFallingPosition
+import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid.rescuePosition
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidGhostBlockMode.handleBlockShape
 import net.minecraft.util.shape.VoxelShapes
 import kotlin.math.floor
@@ -42,7 +42,8 @@ object AntiVoidGhostBlockMode : AntiVoidMode("GhostBlock") {
         }
 
         // We only want to place a fake-block collision below the player if the collision shape is empty.
-        if (event.shape != VoxelShapes.empty() || event.pos.y >= floor(nonFallingPosition.y)) {
+        var safePosition = rescuePosition
+        if (event.shape != VoxelShapes.empty() || safePosition == null || event.pos.y >= floor(safePosition.y)) {
             return@handler
         }
 
@@ -52,6 +53,6 @@ object AntiVoidGhostBlockMode : AntiVoidMode("GhostBlock") {
     /**
      * We have [handleBlockShape] to fix our situation instead.
      */
-    override fun fix() = false
+    override fun rescue() = false
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidMode.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid
+import net.minecraft.util.math.Vec3d
 
 abstract class AntiVoidMode(name: String) : Choice(name) {
 
@@ -34,9 +35,16 @@ abstract class AntiVoidMode(name: String) : Choice(name) {
     open val isExempt: Boolean
         get() = player.isDead || ModuleFly.running
 
+    open fun discoverRescuePosition(): Vec3d? {
+        if (!ModuleAntiVoid.isLikelyFalling) {
+            return player.pos
+        }
+        return null
+    }
+
     /**
      * Attempt to safely move the player to a safe location.
      */
-    abstract fun fix(): Boolean
+    abstract fun rescue(): Boolean
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -264,7 +264,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
         debugParameters[DebuggedOwner(owner, name)] = ParameterCapture(value = value)
     }
 
-    inline fun Any.debugParameter(name: String, lazyValue: () -> Any) {
+    inline fun Any.debugParameter(name: String, lazyValue: () -> Any?) {
         if (!ModuleDebug.running) {
             return
         }


### PR DESCRIPTION
When AntiVoid failed to rescue us, it should stop trying. This is now the case. Also, the logic to determine if we are going to fall is drastically improved. Edge jumps are detecting without any issues, while when we would miss a block, we'd get rescued before we even fall.