### PR TITLE
fix(SkinChanger): not applying skin on custom game profile

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinPlayerListEntry.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinPlayerListEntry.java
@@ -48,16 +48,22 @@ public abstract class MixinPlayerListEntry {
     private Identifier capeTexture = null;
 
     @ModifyReturnValue(method = "getSkinTextures", at = @At("RETURN"))
+    @SuppressWarnings({"ConstantConditions", "EqualsBetweenInconvertibleTypes", "RedundantCast"})
     private SkinTextures liquid_bounce$skin(SkinTextures original) {
         if (HideAppearance.INSTANCE.isDestructed()) {
             return original;
         }
 
-        if (ModuleSkinChanger.INSTANCE.getRunning() &&
-                MinecraftClient.getInstance().getGameProfile().equals(this.profile)) {
-            var customSkinTextures = ModuleSkinChanger.INSTANCE.getSkinTextures();
-            if (customSkinTextures != null) {
-                original = customSkinTextures.get();
+        if (ModuleSkinChanger.INSTANCE.getRunning()) {
+            var player = MinecraftClient.getInstance().player;
+            if (player != null) {
+                var playerListEntry = player.getPlayerListEntry();
+                if (playerListEntry != null && playerListEntry.equals((PlayerListEntry) (Object) this)) {
+                    var customSkinTextures = ModuleSkinChanger.INSTANCE.getSkinTextures();
+                    if (customSkinTextures != null) {
+                        original = customSkinTextures.get();
+                    }
+                }
             }
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleSkinChanger.kt
@@ -16,9 +16,12 @@
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
+@file:OptIn(FlowPreview::class)
+
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.mojang.authlib.GameProfile
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -39,9 +42,9 @@ object ModuleSkinChanger : ClientModule("SkinChanger", Category.RENDER) {
 
     init {
         withScope {
-            username.asStateFlow().debounce { 2.seconds }.collectLatest {
+            username.asStateFlow().debounce { 2.seconds }.collectLatest { username ->
                 while (mc.player == null) { delay(1.seconds) }
-                skinTextures = textureSupplier(it)
+                skinTextures = textureSupplier(username)
             }
         }
     }

--- a/src/main/resources/liquidbounce.accesswidener
+++ b/src/main/resources/liquidbounce.accesswidener
@@ -195,3 +195,4 @@ accessible method net/minecraft/client/gui/screen/multiplayer/ConnectScreen conn
 accessible method net/minecraft/client/gui/screen/multiplayer/ConnectScreen setStatus (Lnet/minecraft/text/Text;)V
 
 accessible method net/minecraft/client/network/PlayerListEntry texturesSupplier (Lcom/mojang/authlib/GameProfile;)Ljava/util/function/Supplier;
+accessible method net/minecraft/client/network/AbstractClientPlayerEntity getPlayerListEntry ()Lnet/minecraft/client/network/PlayerListEntry;


### PR DESCRIPTION
<img width="271" height="339" alt="image" src="https://github.com/user-attachments/assets/28a0ca1e-7721-4080-a8ec-599a7dc42c64" />

Now also overwrites server that provide /skin or custom profile by default.