### PR TITLE
refactor(renderer): event-based fps limiting

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -32,10 +32,8 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions;
 import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleMiddleClickAction;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAutoBreak;
-import net.ccbluex.liquidbounce.features.module.modules.render.ModuleClickGui;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleXRay;
-import net.ccbluex.liquidbounce.integration.BrowserScreen;
-import net.ccbluex.liquidbounce.integration.VirtualDisplayScreen;
+import net.ccbluex.liquidbounce.integration.IntegrationListener;
 import net.ccbluex.liquidbounce.integration.backend.BrowserBackendManager;
 import net.ccbluex.liquidbounce.integration.backend.browser.GlobalBrowserSettings;
 import net.ccbluex.liquidbounce.render.engine.RenderingFlags;
@@ -410,7 +408,7 @@ public abstract class MixinMinecraftClient {
      */
     @Inject(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;currentScreen:Lnet/minecraft/client/gui/screen/Screen;", ordinal = 4, shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILSOFT)
     private void passthroughInputHandler(CallbackInfo ci, @Local Profiler profiler) {
-        if (this.overlay == null && this.player != null && this.world != null && isAClientScreen(this.currentScreen)) {
+        if (this.overlay == null && this.player != null && this.world != null && IntegrationListener.isClientScreen(this.currentScreen)) {
             profiler.swap("Keybindings");
 
             if (ModuleAutoBreak.INSTANCE.getEnabled()) {
@@ -441,13 +439,7 @@ public abstract class MixinMinecraftClient {
     private boolean injectFixAttackCooldownOnVirtualBrowserScreen(MinecraftClient instance, int value) {
         // Do not reset attack cooldown when we are in the vr/browser screen, as this poses an
         // unintended modification to the attack cooldown, which is not intended.
-        return !isAClientScreen(this.currentScreen);
-    }
-
-    @Unique
-    private boolean isAClientScreen(Screen screen) {
-        return screen instanceof BrowserScreen || screen instanceof VirtualDisplayScreen ||
-                screen instanceof ModuleClickGui.ClickScreen;
+        return !IntegrationListener.isClientScreen(this.currentScreen);
     }
 
     @Inject(method = "getFramebuffer", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInactivityFpsLimiter.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinInactivityFpsLimiter.java
@@ -18,9 +18,13 @@
  */
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.render;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.ccbluex.liquidbounce.event.EventManager;
+import net.ccbluex.liquidbounce.event.events.FpsLimitEvent;
 import net.ccbluex.liquidbounce.utils.render.RefreshRateKt;
 import net.minecraft.client.option.InactivityFpsLimiter;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
@@ -33,6 +37,11 @@ public abstract class MixinInactivityFpsLimiter {
     @ModifyConstant(method = "update", constant = @Constant(intValue = 60))
     private int getFramerateLimit(int original) {
         return RefreshRateKt.getRefreshRate();
+    }
+
+    @ModifyReturnValue(method = "update", at = @At("RETURN"))
+    private int hookFpsLimit(int original) {
+        return EventManager.INSTANCE.callEvent(new FpsLimitEvent(original)).getFps();
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -108,6 +108,7 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     AccountManagerLoginResultEvent::class,
     VirtualScreenEvent::class,
     FpsChangeEvent::class,
+    FpsLimitEvent::class,
     ClientPlayerDataEvent::class,
     RotationUpdateEvent::class,
     RefreshArrayListEvent::class,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/UserInterfaceEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/UserInterfaceEvents.kt
@@ -33,6 +33,10 @@ import net.minecraft.text.Text
 @Suppress("unused")
 class FpsChangeEvent(val fps: Int) : Event()
 
+@Nameable("fpsLimit")
+@Suppress("unused")
+class FpsLimitEvent(var fps: Int) : Event()
+
 @Nameable("clientPlayerData")
 @WebSocketEvent
 @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -50,39 +50,6 @@ object ModuleClickGui :
 
     override val running get() = true
 
-    private val limitGameFps by boolean("LimitGameFPS", true)
-
-    private var maxFpsCache: Int? = null
-
-    private fun applyVsync() {
-        if (!limitGameFps) return
-
-        maxFpsCache = mc.options.maxFps.value
-        mc.options.maxFps.value = minOf(IntegrationListener.browserSettings.currentFps, mc.options.maxFps.value)
-    }
-
-    private fun restoreVsync() {
-        if (maxFpsCache == null) return
-
-        mc.options.maxFps.value = maxFpsCache
-        maxFpsCache = null
-    }
-
-    @Suppress("unused")
-    private val shutdownHandler = handler<ClientShutdownEvent> {
-        restoreVsync()
-    }
-
-    @Suppress("unused")
-    private val virtualScreenHandler = handler<VirtualScreenEvent> {
-        if (it.type === VirtualScreenType.CLICK_GUI) {
-            when (it.action) {
-                VirtualScreenEvent.Action.OPEN -> applyVsync()
-                VirtualScreenEvent.Action.CLOSE -> restoreVsync()
-            }
-        }
-    }
-
     @Suppress("UnusedPrivateProperty")
     private val scale by float("Scale", 1f, 0.5f..2f).onChanged {
         EventManager.callEvent(ClickGuiScaleChangeEvent(it))
@@ -220,11 +187,9 @@ object ModuleClickGui :
 
         override fun init() {
             super.init()
-            applyVsync()
         }
 
         override fun close() {
-            restoreVsync()
             mc.mouse.lockCursor()
             super.close()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
@@ -223,6 +223,22 @@ object IntegrationListener : EventListener {
     }
 
     @Suppress("unused")
+    private val fpsLimitHandler = handler<FpsLimitEvent> { event ->
+        if (!browserSettings.syncGameFps) {
+            return@handler
+        }
+
+        if (isClientScreen(mc.currentScreen)) {
+            val rendererFps = browserSettings.currentFps
+
+            // Only lower FPS if the event FPS is higher than the renderer FPS.
+            if (event.fps > rendererFps) {
+                event.fps = rendererFps
+            }
+        }
+    }
+
+    @Suppress("unused")
     private val keyHandler = handler<KeyboardKeyEvent> { event ->
         val keyCode = event.keyCode
         val modifier = event.mods
@@ -307,5 +323,12 @@ object IntegrationListener : EventListener {
             }
         }
     }
+
+    /**
+     * Checks if the given screen is an active client screen.
+     */
+    @JvmStatic
+    fun isClientScreen(screen: Screen?) = screen is VirtualDisplayScreen || screen is ModuleClickGui.ClickScreen ||
+        screen is BrowserScreen
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/IntegrationListener.kt
@@ -41,6 +41,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FIRST_PRIOR
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.screen.TitleScreen
 import org.lwjgl.glfw.GLFW
+import kotlin.math.min
 
 object IntegrationListener : EventListener {
 
@@ -224,18 +225,11 @@ object IntegrationListener : EventListener {
 
     @Suppress("unused")
     private val fpsLimitHandler = handler<FpsLimitEvent> { event ->
-        if (!browserSettings.syncGameFps) {
+        if (!browserSettings.syncGameFps || !isClientScreen(mc.currentScreen)) {
             return@handler
         }
 
-        if (isClientScreen(mc.currentScreen)) {
-            val rendererFps = browserSettings.currentFps
-
-            // Only lower FPS if the event FPS is higher than the renderer FPS.
-            if (event.fps > rendererFps) {
-                event.fps = rendererFps
-            }
-        }
+        event.fps = min(event.fps, browserSettings.currentFps)
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserSettings.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserSettings.kt
@@ -1,8 +1,8 @@
 package net.ccbluex.liquidbounce.integration.backend.browser
 
 import com.mojang.blaze3d.systems.RenderSystem
-import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.config.types.Value
+import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.integration.backend.BrowserBackendManager
 import net.ccbluex.liquidbounce.integration.backend.BrowserBackendManager.browserBackend
@@ -55,6 +55,8 @@ class BrowserSettings(
             update()
         }
     }
+
+    val syncGameFps by boolean("SyncGameFps", true)
 
     val currentFps: Int
         get() {


### PR DESCRIPTION
Added Sync Game Fps option to the browser renderer settings which sync the game FPS no matter in the game or in the menu, as soon as we use the browser rendering.

Reverts @MukjepScarlet https://github.com/CCBlueX/LiquidBounce/pull/6612