### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /mcef/
 /logs/
 /.kotlin/
+.DS_Store


### PR DESCRIPTION
.DS_Store is a macOS temporary file that stores folder information (like the layout of the folder)

it is customary to have in .gitignore as it is meaningless in programming contexts

https://en.wikipedia.org/wiki/.DS_Store