### PR TITLE
chore(theme/flags): README and LICENSE

### DIFF
--- a/src-theme/public/img/flags/LICENSE.md
+++ b/src-theme/public/img/flags/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2024 HatScripts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src-theme/public/img/flags/README.md
+++ b/src-theme/public/img/flags/README.md
@@ -1,0 +1,11 @@
+# circle-flags
+
+Flags in a circle shape, with a transparent background.
+
+Original Repository: https://github.com/HatScripts/circle-flags \
+Fork Repository: https://github.com/CCBlueX/circle-flags
+
+Includes all recognized countries using the ISO 3166-1 alpha-2 two-letter country codes.
+
+# License
+This project is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for details.


### PR DESCRIPTION
This reintroduces the README and LICENSE of [circle-flags](https://github.com/HatScripts/circle-flags) that went missing during the process of the [theme-rewrite commit](https://github.com/CCBlueX/LiquidBounce/pull/2263/commits/a9832a4f9365238366805d14073453d620a70cad).