### PR TITLE
chore: render thread execution

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/listener/OverlayTrainingListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/listener/OverlayTrainingListener.kt
@@ -23,7 +23,6 @@ package net.ccbluex.liquidbounce.deeplearn.listener
 import ai.djl.training.Trainer
 import ai.djl.training.listener.TrainingListener
 import ai.djl.training.listener.TrainingListenerAdapter
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.utils.client.asText
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.regular
@@ -76,7 +75,7 @@ class OverlayTrainingListener(
             .append("░".repeat(25 - progress / 4).asText().formatted(Formatting.DARK_GRAY))
             .append("]".asText().formatted(Formatting.GRAY))
 
-        RenderSystem.recordRenderCall {
+        mc.execute {
             mc.inGameHud.setOverlayMessage(progressBar, false)
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/client/CommandClientBrowserSubcommand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/client/CommandClientBrowserSubcommand.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.client.client
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
 import net.ccbluex.liquidbounce.integration.BrowserScreen
@@ -39,7 +38,7 @@ object CommandClientBrowserSubcommand {
                 .build()
         ).handler {
             chat(regular("Opening browser..."))
-            RenderSystem.recordRenderCall {
+            mc.execute {
                 mc.setScreen(BrowserScreen(args[0] as String))
             }
         }.build()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/module/CommandInvsee.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/module/CommandInvsee.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.module
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandException
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
@@ -60,7 +59,7 @@ object CommandInvsee : Command.Factory {
                     throw CommandException(command.result("playerNotFound", inputName))
                 }
 
-                RenderSystem.recordRenderCall {
+                mc.execute {
                     mc.setScreen(ViewedInventoryScreen(player))
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/misc/HideAppearance.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.misc
 
-import com.mojang.blaze3d.systems.RenderSystem
 import com.terraformersmc.modmenu.util.mod.Mod
 import kotlinx.coroutines.cancel
 import net.ccbluex.liquidbounce.api.core.scope
@@ -30,6 +29,7 @@ import net.ccbluex.liquidbounce.event.events.ClientShutdownEvent
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.command.CommandManager
+import net.ccbluex.liquidbounce.features.misc.HideAppearance.isHidingNow
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -73,7 +73,7 @@ object HideAppearance : EventListener {
     var isHidingNow = false
         set(value) {
             field = value
-            RenderSystem.recordRenderCall(::updateClient)
+            mc.execute(::updateClient)
 
             if (modMenuPresent) {
                 if (value) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTeleport.kt
@@ -1,6 +1,5 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -52,7 +51,7 @@ object ModuleTeleport : ClientModule("Teleport", Category.EXPLOIT, aliases = arr
             chat(warning(message("useCommand")))
 
             // Disables module on next render tick
-            RenderSystem.recordRenderCall {
+            mc.execute {
                 this.enabled = false
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.*
@@ -58,7 +57,7 @@ object ModuleClickGui :
 
     @Suppress("UnusedPrivateProperty")
     private val cache by boolean("Cache", true).onChanged { cache ->
-        RenderSystem.recordRenderCall {
+        mc.execute {
             if (cache) {
                 open()
             } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleXRay.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.features.command.commands.module.CommandXRay
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -220,7 +219,7 @@ object ModuleXRay : ClientModule("XRay", Category.RENDER) {
 
     @Suppress("UNUSED_PARAMETER")
     fun valueChangedReload(it: Any) {
-        RenderSystem.recordRenderCall {
+        mc.execute {
             // Reload world renderer on block list change
             mc.worldRenderer.reload()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
@@ -21,8 +21,7 @@
 
 package net.ccbluex.liquidbounce.integration
 
-import com.mojang.blaze3d.systems.RenderCall
-import com.mojang.blaze3d.systems.RenderSystem
+import com.google.common.base.Predicates
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.openVfpProtocolSelection
 import net.minecraft.client.gui.screen.DisconnectedScreen
@@ -50,9 +49,9 @@ private val Screen.isLunar
 
 enum class VirtualScreenType(
     val routeName: String,
-    private val recognizer: Predicate<Screen> = Predicate { false },
+    private val recognizer: Predicate<Screen> = Predicates.alwaysFalse(),
     val isInGame: Boolean = false,
-    private val open: RenderCall = RenderCall {
+    private val open: Runnable = Runnable {
         mc.setScreen(VirtualDisplayScreen(byName(routeName)!!))
     }
 ) {
@@ -130,7 +129,7 @@ enum class VirtualScreenType(
         recognizer = { it is BrowserScreen }
     );
 
-    fun open() = RenderSystem.recordRenderCall(open)
+    fun open() = mc.execute(open)
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/BrowserBackendManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/BrowserBackendManager.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.integration.backend.browser.GlobalBrowserSetting
 import net.ccbluex.liquidbounce.integration.interop.persistant.PersistentLocalStorage
 import net.ccbluex.liquidbounce.integration.task.TaskManager
 import net.ccbluex.liquidbounce.utils.client.logger
+import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FIRST_PRIORITY
 
 object BrowserBackendManager : EventListener {
@@ -85,7 +86,7 @@ object BrowserBackendManager : EventListener {
     /**
      * Causes an update of every browser by re-setting their viewport.
      */
-    fun forceUpdate() = RenderSystem.recordRenderCall {
+    fun forceUpdate() = mc.execute {
         for (browser in browserBackend.browsers) {
             try {
                 browser.viewport = browser.viewport

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowserBackend.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowserBackend.kt
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.utils.client.error.QuickFix
 import net.ccbluex.liquidbounce.utils.client.error.errors.JcefIsntCompatible
 import net.ccbluex.liquidbounce.utils.client.formatAsCapacity
 import net.ccbluex.liquidbounce.utils.client.logger
+import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.kotlin.sortedInsert
 import net.ccbluex.liquidbounce.utils.validation.HashValidator
 import net.minecraft.util.Util
@@ -97,7 +98,7 @@ class CefBrowserBackend : BrowserBackend, EventListener {
 
                     runCatching {
                         resourceManager.downloadJcef()
-                        RenderSystem.recordRenderCall(whenAvailable)
+                        mc.execute(whenAvailable)
                     }.onFailure {
                         ErrorHandler.fatal(
                             error = it,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserSettings.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserSettings.kt
@@ -1,6 +1,5 @@
 package net.ccbluex.liquidbounce.integration.backend.browser
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.integration.IntegrationListener
@@ -32,7 +31,7 @@ object GlobalBrowserSettings : Configurable("GlobalRenderer") {
     init {
         if (browserBackend.isAccelerationSupported) {
             accelerated = boolean("Accelerated(BETA)", false).onChanged {
-                RenderSystem.recordRenderCall {
+                mc.execute {
                     IntegrationListener.restart()
                     mc.updateWindowTitle()
                 }
@@ -51,7 +50,7 @@ open class BrowserSettings(
      * The maximum frames per second the browser renderer should run at.
      */
     val fps = int("Fps", fpsLimit, 0..max(0, refreshRate), "FPS").onChanged {
-        RenderSystem.recordRenderCall {
+        mc.execute {
             update()
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/AccountFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/AccountFunctions.kt
@@ -4,7 +4,6 @@ package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.api.core.formatAvatarUrl
 import net.ccbluex.liquidbounce.config.gson.interopGson
@@ -53,7 +52,7 @@ fun postNewMicrosoftAccount(requestObject: RequestObject): FullHttpResponse {
 @Suppress("UNUSED_PARAMETER")
 fun postClipboardMicrosoftAccount(requestObject: RequestObject): FullHttpResponse {
     AccountManager.newMicrosoftAccount {
-        RenderSystem.recordRenderCall {
+        mc.execute {
             GLFW.glfwSetClipboardString(mc.window.handle, it)
             EventManager.callEvent(AccountManagerMessageEvent("Copied login url to clipboard"))
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import io.netty.handler.codec.http.HttpMethod
 import net.ccbluex.liquidbounce.config.AutoConfig
@@ -32,6 +31,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.ModuleManager.modulesConfigurable
 import net.ccbluex.liquidbounce.utils.client.logger
+import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.netty.http.model.RequestObject
 import net.ccbluex.netty.http.util.httpForbidden
 import net.ccbluex.netty.http.util.httpNoContent
@@ -86,7 +86,7 @@ fun putSettings(requestObject: RequestObject): FullHttpResponse {
 // POST /api/v1/client/modules/panic
 @Suppress("UNUSED_PARAMETER")
 fun postPanic(requestObject: RequestObject): FullHttpResponse {
-    RenderSystem.recordRenderCall {
+    mc.execute {
         AutoConfig.withLoading {
             runCatching {
                 for (module in ModuleManager) {
@@ -117,7 +117,7 @@ data class ModuleRequest(val name: String) {
             return httpForbidden("$name already ${if (supposedNew) "enabled" else "disabled"}")
         }
 
-        RenderSystem.recordRenderCall {
+        mc.execute {
             runCatching {
                 module.enabled = supposedNew
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ProxyFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ProxyFunctions.kt
@@ -23,7 +23,6 @@
 package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client
 
 import com.google.gson.JsonArray
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.gson.interopGson
@@ -112,28 +111,26 @@ fun postAddProxy(requestObject: RequestObject): FullHttpResponse {
 // POST /api/v1/client/proxies/add/clipboard
 @Suppress("UNUSED_PARAMETER")
 fun postClipboardProxy(requestObject: RequestObject): FullHttpResponse {
-    RenderSystem.recordRenderCall {
-        RenderSystem.recordRenderCall {
-            try {
-                val clipboardText = GLFW.glfwGetClipboardString(mc.window.handle)
-                if (clipboardText.isNullOrBlank()) {
-                    return@recordRenderCall
-                }
-
-                val proxy = try {
-                    Proxy.parse(clipboardText.trim())
-                } catch (e: Exception) {
-                    throw IllegalArgumentException(
-                        "Invalid proxy format. Expected format: host:port:username:password or host:port",
-                        e
-                    )
-                }
-
-                ProxyManager.validateProxy(proxy)
-            } catch (e: Exception) {
-                logger.error("Failed to add proxy from clipboard.", e)
-                EventManager.callEvent(ProxyCheckResultEvent(null, error = e.message ?: "Unknown error"))
+    mc.execute {
+        try {
+            val clipboardText = GLFW.glfwGetClipboardString(mc.window.handle)
+            if (clipboardText.isNullOrBlank()) {
+                return@execute
             }
+
+            val proxy = try {
+                Proxy.parse(clipboardText.trim())
+            } catch (e: Exception) {
+                throw IllegalArgumentException(
+                    "Invalid proxy format. Expected format: host:port:username:password or host:port",
+                    e
+                )
+            }
+
+            ProxyManager.validateProxy(proxy)
+        } catch (e: Exception) {
+            logger.error("Failed to add proxy from clipboard.", e)
+            EventManager.callEvent(ProxyCheckResultEvent(null, error = e.message ?: "Unknown error"))
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
@@ -22,7 +22,6 @@
 package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.client
 
 import com.google.gson.JsonObject
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.integration.IntegrationListener
 import net.ccbluex.liquidbounce.integration.VirtualDisplayScreen
@@ -95,13 +94,13 @@ fun deleteScreen(requestObject: RequestObject): FullHttpResponse {
     val screen = mc.currentScreen ?: return httpForbidden("No screen")
 
     if (screen is VirtualDisplayScreen && screen.parentScreen != null) {
-        RenderSystem.recordRenderCall {
+        mc.execute {
             mc.setScreen(screen.parentScreen)
         }
         return httpNoContent()
     }
 
-    RenderSystem.recordRenderCall {
+    mc.execute {
         mc.setScreen(
             if (inGame) {
                 null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/ServerListFunctions.kt
@@ -22,7 +22,6 @@
 package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game
 
 import com.google.gson.JsonArray
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.config.gson.interopGson
 import net.ccbluex.liquidbounce.config.gson.serializer.minecraft.ResourcePolicy
@@ -90,7 +89,7 @@ fun postConnect(requestObject: RequestObject): FullHttpResponse {
 
     val serverAddress = ServerAddress.parse(serverInfo.address)
 
-    RenderSystem.recordRenderCall {
+    mc.execute {
         ConnectScreen.connect(MultiplayerScreen(TitleScreen()), mc, serverAddress, serverInfo, false, null)
     }
     return httpNoContent()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/WorldListFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/WorldListFunctions.kt
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import com.mojang.blaze3d.systems.RenderSystem
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -86,7 +85,7 @@ fun getWorlds(requestObject: RequestObject): FullHttpResponse {
 fun postJoinWorld(requestObject: RequestObject): FullHttpResponse {
     val request = requestObject.asJson<LevelRequest>()
 
-    RenderSystem.recordRenderCall {
+    mc.execute {
         runCatching {
             mc.createIntegratedServerLoader().start(request.name) {
                 mc.setScreen(SelectWorldScreen(TitleScreen()))
@@ -104,7 +103,7 @@ fun postJoinWorld(requestObject: RequestObject): FullHttpResponse {
 fun postEditWorld(requestObject: RequestObject): FullHttpResponse {
     val request = requestObject.asJson<LevelRequest>()
 
-    RenderSystem.recordRenderCall {
+    mc.execute {
         val session = runCatching {
             mc.levelStorage.createSession(request.name)
         }.onFailure { exception ->
@@ -121,7 +120,7 @@ fun postEditWorld(requestObject: RequestObject): FullHttpResponse {
                     logger.error("Failed to access level ${request.name}", exception)
                 }
             }
-        }.getOrNull() ?: return@recordRenderCall
+        }.getOrNull() ?: return@execute
 
         runCatching {
             EditWorldScreen.create(mc, session) { _ ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
@@ -19,7 +19,6 @@
  */
 package net.ccbluex.liquidbounce.integration.theme
 
-import com.mojang.blaze3d.systems.RenderSystem
 import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.api.models.marketplace.MarketplaceItemType
@@ -49,7 +48,7 @@ object ThemeManager : Configurable("theme") {
 
     var currentTheme by text("Theme", "liquidbounce").onChanged {
         // Update integration browser
-        RenderSystem.recordRenderCall {
+        mc.execute {
             IntegrationListener.update()
             ModuleHud.reopen()
             ModuleClickGui.reload(true)
@@ -68,7 +67,7 @@ object ThemeManager : Configurable("theme") {
     var shaderEnabled by boolean("Shader", false)
         .onChange { enabled ->
             if (enabled) {
-                RenderSystem.recordRenderCall {
+                mc.execute {
                     runBlocking {
                         theme.compileShader()
                         includedTheme.compileShader()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/ScriptManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/ScriptManager.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.script
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.api.models.marketplace.MarketplaceItemType
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.features.marketplace.MarketplaceManager
@@ -26,6 +25,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleClickGui
 import net.ccbluex.liquidbounce.script.bindings.api.ScriptAsyncUtil
 import net.ccbluex.liquidbounce.script.bindings.api.ScriptContextProvider
 import net.ccbluex.liquidbounce.utils.client.logger
+import net.ccbluex.liquidbounce.utils.client.mc
 import org.graalvm.polyglot.Engine
 import org.graalvm.polyglot.Source
 import java.io.File
@@ -165,7 +165,7 @@ object ScriptManager {
 
         if (scripts.isNotEmpty()) {
             // Reload the ClickGUI to update the module list.
-            RenderSystem.recordRenderCall(ModuleClickGui::reload)
+            mc.execute(ModuleClickGui::reload)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ProtocolUtil.kt
@@ -20,7 +20,6 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import com.mojang.blaze3d.systems.RenderSystem
 import com.viaversion.viafabricplus.ViaFabricPlus
 import net.ccbluex.liquidbounce.utils.client.vfp.VfpCompatibility
 import net.ccbluex.liquidbounce.utils.client.vfp.VfpCompatibility1_8
@@ -34,7 +33,7 @@ val usesViaFabricPlus = runCatching {
     // Register ViaFabricPlus protocol version change callback
     ViaFabricPlus.getImpl().registerOnChangeProtocolVersionCallback { _, _ ->
         // Update the window title
-        RenderSystem.recordRenderCall {
+        mc.execute {
             mc.updateWindowTitle()
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ServerObserver.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/ServerObserver.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.utils.client
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.api.thirdparty.IpInfoApi
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.EventListener
@@ -127,7 +126,7 @@ object ServerObserver : EventListener {
         val serverInfo = serverInfo ?: error("no known last server")
         val serverAddress = ServerAddress.parse(serverInfo.address)
 
-        RenderSystem.recordRenderCall {
+        mc.execute {
             ConnectScreen.connect(
                 MultiplayerScreen(TitleScreen()),
                 mc,


### PR DESCRIPTION
`RenderSystem.recordRenderCall` is going to be removed in 1.21.5. To execute task on render thread, use `mc.execute` as `MinecraftClient` is an implementation of `Executor`.