### PR TITLE
feat(env): skip browser

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/BrowserBackendManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/BrowserBackendManager.kt
@@ -24,8 +24,8 @@ import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.BrowserReadyEvent
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.handler
-import net.ccbluex.liquidbounce.integration.backend.browser.GlobalBrowserSettings
 import net.ccbluex.liquidbounce.integration.backend.backends.cef.CefBrowserBackend
+import net.ccbluex.liquidbounce.integration.backend.browser.GlobalBrowserSettings
 import net.ccbluex.liquidbounce.integration.interop.persistant.PersistentLocalStorage
 import net.ccbluex.liquidbounce.integration.task.TaskManager
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -34,6 +34,9 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FIRST_PRIOR
 object BrowserBackendManager : EventListener {
 
     val browserBackend: BrowserBackend = CefBrowserBackend()
+
+    val isSkippingBrowser = System.getenv("SKIP_BROWSER") == "true"
+        || System.getProperty("net.ccbluex.liquidbounce.skip.browser") == "true"
 
     init {
         PersistentLocalStorage
@@ -44,6 +47,10 @@ object BrowserBackendManager : EventListener {
      * when the dependencies are available.
      */
     fun makeDependenciesAvailable(taskManager: TaskManager) {
+        if (isSkippingBrowser) {
+            logger.warn("Environment variable 'SKIP_BROWSER' is set to 'true'.")
+            return
+        }
         browserBackend.makeDependenciesAvailable(taskManager, ::start)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/task/TaskProgressScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/task/TaskProgressScreen.kt
@@ -160,7 +160,8 @@ class TaskProgressScreen(
     }
 
     override fun tick() {
-        if (taskManager.isCompleted && BrowserBackendManager.browserBackend?.isInitialized == true) {
+        if (taskManager.isCompleted && (BrowserBackendManager.browserBackend.isInitialized ||
+                BrowserBackendManager.isSkippingBrowser)) {
             mc.setScreen(TitleScreen())
         }
     }


### PR DESCRIPTION
Allows launching without browser backend. Useful for using bare interop without integrated UI.