### PR TITLE
feat(KillAura/Clicker/ItemCooldown): ignore when exiting range

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -48,7 +48,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
 
     object AttackButton : ToggleableConfigurable(this, "Attack", true) {
 
-        val clicker = tree(Clicker(this, mc.options.attackKey, true))
+        val clicker = tree(Clicker(this, mc.options.attackKey))
         internal val requiresNoInput by boolean("RequiresNoInput", false)
         private val objectiveType by enumChoice("Objective", ObjectiveType.ANY)
         private val onItemUse by enumChoice("OnItemUse", Use.WAIT)
@@ -145,7 +145,7 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
     }
 
     object UseButton : ToggleableConfigurable(this, "Use", false) {
-        val clicker = tree(Clicker(this, mc.options.useKey, false))
+        val clicker = tree(Clicker(this, mc.options.useKey, null))
         internal val delayStart by boolean("DelayStart", false)
         internal val onlyBlock by boolean("OnlyBlock", false)
         internal val requiresNoInput by boolean("RequiresNoInput", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoShoot.kt
@@ -66,7 +66,7 @@ object ModuleAutoShoot : ClientModule("AutoShoot", Category.COMBAT) {
     private val throwableType by enumChoice("ThrowableType", ThrowableType.EGG_AND_SNOWBALL)
     private val gravityType by enumChoice("GravityType", GravityType.AUTO).apply { tagBy(this) }
 
-    private val clicker = tree(Clicker(this, mc.options.useKey, showCooldown = false))
+    private val clicker = tree(Clicker(this, mc.options.useKey, itemCooldown = null))
 
     /**
      * The target tracker to find the best enemy to attack.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -23,19 +23,76 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAura
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.simulateInventoryClosing
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugGeometry
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
+import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
+import net.ccbluex.liquidbounce.utils.aiming.utils.canSeeBox
 import net.ccbluex.liquidbounce.utils.aiming.utils.withFixedYaw
 import net.ccbluex.liquidbounce.utils.clicking.Clicker
+import net.ccbluex.liquidbounce.utils.clicking.ItemCooldown
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.network
 import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.entity.PositionExtrapolation
+import net.ccbluex.liquidbounce.utils.entity.getBoundingBoxAt
 import net.ccbluex.liquidbounce.utils.entity.isBlockAction
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.inventory.openInventorySilently
 import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket.Full
+import kotlin.math.round
 
-object KillAuraClicker : Clicker<ModuleKillAura>(ModuleKillAura, mc.options.attackKey, true) {
+object KillAuraClicker : Clicker<ModuleKillAura>(
+    ModuleKillAura,
+    mc.options.attackKey,
+    KillAuraClickerItemCooldown()
+) {
+
+    class KillAuraClickerItemCooldown : ItemCooldown<ModuleKillAura>(ModuleKillAura) {
+        val ignoreWhenExitingRange by boolean("IgnoreWhenExitingRange", true)
+
+        override fun isCooldownPassed(ticks: Int): Boolean {
+            if (ignoreWhenExitingRange && predictExitingRange(1.0 + ticks.toDouble())) {
+                return true
+            }
+
+            return super.isCooldownPassed(ticks)
+        }
+
+        /**
+         * Predicts if we are going to move out of attack range.
+         */
+        fun predictExitingRange(ticks: Double): Boolean {
+            require(ticks > 0) { "ticks must be positive" }
+
+            val target = KillAuraTargetTracker.target ?: return false
+
+            val futurePos = PositionExtrapolation.getBestForEntity(player)
+                .getPositionInTicks(ticks)
+            val futureTargetPos = PositionExtrapolation.getBestForEntity(target)
+                .getPositionInTicks(ticks)
+
+            val ownEyePos = futurePos.add(0.0, player.getEyeHeight(player.pose).toDouble(), 0.0)
+            val targetBox = target.getBoundingBoxAt(futureTargetPos)
+
+            val isExitingRange = !canSeeBox(
+                eyes = ownEyePos,
+                box = targetBox,
+                // Do not care about scan range
+                range = ModuleKillAura.range.toDouble(),
+                wallsRange = ModuleKillAura.wallRange.toDouble()
+            )
+            debugParameter("Is Exiting Range On ${round(ticks)}") { isExitingRange }
+            if (isExitingRange) {
+                debugGeometry("Exiting") { ModuleDebug.DebuggedPoint(futurePos, Color4b.RED, 0.4) }
+            }
+
+            return isExitingRange
+        }
+
+    }
 
     /**
      * Prepare the environment for attacking an entity

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/ModuleTpAura.kt
@@ -43,7 +43,7 @@ object ModuleTpAura : ClientModule("TpAura", Category.COMBAT, disableOnQuit = tr
 
     private val attackRange by float("AttackRange", 4.2f, 3f..5f)
 
-    val clicker = tree(Clicker(this, mc.options.attackKey, true))
+    val clicker = tree(Clicker(this, mc.options.attackKey))
     val mode = choices("Mode", AStarMode, arrayOf(AStarMode, ImmediateMode))
     val targetSelector = tree(TargetSelector(TargetPriority.HURT_TIME))
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleProjectilePuncher.kt
@@ -48,7 +48,7 @@ import net.minecraft.entity.projectile.ShulkerBulletEntity
  */
 object ModuleProjectilePuncher : ClientModule("ProjectilePuncher", Category.WORLD, aliases = arrayOf("AntiFireball")) {
 
-    private val clicker = tree(Clicker(ModuleProjectilePuncher, mc.options.attackKey, false))
+    private val clicker = tree(Clicker(ModuleProjectilePuncher, mc.options.attackKey, null))
 
     private val swing by boolean("Swing", true)
     private val range by float("Range", 3f, 3f..6f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
@@ -204,7 +204,7 @@ object ModuleScaffold : ClientModule("Scaffold", Category.WORLD) {
 
     object SimulatePlacementAttempts : ToggleableConfigurable(this, "SimulatePlacementAttempts", false) {
 
-        internal val clicker = tree(Clicker(ModuleScaffold, mc.options.useKey, false, maxCps = 100))
+        internal val clicker = tree(Clicker(ModuleScaffold, mc.options.useKey, null, maxCps = 100))
         val failedAttemptsOnly by boolean("FailedAttemptsOnly", true)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -49,8 +49,7 @@ import java.util.*
 open class Clicker<T>(
     val parent: T,
     val keyBinding: KeyBinding,
-
-    showCooldown: Boolean,
+    val itemCooldown: ItemCooldown<T>? = ItemCooldown(parent),
     maxCps: Int = 60,
     name: String = "Clicker"
 ) : Configurable(name, aliases = arrayOf("ClickScheduler")), EventListener where T : EventListener {
@@ -74,10 +73,8 @@ open class Clicker<T>(
             fill()
         }
 
-    private val itemCooldown: ItemCooldown<T>? = if (showCooldown) {
-        tree(ItemCooldown(parent))
-    } else {
-        null
+    init {
+        itemCooldown?.let(this::tree)
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -23,8 +23,12 @@ import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.utils.kotlin.random
 
-class ItemCooldown<T>(module: T) : ToggleableConfigurable(module, "ItemCooldown", true, aliases = arrayOf("Cooldown"))
-    where T : EventListener {
+open class ItemCooldown<T>(module: T) : ToggleableConfigurable(
+    module,
+    "ItemCooldown",
+    true,
+    aliases = arrayOf("Cooldown")
+) where T : EventListener {
 
     private val minimumCooldown by floatRange(
         "Minimum",
@@ -36,7 +40,7 @@ class ItemCooldown<T>(module: T) : ToggleableConfigurable(module, "ItemCooldown"
 
     private var nextCooldown = minimumCooldown.random()
 
-    fun isCooldownPassed(ticks: Int = 0): Boolean {
+    open fun isCooldownPassed(ticks: Int = 0): Boolean {
         if (!this.enabled) {
             return true
         }


### PR DESCRIPTION
This allows the KillAura to attack the target as it goes out of range, preventing us from losing attack damage.