### PR TITLE
refactor(Font): improve get default font renderer

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.api.core.ApiConfig
 import net.ccbluex.liquidbounce.api.core.scope
 import net.ccbluex.liquidbounce.api.models.auth.ClientAccount
-import net.ccbluex.liquidbounce.api.services.client.ClientUpdate
 import net.ccbluex.liquidbounce.api.services.client.ClientUpdate.update
 import net.ccbluex.liquidbounce.api.thirdparty.IpInfoApi
 import net.ccbluex.liquidbounce.config.AutoConfig
@@ -69,12 +68,8 @@ import net.ccbluex.liquidbounce.script.ScriptManager
 import net.ccbluex.liquidbounce.utils.aiming.PostRotationExecutor
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.block.ChunkScanner
-import net.ccbluex.liquidbounce.utils.client.GitInfo
-import net.ccbluex.liquidbounce.utils.client.InteractionTracker
-import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
-import net.ccbluex.liquidbounce.utils.client.ServerObserver
+import net.ccbluex.liquidbounce.utils.client.*
 import net.ccbluex.liquidbounce.utils.client.error.ErrorHandler
-import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
 import net.ccbluex.liquidbounce.utils.entity.RenderedEntities
 import net.ccbluex.liquidbounce.utils.input.InputTracker
@@ -366,7 +361,7 @@ object LiquidBounce : EventListener {
             FontManager.createGlyphManager()
         }
         logger.info("Completed loading fonts in ${duration.inWholeMilliseconds} ms.")
-        logger.info("Fonts: [ ${FontManager.fontFaces.joinToString { face -> face.name }} ]")
+        logger.info("Fonts: [ ${FontManager.fontFaces.keys.joinToString()} ]")
 
         // Insert default components on HUD
         ComponentOverlay.insertDefaultComponents()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/NameProtectMappings.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/NameProtectMappings.kt
@@ -2,6 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.misc.nameprotect
 
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.client.randomUsername
+import net.ccbluex.liquidbounce.utils.kotlin.mapArray
 import org.ahocorasick.trie.Emit
 import org.ahocorasick.trie.Trie
 import java.nio.ByteBuffer
