### PR TITLE
fix(SkinChanger): config value skin not loaded

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.mojang.authlib.GameProfile
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import net.ccbluex.liquidbounce.api.core.withScope

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
@@ -39,6 +39,7 @@ object ModuleSkinChanger : ClientModule("SkinChanger", Category.RENDER) {
     init {
         withScope {
             username.asStateFlow().debounce { 2.seconds }.collectLatest {
+                while (mc.player == null) { delay(1.seconds) }
                 skinTextures = textureSupplier(it)
             }
         }


### PR DESCRIPTION
It seems that PlayerListEntry.texturesSupplier only works when the game is completely initialized (after config deserialization)