### PR TITLE
fix(BreakBlock): sequenced packet

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
@@ -61,17 +61,22 @@ object InstantNukerMode : Choice("Instant") {
         }
 
         for ((pos, _) in targets) {
-            network.sendPacket(
-                PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, pos, Direction.DOWN)
-            )
+            interaction.sendSequencedPacket(world) { sequence ->
+                PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, pos, Direction.DOWN, sequence)
+            }
 
             swingMode.swing(Hand.MAIN_HAND)
             wasTarget = pos
 
             if (!doNotStop) {
-                network.sendPacket(
-                    PlayerActionC2SPacket(PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, pos, Direction.DOWN)
-                )
+                interaction.sendSequencedPacket(world) { sequence ->
+                    PlayerActionC2SPacket(
+                        PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
+                        pos,
+                        Direction.DOWN,
+                        sequence
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/CivMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/CivMineMode.kt
@@ -42,11 +42,14 @@ object CivMineMode : MineMode("Civ", stopOnStateChange = false) {
 
     override fun onCannotLookAtTarget(mineTarget: MineTarget) {
         // send always a packet to keep the target
-        network.sendPacket(PlayerActionC2SPacket(
-            PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
-            mineTarget.targetPos,
-            Direction.DOWN
-        ))
+        interaction.sendSequencedPacket(world) { sequence ->
+            PlayerActionC2SPacket(
+                PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
+                mineTarget.targetPos,
+                Direction.DOWN,
+                sequence
+            )
+        }
     }
 
     override fun shouldTarget(blockPos: BlockPos, state: BlockState): Boolean {
@@ -58,13 +61,14 @@ object CivMineMode : MineMode("Civ", stopOnStateChange = false) {
     }
 
     override fun finish(mineTarget: MineTarget) {
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
                 PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
                 mineTarget.targetPos,
-                mineTarget.direction
+                mineTarget.direction,
+                sequence,
             )
-        )
+        }
 
         ModulePacketMine.swingMode.swing(Hand.MAIN_HAND)
 
@@ -94,13 +98,14 @@ object CivMineMode : MineMode("Civ", stopOnStateChange = false) {
 
         // Alright, for some reason when we spam STOP_DESTROY_BLOCK
         // server accepts us to destroy the same block instantly over and over.
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
                 PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
                 mineTarget.targetPos,
-                mineTarget.direction
+                mineTarget.direction,
+                sequence,
             )
-        )
+        }
 
         if (shouldSwitch) {
             network.sendPacket(UpdateSelectedSlotC2SPacket(oldSlot))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/ImmediateMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/ImmediateMineMode.kt
@@ -31,13 +31,14 @@ object ImmediateMineMode : MineMode("Immediate", canManuallyChange = false, canA
 
     override fun start(mineTarget: MineTarget) {
         NormalMineMode.start(mineTarget)
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
                 PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
                 mineTarget.targetPos,
-                mineTarget.direction
+                mineTarget.direction,
+                sequence,
             )
-        )
+        }
         ModulePacketMine.swingMode.swing(Hand.MAIN_HAND)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/NormalMineMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/packetmine/mode/NormalMineMode.kt
@@ -34,25 +34,27 @@ object NormalMineMode : MineMode("Normal") {
 
     override fun start(mineTarget: MineTarget) {
         EventManager.callEvent(BlockBreakingProgressEvent(mineTarget.targetPos))
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
                 PlayerActionC2SPacket.Action.START_DESTROY_BLOCK,
                 mineTarget.targetPos,
-                mineTarget.direction
+                mineTarget.direction,
+                sequence,
             )
-        )
+        }
 
         ModulePacketMine.swingMode.swing(Hand.MAIN_HAND)
     }
 
     override fun finish(mineTarget: MineTarget) {
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
                 PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK,
                 mineTarget.targetPos,
-                mineTarget.direction
+                mineTarget.direction,
+                sequence,
             )
-        )
+        }
 
         ModulePacketMine.swingMode.swing(Hand.MAIN_HAND)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/BlockExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/BlockExtensions.kt
@@ -577,17 +577,17 @@ fun doBreak(
     if (immediate) {
         EventManager.callEvent(BlockBreakingProgressEvent(blockPos))
 
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
-                PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, blockPos, direction
+                PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, blockPos, direction, sequence
             )
-        )
+        }
         swingMode.swing(Hand.MAIN_HAND)
-        network.sendPacket(
+        interaction.sendSequencedPacket(world) { sequence ->
             PlayerActionC2SPacket(
-                PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, blockPos, direction
+                PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, blockPos, direction, sequence
             )
-        )
+        }
         return
     }
 


### PR DESCRIPTION
`interaction.attackBlock` does, but we didn't. It's fixed now.