### PR TITLE
Add ElytraFlyModePitch40Infinite mode

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/ModuleElytraFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/ModuleElytraFly.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraFlyModeBoost
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraFlyModeStatic
 import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraFlyModeVanilla
+import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes.ElytraFlyModePitch40Infinite
 import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.set
 import net.minecraft.entity.EquipmentSlot
@@ -64,7 +65,8 @@ object ModuleElytraFly : ClientModule("ElytraFly", Category.MOVEMENT) {
     internal val modes = choices("Mode", ElytraFlyModeStatic, arrayOf(
         ElytraFlyModeStatic,
         ElytraFlyModeVanilla,
-        ElytraFlyModeBoost
+        ElytraFlyModeBoost,
+        ElytraFlyModePitch40Infinite
     ))
 
     private var needsToRestart = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModePitch40Infinite.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModePitch40Infinite.kt
@@ -1,0 +1,65 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes
+
+import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly
+import net.minecraft.util.math.MathHelper
+import kotlin.math.max
+import kotlin.math.min
+
+internal object ElytraFlyModePitch40Infinite : ElytraFlyMode("Pitch40Infinite") {
+
+    private val minSpeed by float("MinSpeed", 25f, 10f..70f)
+    private val maxSpeed by float("MaxSpeed", 150f, 50f..170f)
+    private val maxHeight by int("MaxHeight", 200, 50..360)
+    private var infinitePitch = 0f
+    private var infiniteFlag = false
+
+    override fun enable() {
+        infinitePitch = 0f
+        infiniteFlag = false
+        if (player.y < maxHeight) {
+            // Can disable module or show warning
+            // For example: ModuleElytraFly.disable("Go above $maxHeight height!")
+        }
+    }
+
+    override fun onTick() {
+        if (!player.isGliding) {
+            return
+        }
+
+        val speed = player.velocity.horizontalLength() * 72f
+        if (player.y < maxHeight) {
+            if (speed < minSpeed && !infiniteFlag) {
+                infiniteFlag = true
+            }
+            if (speed > maxSpeed && infiniteFlag) {
+                infiniteFlag = false
+            }
+        } else {
+            infiniteFlag = true
+        }
+
+        infinitePitch += if (infiniteFlag) 3f else -3f
+        infinitePitch = MathHelper.clamp(infinitePitch, -40f, 40f)
+
+        player.pitch = infinitePitch
+    }
+} 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModePitch40Infinite.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModePitch40Infinite.kt
@@ -18,25 +18,29 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes
 
-import net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.ModuleElytraFly
 import net.minecraft.util.math.MathHelper
-import kotlin.math.max
-import kotlin.math.min
 
 internal object ElytraFlyModePitch40Infinite : ElytraFlyMode("Pitch40Infinite") {
 
     private val minSpeed by float("MinSpeed", 25f, 10f..70f)
     private val maxSpeed by float("MaxSpeed", 150f, 50f..170f)
     private val maxHeight by int("MaxHeight", 200, 50..360)
+    private val pitchIncrement by float("PitchIncrement", 3f, 1f..10f)
+    
     private var infinitePitch = 0f
     private var infiniteFlag = false
+    
+    // Speed conversion constant (m/s to km/h approximately)
+    private const val SPEED_CONVERSION_FACTOR = 72f
+    private const val MIN_PITCH = -40f
+    private const val MAX_PITCH = 40f
 
     override fun enable() {
-        infinitePitch = 0f
-        infiniteFlag = false
+        resetState()
+        
+        // Warning if player is too low
         if (player.y < maxHeight) {
-            // Can disable module or show warning
-            // For example: ModuleElytraFly.disable("Go above $maxHeight height!")
+            // TODO: Add notification to user about recommended height
         }
     }
 
@@ -45,21 +49,49 @@ internal object ElytraFlyModePitch40Infinite : ElytraFlyMode("Pitch40Infinite") 
             return
         }
 
-        val speed = player.velocity.horizontalLength() * 72f
-        if (player.y < maxHeight) {
-            if (speed < minSpeed && !infiniteFlag) {
-                infiniteFlag = true
-            }
-            if (speed > maxSpeed && infiniteFlag) {
-                infiniteFlag = false
-            }
-        } else {
-            infiniteFlag = true
+        val currentSpeed = calculateCurrentSpeed()
+        updateInfiniteFlag(currentSpeed)
+        updatePitch()
+    }
+    
+    /**
+     * Resets the mode state to initial values
+     */
+    private fun resetState() {
+        infinitePitch = 0f
+        infiniteFlag = false
+    }
+    
+    /**
+     * Calculates the current player speed in km/h
+     */
+    private fun calculateCurrentSpeed(): Float {
+        return (player.velocity.horizontalLength() * SPEED_CONVERSION_FACTOR).toFloat()
+    }
+    
+    /**
+     * Updates the infinite flag based on speed and height
+     */
+    private fun updateInfiniteFlag(speed: Float) {
+        infiniteFlag = when {
+            player.y >= maxHeight -> true
+            speed < minSpeed && !infiniteFlag -> true
+            speed > maxSpeed && infiniteFlag -> false
+            else -> infiniteFlag
         }
-
-        infinitePitch += if (infiniteFlag) 3f else -3f
-        infinitePitch = MathHelper.clamp(infinitePitch, -40f, 40f)
-
+    }
+    
+    /**
+     * Updates the pitch value with smooth changes
+     */
+    private fun updatePitch() {
+        val pitchDelta = if (infiniteFlag) pitchIncrement else -pitchIncrement
+        infinitePitch = MathHelper.clamp(
+            infinitePitch + pitchDelta,
+            MIN_PITCH,
+            MAX_PITCH
+        )
+        
         player.pitch = infinitePitch
     }
 } 


### PR DESCRIPTION
What it does:
New elytra flight mode that automatically controls pitch for infinite flight.

It is completely legal and compatible with all anti-cheat server systems. 

How it works:
Speed < 25: Pitch increases (+3° per tick)
Speed > 150: Pitch decreases (-3° per tick)
Pitch range: -40° to +40° (safe limits)
Height limit: 200 blocks (different behavior above)
Some items are outdated information

Result:
Player can fly infinitely with elytra without manual pitch control - the mode automatically adjusts pitch to maintain optimal speed.