### PR TITLE
fix(DeepLearning): enforce pytorch flavor to be CPU

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/DeepLearningEngine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/DeepLearningEngine.kt
@@ -56,6 +56,11 @@ object DeepLearningEngine {
         // Disable tracking of DJL
         System.setProperty("OPT_OUT_TRACKING", "true")
 
+        // Set the default engine to PyTorch
+        System.setProperty("DJL_DEFAULT_ENGINE", "PyTorch")
+        // Enforce CPU pytorch flavor (CUDA often conflicts with NVIDIA CUDA and is too large for our use case)
+        System.setProperty("PYTORCH_FLAVOR", "cpu")
+
         ModelHolster
     }
 


### PR DESCRIPTION
CUDA often conflicts with NVIDIA's CUDA drivers(?). Additionally, CUDA is too large for our use case, and we don't want people to have to wait a long time for it to download. This should make it compatible with every system.