@@ -95,8 +96,9 @@ class NameProtectMappings {
         val currentInstructions = this.replacementInstructions ?: return emptyList()
 
         return currentInstructions.matcher.parseText(text)
-            .map { it to currentInstructions.replacements[it.keyword]!! }
-            .sortedBy { it.first.start }
+            .mapArray { it to currentInstructions.replacements[it.keyword]!! }
+            .apply { sortBy { it.first.start } }
+            .asList()
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/FontManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/FontManager.kt
@@ -29,6 +29,13 @@ import java.io.File
 
 object FontManager {
 
+    private val STYLES = intArrayOf(
+        Font.BOLD,
+        Font.BOLD,
+        Font.ITALIC,
+        Font.BOLD or Font.ITALIC
+    )
+
     /**
      * As fallback, we can use a common font that is available on all systems.
      */
@@ -60,9 +67,11 @@ object FontManager {
     /**
      * All font faces that are known to the font manager.
      */
-    internal val fontFaces = mutableSetOf(
-        COMMON_FONT
-    )
+    internal val fontFaces = HashMap<String, FontFace>(8).apply { put(COMMON_FONT.name, COMMON_FONT) }
+
+    private fun addFontFace(fontFace: FontFace) {
+        fontFaces[fontFace.name] = fontFace
+    }
 
     /**
      * The active font renderer that all text rendering will be based on.
@@ -90,12 +99,12 @@ object FontManager {
     /**
      * Returns the font by the given name.
      */
-    internal fun fontFace(name: String) = fontFaces.associateBy { fontFace -> fontFace.name }[name]
+    internal fun fontFace(name: String) = fontFaces[name]
 
     internal fun createGlyphManager() {
         glyphManager = FontGlyphPageManager(
-            baseFonts = fontFaces,
-            additionalFonts = setOf(CJK_FONT).filterNotNull().toSet()
+            baseFonts = fontFaces.values,
+            additionalFonts = setOfNotNull(CJK_FONT)
         )
     }
 
@@ -120,7 +129,7 @@ object FontManager {
                 return
             }
 
-            if (fontFaces.any { it.file == file }) {
+            if (fontFaces.values.any { it.file == file }) {
                 logger.warn("Font file ${file.absolutePath} is already loaded.")
                 return
             }
@@ -134,7 +143,7 @@ object FontManager {
             val fontFace = FontFace(font.name, DEFAULT_FONT_SIZE, file)
             // In this case, we have only one style available, which is the plain style.
             fontFace.fillStyle(font, 0)
-            fontFaces += fontFace
+            addFontFace(fontFace)
         } catch (e: Exception) {
             logger.warn("Failed to load font from file ${file.absolutePath}", e)
         }
@@ -143,15 +152,9 @@ object FontManager {
     private fun systemFont(name: String): FontFace {
         val fontFace = FontFace(name, DEFAULT_FONT_SIZE)
 
-        arrayOf(
-            Font.BOLD,
-            Font.BOLD,
-            Font.ITALIC,
-            Font.BOLD or Font.ITALIC
-        ).map { style ->
-            Font(name, style, DEFAULT_FONT_SIZE.toInt())
+        STYLES.forEachIndexed { index, style ->
+            val font = Font(name, style, DEFAULT_FONT_SIZE.toInt())
                 .deriveFont(DEFAULT_FONT_SIZE)
-        }.forEachIndexed { index, font ->
             fontFace.fillStyle(font, index)
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontGlyphPageManager.kt
@@ -14,8 +14,8 @@ import kotlin.math.ceil
 private val BASIC_CHARS = '\u0000'..'\u0200'
 
 class FontGlyphPageManager(
-    baseFonts: Set<FontManager.FontFace>,
-    additionalFonts: Set<FontManager.FontFace> = emptySet()
+    baseFonts: Collection<FontManager.FontFace>,
+    additionalFonts: Collection<FontManager.FontFace> = emptySet()
 ): EventListener {
 
     private val staticPage: List<StaticGlyphPage> = StaticGlyphPage.createGlyphPages(baseFonts.flatMap { loadedFont ->
@@ -23,11 +23,14 @@ class FontGlyphPageManager(
     })
     private val dynamicPage: DynamicGlyphPage = DynamicGlyphPage(
         Dimension(1024, 1024),
-        ceil(baseFonts.elementAt(0).styles[0]!!.height * 2.0F).toInt()
+        ceil(baseFonts.first().styles[0]!!.height * 2.0F).toInt()
     )
     private val dynamicFontManager: DynamicFontCacheManager = DynamicFontCacheManager(
         this.dynamicPage,
-        baseFonts + additionalFonts
+        HashSet<FontManager.FontFace>(baseFonts.size + staticPage.size).apply {
+            addAll(baseFonts)
+            addAll(additionalFonts)
+        }
     )
 
     private val availableFonts: Map<FontManager.FontFace, FontGlyphRegistry>
@@ -57,7 +60,7 @@ class FontGlyphPageManager(
     }
 
     private fun createGlyphRegistries(
-        baseFonts: Set<FontManager.FontFace>,
+        baseFonts: Collection<FontManager.FontFace>,
         glyphPages: List<StaticGlyphPage>
     ): Map<FontManager.FontFace, FontGlyphRegistry> = baseFonts.associateWith { loadedFont ->
         val array = Array(4) { Char2ObjectOpenHashMap<GlyphDescriptor>(512) }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
@@ -74,7 +74,7 @@ class FontRenderer(
     private val cache = FontRendererCache()
     override val height: Float = font.styles.firstNotNullOf { it?.height }
     val ascent: Float = font.styles.firstNotNullOf { it?.ascent }
-
+    private val positionCache = Vector3f()
 
     override fun begin() {
         if (this.cache.renderedGlyphs.isNotEmpty() || this.cache.lines.isNotEmpty()) {
@@ -105,13 +105,13 @@ class FontRenderer(
         if (shadow) {
             len = drawInternal(
                 text,
-                pos = Vector3f(x0 + 2.0f * scale, y0 + 2.0f * scale, z),
+                pos = positionCache.set(x0 + 2.0f * scale, y0 + 2.0f * scale, z),
                 scale,
                 overrideColor = Color4b(0, 0, 0, 150)
             )
         }
 
-        return max(len, drawInternal(text, Vector3f(x0, y0, z * 2.0F), scale))
+        return max(len, drawInternal(text, positionCache.set(x0, y0, z * 2.0F), scale))
     }
 
     /**
@@ -132,8 +132,9 @@ class FontRenderer(
             return pos.x
         }
 
-        val underlineStack = ArrayList<IntRange>(text.underlines.asReversed())
-        val strikethroughStack = ArrayList<IntRange>(text.strikeThroughs.asReversed())
+        // remove from front
+        val underlineStack = ArrayDeque(text.underlines)
+        val strikethroughStack = ArrayDeque(text.strikeThroughs)
 
         var x = pos.x
         var y = pos.y + this.ascent * scale
@@ -148,10 +149,10 @@ class FontRenderer(
                 ?: fallbackGlyph
             val color = overrideColor ?: processedChar.color
 
-            if (underlineStack.lastOrNull()?.start == charIdx) {
+            if (underlineStack.firstOrNull()?.start == charIdx) {
                 underlineStartX = x
             }
-            if (strikethroughStack.lastOrNull()?.start == charIdx) {
+            if (strikethroughStack.firstOrNull()?.start == charIdx) {
                 strikeThroughStartX = x
             }
 
@@ -181,13 +182,13 @@ class FontRenderer(
             x += layoutInfo.advanceX * scale
             y += layoutInfo.advanceY * scale
 
-            if (underlineStack.lastOrNull()?.endInclusive == charIdx) {
-                underlineStack.removeLast()
+            if (underlineStack.firstOrNull()?.endInclusive == charIdx) {
+                underlineStack.removeFirst()
 
                 drawLine(underlineStartX!!, x, y, pos.z, color, false)
             }
-            if (strikethroughStack.lastOrNull()?.endInclusive == charIdx) {
-                strikethroughStack.removeLast()
+            if (strikethroughStack.firstOrNull()?.endInclusive == charIdx) {
+                strikethroughStack.removeFirst()
 
                 drawLine(strikeThroughStartX!!, x, y, pos.z, color, true)
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
@@ -227,14 +227,8 @@ class DynamicFontCacheManager(
     }
 
     private fun findFontForGlyph(ch: GlyphIdentifier): FontManager.FontId? {
-        return this.availableFonts.firstNotNullOfOrNull {
-            val fontInStyle = it.styles.get(ch.font)
-
-            if (fontInStyle != null && fontInStyle.awtFont.canDisplay(ch.codepoint)) {
-                fontInStyle
-            } else {
-                null
-            }
+        return this.availableFonts.firstNotNullOfOrNull { fontFace ->
+            fontFace.styles[ch.font]?.takeIf { it.awtFont.canDisplay(ch.codepoint) }
         }
     }
 
@@ -253,6 +247,6 @@ private class CharCacheData(
     /**
      * Possible values: [UNCACHED], [CACHED] and [BLOCKED]
      */
-    var cacheState: AtomicInteger = AtomicInteger(UNCACHED),
+    val cacheState: AtomicInteger = AtomicInteger(UNCACHED),
     val lastUsage: AtomicLong = AtomicLong(0L)
 )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
@@ -134,19 +134,18 @@ class DynamicFontCacheManager(
 
         val allocationList = createAllocationRequests(requestedChars)
 
-        val unsuccessfullAllocations = this.glyphPageLock.withLock {
+        val unsuccessfulAllocations = this.glyphPageLock.withLock {
             tryAllocations(allocationList)
         }
 
-        if (unsuccessfullAllocations.isEmpty()) {
+        if (unsuccessfulAllocations.isEmpty()) {
             return
         }
 
-       freeSpace()
-
+        freeSpace()
 
         val stillUnsuccessfulAllocations =
-            createAllocationRequests(unsuccessfullAllocations.map { GlyphIdentifier(it.codepoint, it.font.style) })
+            createAllocationRequests(unsuccessfulAllocations.map { GlyphIdentifier(it.codepoint, it.font.style) })
 
         // TODO: Optimize the atlas in this situation
         // We weren't able to allocate those chars even after freeing some space. Don't ask us ever again about

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/dynamic/DynamicFontCacheManager.kt
@@ -19,7 +19,7 @@ class DynamicFontCacheManager(
     /**
      * Available fonts, sorted by priority
      */
-    private val availableFonts: Set<FontManager.FontFace>
+    private val availableFonts: Collection<FontManager.FontFace>
 ) {
     private val glyphPageLock = ReentrantLock()
     private val glyphPageDirtyFlag = AtomicBoolean(false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/LegacyTextSanitizer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/LegacyTextSanitizer.kt
@@ -1,7 +1,10 @@
 package net.ccbluex.liquidbounce.render.engine.font.processor
 
-import net.minecraft.text.*
+import net.minecraft.text.CharacterVisitor
+import net.minecraft.text.OrderedText
 import net.minecraft.text.StringVisitable.StyledVisitor
+import net.minecraft.text.Style
+import net.minecraft.text.Text
 import net.minecraft.util.Formatting
 import java.util.*
 
@@ -12,10 +15,10 @@ import java.util.*
  * @param innerVisitor the receiver of the degenerated text formatting.
  */
 class LegacyTextSanitizer(
-    private val innerVisitor: StyledVisitor<Unit>
-): StyledVisitor<Unit> {
+    private val innerVisitor: StyledVisitor<Nothing>
+): StyledVisitor<Nothing> {
 
-    override fun accept(style: Style, text: String): Optional<Unit> {
+    override fun accept(style: Style, text: String): Optional<Nothing> {
         var currentStyle = style
 
         var currentIndex = 0
@@ -69,12 +72,11 @@ class LegacyTextSanitizer(
 
     class SanitizedLegacyText(private val text: Text): OrderedText {
         override fun accept(visitor: CharacterVisitor): Boolean {
-            var idx = 0
-
             val degenerator = LegacyTextSanitizer { style, text ->
-                for (codePoint in text.chars()) {
-                    visitor.accept(idx, style, codePoint)
+                var idx = 0
 
+                text.chars().forEach { codePoint ->
+                    visitor.accept(idx, style, codePoint)
                     idx++
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/MinecraftTextProcessor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/MinecraftTextProcessor.kt
@@ -11,7 +11,7 @@ class MinecraftTextProcessor(
     val text: Text,
     val defaultColor: Color4b,
     obfuscationSeed: Long?
-) : TextProcessor(obfuscationSeed), StyledVisitor<Unit> {
+) : TextProcessor(obfuscationSeed), StyledVisitor<Nothing> {
     private val chars = ArrayList<ProcessedTextCharacter>()
     private val underlines = ArrayList<IntRange>()
     private val strikethroughs = ArrayList<IntRange>()
@@ -24,16 +24,17 @@ class MinecraftTextProcessor(
         return ProcessedText(chars, underlines, strikethroughs)
     }
 
-    override fun accept(style: Style, text: String): Optional<Unit> {
+    override fun accept(style: Style, text: String): Optional<Nothing> {
         val font = when {
             style.isBold && style.isItalic -> Font.BOLD or Font.ITALIC
             style.isBold -> Font.BOLD
             style.isItalic -> Font.ITALIC
             else -> Font.PLAIN
         }
-        val color = style.color?.rgb?.let { Color4b(it) } ?: defaultColor
+        val color = style.color?.let { Color4b(it.rgb) } ?: defaultColor
         val obfuscated = style.isObfuscated
 
+        this.chars.ensureCapacity(text.length)
         for (char in text.toCharArray()) {
             val actualChar = if (obfuscated) generateObfuscatedChar() else char
 


### PR DESCRIPTION
Explanation: 
The old by-name lookup creates a LinkedHashMap (via `associate`) on every call. Thus the module will creates hundreds of map every second. This PR make the map be pre-defined, so the modules can get it directly.