### PR TITLE
chore: auto add copyright header (in Intellij IDEA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
+!.idea/copyright/
 *.iml
 *.ipr
 *.iws

--- a/.idea/copyright/LiquidBounce.xml
+++ b/.idea/copyright/LiquidBounce.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)&#10;&#10;Copyright (c) 2015 - &amp;#36;today.year CCBlueX&#10;&#10;LiquidBounce is free software: you can redistribute it and/or modify&#10;it under the terms of the GNU General Public License as published by&#10;the Free Software Foundation, either version 3 of the License, or&#10;(at your option) any later version.&#10;&#10;LiquidBounce is distributed in the hope that it will be useful,&#10;but WITHOUT ANY WARRANTY; without even the implied warranty of&#10;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the&#10;GNU General Public License for more details.&#10;&#10;You should have received a copy of the GNU General Public License&#10;along with LiquidBounce. If not, see &lt;https://www.gnu.org/licenses/&gt;." />
+    <option name="myName" value="LiquidBounce" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="LiquidBounce">
+    <module2copyright>
+      <element module="Project Files" copyright="LiquidBounce" />
+    </module2copyright>
+  </settings>
+</component>


### PR DESCRIPTION
Works for `.java` `.kt` `.ts` `.svelte`