### PR TITLE
feat(Clicker/ItemCooldown): server cooldown detection

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debug
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.client.convertToString
 import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
+import net.ccbluex.liquidbounce.utils.entity.hasCooldown
 import net.ccbluex.liquidbounce.utils.entity.wouldBlockHit
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.Slots
@@ -210,7 +211,7 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", Category.COMBAT) {
     fun getAttackSpeed(original: Double): Double {
         debugParameter("Original Attack Speed") { original }
 
-        if (!running || ChangeOnAction.ON_ATTACK !in changeOnActions) {
+        if (!running || ChangeOnAction.ON_ATTACK !in changeOnActions || !player.hasCooldown) {
             return original
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -52,7 +52,7 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
     KillAuraClickerItemCooldown()
 ) {
 
-    class KillAuraClickerItemCooldown : ItemCooldown<ModuleKillAura>(ModuleKillAura) {
+    class KillAuraClickerItemCooldown : ItemCooldown() {
 
         private val ignoreOnShieldBreak by boolean("IgnoreOnShieldBreak", true)
         private val ignoreOnMaceSmash by boolean("IgnoreOnMaceSmash", true)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -29,6 +29,8 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debug
 import net.ccbluex.liquidbounce.utils.clicking.pattern.ClickPattern
 import net.ccbluex.liquidbounce.utils.clicking.pattern.patterns.*
 import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.entity.hasCooldown
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.minecraft.client.option.KeyBinding
 import java.util.*
@@ -49,7 +51,7 @@ import java.util.*
 open class Clicker<T>(
     val parent: T,
     val keyBinding: KeyBinding,
-    val itemCooldown: ItemCooldown<T>? = ItemCooldown(parent),
+    val itemCooldown: ItemCooldown? = ItemCooldown(),
     maxCps: Int = 60,
     name: String = "Clicker"
 ) : Configurable(name, aliases = arrayOf("ClickScheduler")), EventListener where T : EventListener {
@@ -123,27 +125,17 @@ open class Clicker<T>(
         if (isEnforcedClick()) {
             return 1
         }
-
-        if (itemCooldown?.isCooldownPassed(tick) == false) {
-            return 0
-        }
-
         return clickArray.get(tick)
     }
 
     private fun isEnforcedClick(tick: Int = 0): Boolean {
-        // Check if our last click is over 1000ms ago,
-        if (lastClickPassed + (tick * 50L) >= 1000L) {
+        val hasCooldown = player.hasCooldown
+        debugParameter("HasCooldown") { hasCooldown }
+        if (hasCooldown && itemCooldown?.isCooldownPassed(tick) == true) {
             return true
         }
 
-        // Our cooldown is over, we want to click now!
-        if (itemCooldown?.enabled == true && itemCooldown.isCooldownPassed(tick)) {
-            return true
-        }
-
-        // Otherwise, follow our pattern
-        return false
+        return lastClickPassed + (tick * 50L) >= 1000L
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -18,16 +18,11 @@
  */
 package net.ccbluex.liquidbounce.utils.clicking
 
-import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.EventListener
+import net.ccbluex.liquidbounce.config.types.nesting.Configurable
+import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.kotlin.random
 
-open class ItemCooldown<T>(module: T) : ToggleableConfigurable(
-    module,
-    "ItemCooldown",
-    true,
-    aliases = arrayOf("Cooldown")
-) where T : EventListener {
+open class ItemCooldown : Configurable("ItemCooldown", aliases = arrayOf("Cooldown")) {
 
     private val minimumCooldown by floatRange(
         "Minimum",
@@ -36,10 +31,7 @@ open class ItemCooldown<T>(module: T) : ToggleableConfigurable(
 
     private var nextCooldown = minimumCooldown.random()
 
-    open fun isCooldownPassed(ticks: Int = 0) = when {
-        !this.enabled -> true
-        else -> cooldownProgress(ticks) >= nextCooldown
-    }
+    open fun isCooldownPassed(ticks: Int = 0) = cooldownProgress(ticks) >= nextCooldown
 
     /**
      * Calculates the current cooldown progress.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -41,6 +41,7 @@ import net.minecraft.entity.Entity
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.TntEntity
+import net.minecraft.entity.attribute.EntityAttributes
 import net.minecraft.entity.damage.DamageSource
 import net.minecraft.entity.decoration.EndCrystalEntity
 import net.minecraft.entity.effect.StatusEffects
@@ -99,6 +100,12 @@ val ClientPlayerEntity.onGroundTicks: Int
 
 val ClientPlayerEntity.direction: Float
     get() = getMovementDirectionOfInput(DirectionalInput(input))
+
+/**
+ * Check if the attack speed is below 1 tick. If so, we have a cooldown.
+ */
+val ClientPlayerEntity.hasCooldown: Boolean
+    get() = !isOlderThanOrEqual1_8 && this.getAttributeValue(EntityAttributes.ATTACK_SPEED) < 20.0
 
 fun ClientPlayerEntity.getMovementDirectionOfInput(input: DirectionalInput): Float {
     return getMovementDirectionOfInput(this.yaw, input)


### PR DESCRIPTION
Works with ViaVersion, Player Attribute Modification and Item Attribute Modification. Tested on 1.21.4 and 1.12.2 protocol.

Example:
- `/attribute @p minecraft:attack_speed base set 23`
- `/give @p diamond_sword[attribute_modifiers={modifiers:[{type:"attack_speed",amount:20,operation:"add_value",slot:"mainhand",id:"attack_speed_boost"}]}]`