### PR TITLE
refactor: CommandSystem

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -152,7 +152,7 @@ object CommandExecutor : EventListener {
     /**
      * Render thread scope
      */
-    private val commandCoroutineScope = CoroutineScope(
+    internal val commandCoroutineScope = CoroutineScope(
         mc.asCoroutineDispatcher() + SupervisorJob() + coroutineExceptionHandler + CoroutineName("CommandExecutor")
     )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandBuilderDsl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandBuilderDsl.kt
@@ -1,0 +1,23 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.command.dsl
+
+@DslMarker
+annotation class CommandBuilderDsl

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandBuilderScope.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandBuilderScope.kt
@@ -1,0 +1,49 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.command.dsl
+
+import net.ccbluex.liquidbounce.features.command.Command
+
+@CommandBuilderDsl
+class CommandBuilderScope private constructor(
+    private val name: String,
+    private vararg val aliases: String,
+    private var parent: Command? = null,
+) {
+
+//    private val paramters =
+
+    var requiresInGame: Boolean = false
+
+    private var execute: (CommandExecutionScope.() -> Unit)? = null
+
+//    fun <T> parameter()
+
+//    fun sub
+
+    fun onExecute(function: CommandExecutionScope.() -> Unit) {
+        execute = function
+    }
+
+    companion object {
+        fun create(name: String, vararg aliases: String) = CommandBuilderScope(name, aliases = aliases)
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandExecutionScope.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/CommandExecutionScope.kt
@@ -1,0 +1,43 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.command.dsl
+
+import kotlinx.coroutines.CoroutineScope
+import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.features.command.CommandExecutor
+
+@CommandBuilderDsl
+sealed interface CommandExecutionScope {
+    val command: Command
+    val raw: String
+    val args: Array<out Any?>
+
+    class Suspend(
+        override val command: Command,
+        override val raw: String,
+        override val args: Array<out Any>,
+    ) : CommandExecutionScope, CoroutineScope by CommandExecutor.commandCoroutineScope
+
+    class Sync(
+        override val command: Command,
+        override val raw: String,
+        override val args: Array<out Any>,
+    ) : CommandExecutionScope
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/ParameterBuilderScope.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/dsl/ParameterBuilderScope.kt
@@ -1,0 +1,24 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.command.dsl
+
+@CommandBuilderDsl
+class ParameterBuilderScope {
+}


### PR DESCRIPTION
## What's the problem of current implementation

Currently we get the parameters from the parser result **manually** and which out any type check at compile time. We can only cast them from `Any` to the actual type, and we even need to check the parameter index. This is not good in such a language with static type system.