### PR TITLE
refactor(Spider/Spider29thMarch2025): jump height option

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderPolar29thMarch2025.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderPolar29thMarch2025.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes
 import net.ccbluex.liquidbounce.config.types.Choice
 import net.ccbluex.liquidbounce.config.types.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
+import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.ModuleSpider
@@ -39,7 +40,11 @@ internal object SpiderPolar29thMarch2025 : Choice("Polar-29.03.2025") {
     override val parent: ChoiceConfigurable<Choice>
         get() = ModuleSpider.modes
 
-    private val fast by boolean("Fast", true)
+    /**
+     * Polar allows jumping 0.6 high, but it's faster to use 0.55 to hit the
+     * block collision shape.
+     */
+    private val jumpHeight by float("JumpHeight", 0.55f, 0.42f..0.6f)
 
     @Suppress("unused")
     private val boxHandler = handler<BlockShapeEvent> { event ->
@@ -51,14 +56,11 @@ internal object SpiderPolar29thMarch2025 : Choice("Polar-29.03.2025") {
         }
     }
 
-    /**
-     * Could also count as 2-Block Step. Probably could be abused further
-     * to go even faster.
-     */
     @Suppress("unused")
-    private val fastHandler = tickHandler {
-        if (fast && player.horizontalCollision && player.isOnGround) {
-            player.velocity = player.velocity.copy(y = 0.6)
+    private val jumpHandler = handler<PlayerJumpEvent> { event ->
+        var highJump = jumpHeight
+        if (player.horizontalCollision && highJump > 0.42f) {
+            event.motion = highJump
         }
     }
 


### PR DESCRIPTION
Replaces 'Fast' option with Jump Height option which makes it easier to use and now uses 0.55 as it's a bit faster than jumping the total of 0.6.