### PR TITLE
feat(AutoWeapon): sync item cooldown

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinPlayerEntity.java
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.event.events.PlayerEquipmentChangeEvent;
 import net.ccbluex.liquidbounce.event.events.PlayerSafeWalkEvent;
 import net.ccbluex.liquidbounce.event.events.PlayerStrideEvent;
 import net.ccbluex.liquidbounce.features.command.commands.ingame.fakeplayer.FakePlayer;
+import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon;
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleKeepSprint;
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.modes.CriticalsNoGround;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleAntiReducedDebugInfo;
@@ -213,6 +214,15 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity {
     @Inject(method = "equipStack", at = @At("HEAD"))
     private void hookPlayerEquipmentChange(EquipmentSlot slot, ItemStack stack, CallbackInfo ci) {
         EventManager.INSTANCE.callEvent(new PlayerEquipmentChangeEvent((PlayerEntity) (Object) this, slot, stack));
+    }
+
+    @ModifyExpressionValue(method = "getAttackCooldownProgressPerTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getAttributeValue(Lnet/minecraft/registry/entry/RegistryEntry;)D"))
+    private double hookAutoWeaponAttackSpeed(double original) {
+        if ((Object) this == MinecraftClient.getInstance().player && ModuleReach.INSTANCE.getRunning()) {
+            return original;
+        }
+
+        return ModuleAutoWeapon.INSTANCE.getAttackSpeed(original);
     }
 
     /*

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -29,10 +29,13 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon.
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemCategorization
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.WeaponItemFacet
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
+import net.ccbluex.liquidbounce.utils.client.convertToString
 import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.item.attackSpeed
 import net.ccbluex.liquidbounce.utils.item.isConsumable
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
@@ -194,6 +197,29 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", Category.COMBAT) {
             .maxOrNull()
 
         return bestSlot?.itemSlot as HotbarItemSlot?
+    }
+
+    /**
+     * Get the attack speed of the determined weapon, or
+     * return [original] if no weapon is selected
+     * or if [ChangeOnAction] does not contain [ChangeOnAction.ON_ATTACK].
+     *
+     * When we switch our item on the same tick as we attack,
+     * the cooldown progress is not updated.
+     */
+    fun getAttackSpeed(original: Double): Double {
+        debugParameter("Original Attack Speed") { original }
+
+        if (!running || ChangeOnAction.ON_ATTACK !in changeOnActions) {
+            return original
+        }
+
+        val itemStack = determineWeaponSlot(null)?.itemStack ?: return original
+        val itemAttackSpeed = itemStack.attackSpeed
+        debugParameter("Item") { itemStack.itemName.convertToString() }
+        debugParameter("Attack Speed") { itemAttackSpeed }
+
+        return itemAttackSpeed
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
@@ -160,13 +160,13 @@ fun ItemStack.getSharpnessDamage(level: Int = sharpnessLevel): Double =
         level * 1.25
     }
 
-val ItemStack.attackSpeed: Float
+val ItemStack.attackSpeed: Double
     get() = item.getAttributeValue(EntityAttributes.ATTACK_SPEED)
 
 val ItemStack.durability
     get() = this.maxDamage - this.damage
 
-private fun Item.getAttributeValue(attribute: RegistryEntry<EntityAttribute>): Float {
+private fun Item.getAttributeValue(attribute: RegistryEntry<EntityAttribute>): Double {
     val attribInstance = EntityAttributeInstance(attribute) {}
 
     this.components
@@ -179,7 +179,7 @@ private fun Item.getAttributeValue(attribute: RegistryEntry<EntityAttribute>): F
             attribInstance.addTemporaryModifier(modifier)
         }
 
-    return attribInstance.value.toFloat()
+    return attribInstance.value
 }
 
 fun RegistryKey<Enchantment>.toRegistryEntry(): RegistryEntry<Enchantment> {


### PR DESCRIPTION
When we switch our item on the same tick as we attack, the cooldown progress is not updated and we deal full damage.