### PR TITLE
refactor(BlockTracker): reduce memory usage

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -32,6 +32,7 @@ import net.ccbluex.liquidbounce.utils.block.ChunkScanner
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.ccbluex.liquidbounce.utils.inventory.findBlocksEndingWith
 import net.ccbluex.liquidbounce.utils.math.toVec3d
+import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.math.BlockPos
@@ -84,7 +85,7 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
 
             renderEnvironmentForWorld(matrixStack) {
                 dirty = drawInternal(
-                    BlockTracker.trackedBlockMap.keys,
+                    BlockTracker.allPositions(),
                     colorMode,
                     fullAlpha,
                     drawOutline
@@ -95,7 +96,7 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
         }
 
         private fun WorldRenderEnvironment.drawInternal(
-            blocks: Set<BlockPos>,
+            blocks: Sequence<BlockPos>,
             colorMode: GenericColorMode<Pair<BlockPos, BlockState>>,
             fullAlpha: Boolean,
             drawOutline: Boolean
@@ -184,17 +185,9 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
         ChunkScanner.unsubscribe(BlockTracker)
     }
 
-    private object TrackedState
-
-    private object BlockTracker : AbstractBlockLocationTracker<TrackedState>() {
-        override fun getStateFor(pos: BlockPos, state: BlockState): TrackedState? {
-            return if (!state.isAir && targets.contains(state.block)) {
-                TrackedState
-            } else {
-                null
-            }
-        }
-
+    private object BlockTracker : AbstractBlockLocationTracker.State2BlockPos<Block>() {
+        override fun getStateFor(pos: BlockPos, state: BlockState): Block? =
+            state.block?.takeIf { it in targets }
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -108,7 +108,7 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
         private fun collectBoxesToDraw(event: WorldRenderEvent): List<BoxRecord> {
             val queuedBoxes = mutableListOf<BoxRecord>()
 
-            for ((pos, type) in StorageScanner.trackedBlockMap) {
+            for ((pos, type) in StorageScanner.iterate()) {
                 val color = type.color
 
                 if (color.a <= 0 || !type.shouldRender(pos)) {
@@ -157,13 +157,13 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
         @Suppress("unused")
         val glowRenderHandler = handler<DrawOutlinesEvent> { event ->
             if (event.type != DrawOutlinesEvent.OutlineType.MINECRAFT_GLOW
-                || StorageScanner.trackedBlockMap.isEmpty()) {
+                || StorageScanner.isEmpty()) {
                 return@handler
             }
 
             renderEnvironmentForWorld(event.matrixStack) {
                 BoxRenderer.drawWith(this) {
-                    for ((pos, type) in StorageScanner.trackedBlockMap) {
+                    for ((pos, type) in StorageScanner.iterate()) {
                         val state = pos.getState() ?: continue
 
                         // non-model blocks are already processed by WorldRenderer where we injected code which renders
@@ -256,7 +256,7 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
         open fun shouldRender(pos: BlockPos): Boolean = true
     }
 
-    private object StorageScanner : AbstractBlockLocationTracker<ChestType>() {
+    private object StorageScanner : AbstractBlockLocationTracker.State2BlockPos<ChestType>() {
         override fun getStateFor(pos: BlockPos, state: BlockState): ChestType? {
             val chunk = mc.world?.getChunk(pos) ?: return null
             return chunk.getBlockEntity(pos)?.categorize()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmBlockHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmBlockHandler.kt
@@ -31,7 +31,7 @@ enum class AutoFarmTrackedStates {
     Soulsand
 }
 
-object AutoFarmBlockTracker : AbstractBlockLocationTracker<AutoFarmTrackedStates>() {
+object AutoFarmBlockTracker : AbstractBlockLocationTracker.State2BlockPos<AutoFarmTrackedStates>() {
     override fun getStateFor(pos: BlockPos, state: BlockState): AutoFarmTrackedStates? {
         if (ModuleAutoFarm.isTargeted(state, pos)) {
             return AutoFarmTrackedStates.Destroy
@@ -65,10 +65,10 @@ object AutoFarmBlockTracker : AbstractBlockLocationTracker<AutoFarmTrackedStates
         val targetBlockPos = pos.down()
         if (state.isAir) {
             // If there is no air above, add it
-            this.trackedBlockMap[targetBlockPos] = trackedState
+            track(targetBlockPos, trackedState)
         } else {
             // If there is no air above, we want to remove it
-            this.trackedBlockMap.remove(targetBlockPos)
+            untrack(targetBlockPos)
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmVisualizer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmVisualizer.kt
@@ -88,11 +88,9 @@ object AutoFarmVisualizer : ToggleableConfigurable(ModuleAutoFarm, "Visualize", 
             val fillColor = baseColor.with(a = 50)
             val outlineColor = baseColor.with(a = 100)
 
-            val markedBlocks = AutoFarmBlockTracker.trackedBlockMap
-
             renderEnvironmentForWorld(matrixStack) {
                 CurrentTarget.render(this)
-                for ((pos, type) in markedBlocks) {
+                for ((pos, type) in AutoFarmBlockTracker.iterate()) {
                     if ((pos.x - player.x).sq() + (pos.z - player.z).sq() > rangeSquared) continue
 
                     withPositionRelativeToCamera(pos.toVec3d()) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AbstractBlockLocationTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AbstractBlockLocationTracker.kt
@@ -18,48 +18,191 @@
  */
 package net.ccbluex.liquidbounce.utils.block
 
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet
+import it.unimi.dsi.fastutil.longs.LongSet
 import net.minecraft.block.BlockState
 import net.minecraft.util.math.BlockPos
-import java.util.concurrent.ConcurrentSkipListMap
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 /**
- * Tracks locations of specific blocks in the world
+ * Tracks locations of specific states in the world.
  *
  * @param T state type
  */
-abstract class AbstractBlockLocationTracker<T> : ChunkScanner.BlockChangeSubscriber {
-
-    val trackedBlockMap = ConcurrentSkipListMap<BlockPos, T>()
+sealed class AbstractBlockLocationTracker<T> : ChunkScanner.BlockChangeSubscriber {
 
     /**
-     * Implementations of this method must be thread-safe
+     * Gets the [state] of specified [BlockPos] and its [BlockState].
+     *
+     * @return null if [pos] should be untracked
      */
     abstract fun getStateFor(pos: BlockPos, state: BlockState): T?
 
-    override fun recordBlock(pos: BlockPos, state: BlockState, cleared: Boolean) {
+    /**
+     * Untracks a [BlockPos].
+     *
+     * @return true if the [pos] was tracked and now removed, false if the [pos] is untracked.
+     */
+    abstract fun untrack(pos: BlockPos): Boolean
+
+    /**
+     * Tracks a [BlockPos] with [state].
+     */
+    abstract fun track(pos: BlockPos, state: T)
+
+    /**
+     * Returns a [Sequence] providing all tracked [BlockPos].
+     *
+     * Note: The elements of the [Sequence] is [BlockPos.Mutable]. Copy them if they will be maintained.
+     */
+    abstract fun allPositions(): Sequence<BlockPos>
+
+    /**
+     * Returns a [Sequence] providing all tracked [BlockPos] and its state [T].
+     *
+     * Note: The elements of the [Map.Entry.key] is [BlockPos.Mutable]. Copy them if they will be maintained.
+     */
+    abstract fun iterate(): Sequence<Map.Entry<BlockPos, T>>
+
+    /**
+     * Returns if there iss nothing tracked.
+     */
+    abstract fun isEmpty(): Boolean
+
+    final override fun recordBlock(pos: BlockPos, state: BlockState, cleared: Boolean) {
         val newState = this.getStateFor(pos, state)
 
         if (newState == null) {
             if (!cleared) {
-                this.trackedBlockMap.remove(pos)
+                untrack(pos)
             }
+        } else {
+            track(pos, newState)
+        }
+    }
 
-            return
+    final override fun chunkUpdate(x: Int, z: Int) {
+        // NOP
+    }
+
+    /**
+     * This base implementation stores multiple [BlockPos] for each state [T].
+     *
+     * If one instance of [T] will be mapped from many [BlockPos],
+     * for example, [T] is [Enum], this base will consume less memory.
+     *
+     * @param T the generic should be stable for hash.
+     * @see BlockPos2State
+     * @see AbstractBlockLocationTracker
+     */
+    abstract class State2BlockPos<T> : AbstractBlockLocationTracker<T>() {
+        private val stateAndPositions = hashMapOf<T, LongSet>()
+
+        private val lock = ReentrantReadWriteLock()
+
+        final override fun allPositions() = sequence<BlockPos> {
+            val mutable = BlockPos.Mutable()
+            lock.read {
+                for (positions in stateAndPositions.values) {
+                    val iterator = positions.longIterator()
+                    while (iterator.hasNext()) {
+                        mutable.set(iterator.nextLong())
+                        yield(mutable)
+                    }
+                }
+            }
         }
 
-        val targetBlockPos = if (pos is BlockPos.Mutable) pos.toImmutable() else pos
-        this.trackedBlockMap[targetBlockPos] = newState
+        final override fun iterate() = sequence<Map.Entry<BlockPos, T>> {
+            val mutable = BlockPos.Mutable()
+            var entry: FullMutableEntry<BlockPos, T>? = null
+            lock.read {
+                for ((state, positions) in stateAndPositions) {
+                    val iterator = positions.longIterator()
+                    while (iterator.hasNext()) {
+                        mutable.set(iterator.nextLong())
+                        if (entry == null) {
+                            entry = FullMutableEntry(mutable, state)
+                        } else {
+                            entry.value = state
+                        }
+                        yield(entry)
+                    }
+                }
+            }
+        }
+
+        final override fun isEmpty() = lock.read {
+            stateAndPositions.isEmpty() || stateAndPositions.values.all { it.isEmpty() }
+        }
+
+        final override fun track(pos: BlockPos, state: T) {
+            lock.write {
+                stateAndPositions.computeIfAbsent(state) { LongOpenHashSet() }.add(pos.asLong())
+            }
+        }
+
+        final override fun untrack(pos: BlockPos): Boolean {
+            lock.write {
+                val longValue = pos.asLong()
+                return stateAndPositions.values.any { it.remove(longValue) }
+            }
+        }
+
+        final override fun clearAllChunks() {
+            lock.write {
+                stateAndPositions.clear()
+            }
+        }
+
+        final override fun clearChunk(x: Int, z: Int) {
+            val pos = BlockPos.Mutable()
+            lock.write {
+                stateAndPositions.values.forEach { set ->
+                    set.removeIf {
+                        pos.set(it)
+                        pos.x shr 4 == x && pos.z shr 4 == z
+                    }
+                }
+            }
+        }
+
+        private class FullMutableEntry<K, V>(override var key: K, override var value: V) : Map.Entry<K, V>
     }
 
-    override fun clearChunk(x: Int, z: Int) {
-        this.trackedBlockMap.entries.removeIf { (key, _) -> key.x shr 4 == x && key.z shr 4 == z }
-    }
+    /**
+     * This base implementation stores [BlockPos] and state [T] one by one.
+     *
+     * @see State2BlockPos
+     * @see AbstractBlockLocationTracker
+     */
+    abstract class BlockPos2State<T> : AbstractBlockLocationTracker<T>() {
+        private val positionAndState = ConcurrentHashMap<BlockPos, T>()
 
-    override fun clearAllChunks() {
-        this.trackedBlockMap.clear()
-    }
+        final override fun allPositions() = positionAndState.keys.asSequence()
 
-    override fun chunkUpdate(x: Int, z: Int) {
-        // Do nothing. Logic is already implemented in recordBlock
+        final override fun iterate() = positionAndState.entries.asSequence()
+
+        final override fun isEmpty() = positionAndState.isEmpty()
+
+        final override fun track(pos: BlockPos, state: T) {
+            val targetBlockPos = if (pos is BlockPos.Mutable) pos.toImmutable() else pos
+            positionAndState[targetBlockPos] = state
+        }
+
+        final override fun untrack(pos: BlockPos): Boolean {
+            return positionAndState.remove(pos) != null
+        }
+
+        final override fun clearAllChunks() {
+            positionAndState.clear()
+        }
+
+        final override fun clearChunk(x: Int, z: Int) {
+            positionAndState.keys.removeIf { it.x shr 4 == x && it.z shr 4 == z }
+        }
     }
 }


### PR DESCRIPTION
Especially for BlockESP

Some explanation:
Now we have another tracker implementation with reversed key-value(s) storage, thus **one state** to **multiple positions**. This will save more memory for features like BlockESP/StorageESP, because the states of these features are limited (Block constants/Storage types).