### PR TITLE
fix: expand arrow not being shown for certain modules in click gui

### DIFF
--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -23,9 +23,11 @@
     let configurable: ConfigurableSetting;
     const path = `clickgui.${name}`;
     let expanded = false;
+    let hasSettings = false;
 
     onMount(async () => {
         configurable = await getModuleSettings(name);
+        hasSettings = configurable.value.filter(v => v.name !== "Bind" && v.name !== "Hidden").length > 0;
 
         setTimeout(() => {
             expanded = localStorage.getItem(path) === "true"
@@ -99,7 +101,7 @@
 <div
         class="module"
         class:expanded
-        class:has-settings={configurable?.value.length > 2}
+        class:has-settings={hasSettings}
         in:slide={{ duration: 500, easing: quintOut }}
         out:slide={{ duration: 500, easing: quintOut }}
 >

--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -26,8 +26,7 @@
     let hasSettings = false;
 
     onMount(async () => {
-        configurable = await getModuleSettings(name);
-        hasSettings = configurable.value.filter(v => v.name !== "Bind" && v.name !== "Hidden").length > 0;
+        await fetchModuleSettings();
 
         setTimeout(() => {
             expanded = localStorage.getItem(path) === "true"
@@ -50,9 +49,14 @@
         }, 1000);
     });
 
+    async function fetchModuleSettings() {
+        configurable = await getModuleSettings(name);
+        hasSettings = configurable.value.filter(v => v.name !== "Bind" && v.name !== "Hidden").length > 0;
+    }
+
     async function updateModuleSettings() {
         await setModuleSettings(name, configurable);
-        configurable = await getModuleSettings(name);
+        await fetchModuleSettings();
     }
 
     async function toggleModule() {


### PR DESCRIPTION
Currently, the expand arrow is only shown when a module has more than two settings (settings apart from `Bind` and `Hidden`). This works for most modules, but some, such as `Targets` do not have these settings, and therefore an arrow is not shown even though they contain other settings.

This is now fixed:
<img width="280" height="113" alt="image" src="https://github.com/user-attachments/assets/896a3926-6e04-462f-b9cb-7491872080ca" />
