### PR TITLE
refactor(InvCleaner): improve ItemMerge

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ItemMerge.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ItemMerge.kt
@@ -35,18 +35,20 @@ object ItemMerge {
                 continue
             }
 
-            val stacks = mergeableItem.value.map { MergeableStack(it, it.itemStack.count) }
+            val stacks = mergeableItem.value.mapTo(ArrayDeque(mergeableItem.value.size)) {
+                MergeableStack(it, it.itemStack.count)
+            }
+            stacks.sortBy { it.count }
 
-            mergeStacks(itemsToMerge, stacks.toMutableList(), maxStackSize)
+            itemsToMerge.mergeStacks(stacks, maxStackSize)
         }
 
         return itemsToMerge
     }
 
-    class MergeableStack(val slot: ItemSlot, var count: Int)
+    private class MergeableStack(val slot: ItemSlot, var count: Int)
 
-    private fun mergeStacks(
-        itemsToDoubleclick: MutableList<ItemSlot>,
+    private fun MutableList<ItemSlot>.mergeStacks(
         stacks: MutableList<MergeableStack>,
         maxStackSize: Int,
     ) {
@@ -54,19 +56,17 @@ object ItemMerge {
             return
         }
 
-        stacks.sortBy { it.count }
-
         // Remove
         while (stacks.isNotEmpty() && stacks.last().count + stacks[0].count > maxStackSize) {
             stacks.removeLast()
         }
 
         // Find the biggest stack that can be merged
-        val itemToDoubleclick = stacks.removeLastOrNull() ?: return
+        val itemToDbclick = stacks.removeLastOrNull() ?: return
 
-        itemsToDoubleclick.add(itemToDoubleclick.slot)
+        add(itemToDbclick.slot)
 
-        var itemsToRemove = maxStackSize - itemToDoubleclick.count
+        var itemsToRemove = maxStackSize - itemToDbclick.count
 
         // Remove all small stacks that have been removed by last merge
         while (itemsToRemove > 0 && stacks.isNotEmpty()) {
@@ -83,7 +83,7 @@ object ItemMerge {
             itemsToRemove -= stack.count
         }
 
-        mergeStacks(itemsToDoubleclick, stacks, maxStackSize)
+        mergeStacks(stacks, maxStackSize)
     }
 
     private fun canMerge(


### PR DESCRIPTION
1. only sort once because we only remove first and last
2. use ArrayDeque instead of ArrayList because we remove first