### PR TITLE
refactor(SkinChanger): async request

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
@@ -21,6 +21,8 @@ package net.ccbluex.liquidbounce.config.types
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import net.ccbluex.liquidbounce.authlib.account.MinecraftAccount
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
@@ -79,6 +81,12 @@ open class Value<T : Any>(
     @Exclude
     @ProtocolExclude
     private val changedListeners = mutableListOf<ValueChangedListener<T>>()
+
+    @Exclude
+    @ProtocolExclude
+    private val stateFlow = MutableStateFlow(inner)
+
+    fun asStateFlow(): StateFlow<T> = stateFlow
 
     /**
      * If true, value will not be included in generated public config
@@ -230,6 +238,7 @@ open class Value<T : Any>(
             apply(currT)
             EventManager.callEvent(ValueChangedEvent(this))
             changedListeners.forEach { it(currT) }
+            stateFlow.value = currT
         }.onFailure { ex ->
             logger.error("Failed to set ${this.name} from ${this.inner} to $t", ex)
         }


### PR DESCRIPTION
The original implementation blocks render thread on fetching because `GameProfileRepository().fetchUuidByUsername(username)` do sync HTTP request.