### PR TITLE
fix(AltManager): replace dead URLs

### DIFF
--- a/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
+++ b/src-theme/src/routes/menu/altmanager/addaccount/TheAlteningAccountTab.svelte
@@ -24,5 +24,5 @@
 <Tab>
     <IconTextInput icon="user" title="Token" bind:value={token}/>
     <ButtonSetting {disabled} title="Add Account" on:click={addAccount} listenForEnter={true} inset={true} {loading}/>
-    <ButtonSetting title="Get Account Token" on:click={() => browse("ALTENING_FREE")} secondary={true}/>
+    <ButtonSetting title="Get Account Token" on:click={() => browse("THE_ALTENING")} secondary={true}/>
 </Tab>

--- a/src/main/resources/resources/liquidbounce/client_urls.properties
+++ b/src/main/resources/resources/liquidbounce/client_urls.properties
@@ -5,5 +5,4 @@ MAINTAINER_TWITTER=https://x.com/CCBlueX
 MAINTAINER_YOUTUBE=https://youtube.com/CCBlueX
 CLIENT_WEBSITE=https://liquidbounce.net
 VIAFABRICPLUS=https://modrinth.com/mod/viafabricplus
-EASYMC=https://easymc.io/get
-ALTENING_FREE=https://thealtening.com/free/free-minecraft-alts
+THE_ALTENING=https://thealtening.com/?ref=liquidbounce


### PR DESCRIPTION
EasyMC no longer exists and was removed from AltManage ages ago. Because of that, TheAltening no longer has a free page and returns a 404 error.