### PR TITLE
refactor(API): cancellable async request

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ val includeModDependency: Configuration by configurations.creating
  */
 fun Configuration.excludeProvidedLibs() = apply {
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
 
     exclude(group = "com.google.code.gson", module = "gson")
     exclude(group = "net.java.dev.jna", module = "jna")
@@ -179,6 +180,7 @@ dependencies {
 
     // HTTP library
     includeDependency("com.squareup.okhttp3:okhttp:5.1.0")
+    includeDependency("com.squareup.okhttp3:okhttp-coroutines:5.1.0")
 
     // SOCKS5 & HTTP Proxy Support
     includeDependency("io.netty:netty-handler-proxy:4.1.115.Final")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
@@ -32,6 +32,7 @@ import net.minecraft.util.Util
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
 import okio.BufferedSource
 import okio.sink
 import java.io.File
@@ -106,7 +107,7 @@ object HttpClient {
         headers: Headers.Builder.() -> Unit = {},
         body: RequestBody? = null,
         progressListener: OkHttpProgressInterceptor.ProgressListener? = null
-    ): Response = withContext(Dispatchers.IO) {
+    ): Response {
         val request = Request.Builder()
             .url(url)
             .method(method.name, body)
@@ -114,13 +115,13 @@ object HttpClient {
             .header("User-Agent", agent)
             .build()
 
-        if (progressListener == null) {
-            client.newCall(request).execute()
+        return if (progressListener == null) {
+            client.newCall(request).executeAsync()
         } else {
             client.newBuilder()
                 .addNetworkInterceptor(OkHttpProgressInterceptor(progressListener))
                 .build()
-                .newCall(request).execute()
+                .newCall(request).executeAsync()
         }
     }
 


### PR DESCRIPTION
The old one doesn't aware of job cancellation. Now it does.

New dependency: okhttp-coroutines (include jar 8KB)