### PR TITLE
fix: font weight of list setting

### DIFF
--- a/src-theme/src/routes/clickgui/setting/list/GenericListSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/list/GenericListSetting.svelte
@@ -80,7 +80,7 @@
     .name {
       color: $clickgui-text-color;
       font-size: 12px;
-      font-weight: 500;
+      font-weight: 600;
     }
   }
 


### PR DESCRIPTION
Titles of settings that can only be expanded should have font weight 600. Currently, it is the default.

<img width="308" height="120" alt="image" src="https://github.com/user-attachments/assets/da4c3501-e34f-4ded-9466-db1ae50611b7" />