### PR TITLE
fix(InventoryCleaner): handle per-run execution correctly

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
@@ -38,7 +38,7 @@ import net.minecraft.screen.slot.SlotActionType
 object ModuleInventoryCleaner : ClientModule("InventoryCleaner", Category.PLAYER,
     aliases = arrayOf("InventoryManager")
 ) {
-  
+
     private val inventoryConstraints = tree(PlayerInventoryConstraints())
 
     private val maxBlocks by int("MaximumBlocks", 512, 0..2500)
@@ -114,49 +114,80 @@ object ModuleInventoryCleaner : ClientModule("InventoryCleaner", Category.PLAYER
 
     @Suppress("unused")
     private val handleInventorySchedule = handler<ScheduleInventoryActionEvent> { event ->
-        val cleanupPlan = CleanupPlanGenerator(cleanupTemplateFromSettings, findNonEmptySlotsInInventory())
+        val currentInventorySlots = findNonEmptySlotsInInventory()
+        val cleanupPlan = CleanupPlanGenerator(cleanupTemplateFromSettings, currentInventorySlots)
             .generatePlan()
 
-        // Step 1: Move items to the correct slots
-        for (hotbarSwap in cleanupPlan.swaps) {
-            check(hotbarSwap.to is HotbarItemSlot) { "Cannot swap to non-hotbar-slot" }
-
-            event.schedule(
-                inventoryConstraints,
-                ClickInventoryAction.performSwap(null, hotbarSwap.from, hotbarSwap.to)
-            )
-
-            // todo: run when successful or do not care?
-            cleanupPlan.remapSlots(
-                hashMapOf(
-                    Pair(hotbarSwap.from, hotbarSwap.to),
-                    Pair(hotbarSwap.to, hotbarSwap.from),
-                )
-            )
-        }
-
-        // Step 2: Merge stacks
-        val stacksToMerge = ItemMerge.findStacksToMerge(cleanupPlan)
-        for (slot in stacksToMerge) {
-            event.schedule(
-                inventoryConstraints,
-                ClickInventoryAction.click(null, slot, 0, SlotActionType.PICKUP),
-                ClickInventoryAction.click(null, slot, 0, SlotActionType.PICKUP_ALL),
-                ClickInventoryAction.click(null, slot, 0, SlotActionType.PICKUP),
-            )
-        }
-
-        // It is important that we call findItemSlotsInInventory() here again, because the inventory has changed.
-        val itemsToThrowOut = findItemsToThrowOut(cleanupPlan, findNonEmptySlotsInInventory())
-
-        for (slot in itemsToThrowOut) {
-            event.schedule(
-                inventoryConstraints,
-                ClickInventoryAction.performThrow(screen = null, slot),
-                Priority.NOT_IMPORTANT
-            )
+        // Process inventory actions in priority order
+        when {
+            // Step 1: Prioritize hotbar swaps
+            processHotbarSwaps(event, cleanupPlan) -> return@handler
+            // Step 2: Merge stackable items to optimize space
+            processStackMerging(event, cleanupPlan) -> return@handler
+            // Step 3: Remove unwanted items (lowest priority)
+            processItemDisposal(event, cleanupPlan, currentInventorySlots) -> return@handler
         }
     }
+
+    /**
+     * Handles swapping items to correct hotbar positions
+     * @return true if a swap was scheduled, false otherwise
+     */
+    private fun processHotbarSwaps(event: ScheduleInventoryActionEvent, cleanupPlan: InventoryCleanupPlan): Boolean {
+        val hotbarSwap = cleanupPlan.swaps.firstOrNull() ?: return false
+
+        require(hotbarSwap.to is HotbarItemSlot) {
+            "Invalid swap target: ${hotbarSwap.to}. Only hotbar slots are supported."
+        }
+
+        event.schedule(
+            inventoryConstraints,
+            ClickInventoryAction.performSwap(null, hotbarSwap.from, hotbarSwap.to)
+        )
+
+        return true
+    }
+
+    /**
+     * Handles merging stackable items to optimize inventory space
+     * @return true if a merge was scheduled, false otherwise
+     */
+    private fun processStackMerging(event: ScheduleInventoryActionEvent, cleanupPlan: InventoryCleanupPlan): Boolean {
+        val stacksToMerge = ItemMerge.findStacksToMerge(cleanupPlan)
+        val slotToMerge = stacksToMerge.firstOrNull() ?: return false
+
+        // pickup -> pickup all -> pickup to handle remaining items
+        event.schedule(
+            inventoryConstraints,
+            ClickInventoryAction.click(null, slotToMerge, 0, SlotActionType.PICKUP),
+            ClickInventoryAction.click(null, slotToMerge, 0, SlotActionType.PICKUP_ALL),
+            ClickInventoryAction.click(null, slotToMerge, 0, SlotActionType.PICKUP)
+        )
+
+        return true
+    }
+
+    /**
+     * Handles disposal of unwanted items
+     * @return true if an item was scheduled for disposal, false otherwise
+     */
+    private fun processItemDisposal(
+        event: ScheduleInventoryActionEvent,
+        cleanupPlan: InventoryCleanupPlan,
+        currentInventorySlots: List<ItemSlot>
+    ): Boolean {
+        val itemsToDispose = findItemsToThrowOut(cleanupPlan, currentInventorySlots)
+        val itemToThrow = itemsToDispose.firstOrNull() ?: return false
+
+        event.schedule(
+            inventoryConstraints,
+            ClickInventoryAction.performThrow(screen = null, itemToThrow),
+            Priority.NOT_IMPORTANT
+        )
+
+        return true
+    }
+
 
     fun findItemsToThrowOut(
         cleanupPlan: InventoryCleanupPlan,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/invcleaner/ModuleInventoryCleaner.kt
@@ -188,7 +188,6 @@ object ModuleInventoryCleaner : ClientModule("InventoryCleaner", Category.PLAYER
         return true
     }
 
-
     fun findItemsToThrowOut(
         cleanupPlan: InventoryCleanupPlan,
         itemsInInv: List<ItemSlot>,


### PR DESCRIPTION
Originally, InventoryCleaner was intended to process the entire cleanup plan in a single run. However, due to changes in the InventoryManager, it now only executes one action from the plan per event. The code left for on-the-fly slot remapping lead to incorrect item clicks and useful items being dropped.

Fixes https://github.com/CCBlueX/LiquidBounce/issues/6591