### PR TITLE
feat(AutoTool): Require(Sneak)Hold

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinKeyBinding.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinKeyBinding.java
@@ -23,6 +23,7 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.KeybindChangeEvent;
 import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent;
+import net.ccbluex.liquidbounce.event.events.MinecraftKeyPressed;
 import net.ccbluex.liquidbounce.utils.client.VanillaTranslationRecognizer;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
@@ -49,4 +50,10 @@ public class MixinKeyBinding {
         return EventManager.INSTANCE.callEvent(new KeybindIsPressedEvent((KeyBinding) (Object) this, original)).isPressed();
     }
 
+    @Inject(method = "setKeyPressed", at = @At("HEAD"), cancellable = true)
+    private static void hookSetKeyPressed(InputUtil.Key key, boolean pressed, CallbackInfo ci) {
+        if (EventManager.INSTANCE.callEvent(new MinecraftKeyPressed(key, pressed)).isCancelled()) {
+            ci.cancel();
+        }
+    }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinKeyBinding.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinKeyBinding.java
@@ -23,7 +23,7 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.KeybindChangeEvent;
 import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent;
-import net.ccbluex.liquidbounce.event.events.MinecraftKeyPressed;
+import net.ccbluex.liquidbounce.event.events.SetKeyPressedEvent;
 import net.ccbluex.liquidbounce.utils.client.VanillaTranslationRecognizer;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
@@ -52,7 +52,7 @@ public class MixinKeyBinding {
 
     @Inject(method = "setKeyPressed", at = @At("HEAD"), cancellable = true)
     private static void hookSetKeyPressed(InputUtil.Key key, boolean pressed, CallbackInfo ci) {
-        if (EventManager.INSTANCE.callEvent(new MinecraftKeyPressed(key, pressed)).isCancelled()) {
+        if (EventManager.INSTANCE.callEvent(new SetKeyPressedEvent(key, pressed)).isCancelled()) {
             ci.cancel();
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -146,7 +146,7 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     TitleEvent.Subtitle::class,
     TitleEvent.Fade::class,
     TitleEvent.Clear::class,
-    MinecraftKeyPressed::class
+    SetKeyPressedEvent::class
 )
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -146,6 +146,7 @@ val ALL_EVENT_CLASSES: Array<KClass<out Event>> = arrayOf(
     TitleEvent.Subtitle::class,
     TitleEvent.Fade::class,
     TitleEvent.Clear::class,
+    MinecraftKeyPressed::class
 )
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -93,7 +93,7 @@ class TargetChangeEvent(val target: PlayerData?) : Event(), WebSocketEvent
 class BlockCountChangeEvent(val count: Int?) : Event(), WebSocketEvent
 
 @Nameable("minecraftKeyPressed")
-class MinecraftKeyPressed(val key: InputUtil.Key, val pressed: Boolean) : CancellableEvent()
+class SetKeyPressedEvent(val key: InputUtil.Key, val pressed: Boolean) : CancellableEvent()
 
 @Nameable("clientChatStateChange")
 class ClientChatStateChange(val state: State) : Event(), WebSocketEvent {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -38,6 +38,7 @@ import net.ccbluex.liquidbounce.utils.inventory.InventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.InventoryConstraints
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.client.network.ServerInfo
+import net.minecraft.client.util.InputUtil
 import net.minecraft.world.GameMode
 
 @Deprecated(
@@ -90,6 +91,9 @@ class TargetChangeEvent(val target: PlayerData?) : Event(), WebSocketEvent
 
 @Nameable("blockCountChange")
 class BlockCountChangeEvent(val count: Int?) : Event(), WebSocketEvent
+
+@Nameable("minecraftKeyPressed")
+class MinecraftKeyPressed(val key: InputUtil.Key, val pressed: Boolean) : CancellableEvent()
 
 @Nameable("clientChatStateChange")
 class ClientChatStateChange(val state: State) : Event(), WebSocketEvent {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -21,16 +21,18 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.BlockAttackEvent
 import net.ccbluex.liquidbounce.event.events.BlockBreakingProgressEvent
+import net.ccbluex.liquidbounce.event.events.MinecraftKeyPressed
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.block.bed.BedBlockTracker
 import net.ccbluex.liquidbounce.utils.block.getCenterDistanceSquaredEyes
-import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.collection.Filter
+import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.ItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.SlotGroup
 import net.ccbluex.liquidbounce.utils.inventory.Slots
@@ -87,10 +89,34 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
 
     private val swapPreviousDelay by int("SwapPreviousDelay", 20, 1..100, "ticks")
 
-    private val requireSneaking by boolean("RequireSneaking", false)
+    private object RequireSneaking : ToggleableConfigurable(
+        this, "RequireSneaking", false
+    ) {
+        private val requireHold by boolean("RequireHold", false)
+
+        private var breakStartedWithHoldingShift = false
+
+        @Suppress("unused")
+        private val blockAttackHandler = handler<BlockAttackEvent> {
+            if (!breakStartedWithHoldingShift) {
+                breakStartedWithHoldingShift = player.isSneaking
+            }
+        }
+
+        @Suppress("unused")
+        private val keyHandler = handler<MinecraftKeyPressed> {
+            if (it.key == mc.options.attackKey.boundKey && !it.pressed) {
+                breakStartedWithHoldingShift = false
+            }
+        }
+
+        fun matches(): Boolean {
+            return player.isSneaking || (!requireHold && breakStartedWithHoldingShift)
+        }
+    }
 
     private object RequireNearBed : ToggleableConfigurable(
-        this, "RequireNearBed", enabled = false
+        this, "RequireNearBed", false
     ), BedBlockTracker.Subscriber {
         override val maxLayers: Int get() = 1
 
@@ -110,24 +136,26 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
     }
 
     init {
-        tree(RequireNearBed)
+        treeAll(
+            RequireSneaking,
+            RequireNearBed
+        )
     }
 
     @Suppress("unused")
     private val handleBlockBreakingProgress = handler<BlockBreakingProgressEvent> { event ->
-        if (!RequireNearBed.enabled || RequireNearBed.matches()) {
+        if (
+            (!RequireNearBed.enabled || RequireNearBed.matches())
+            && (!RequireSneaking.enabled || RequireSneaking.matches())
+        ) {
             switchToBreakBlock(event.pos)
         }
     }
 
     fun switchToBreakBlock(pos: BlockPos) {
-        if (requireSneaking && !player.isSneaking) {
-            return
-        }
-
         val blockState = pos.getState()!!
-        val slot = toolSelector.activeChoice.getTool(blockState) ?: return
-        SilentHotbar.selectSlotSilently(this, slot, swapPreviousDelay)
+        val bestSlot = toolSelector.activeChoice.getTool(blockState) ?: return
+        SilentHotbar.selectSlotSilently(this, bestSlot, swapPreviousDelay)
     }
 
     fun <T : ItemSlot> SlotGroup<T>.findBestToolToMineBlock(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -99,7 +99,7 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
         @Suppress("unused")
         private val blockAttackHandler = handler<BlockAttackEvent> {
             if (!breakStartedWithHoldingShift) {
-                breakStartedWithHoldingShift = player.isSneaking
+                breakStartedWithHoldingShift = mc.options.sneakKey.isPressed
             }
         }
 
@@ -111,7 +111,7 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
         }
 
         fun matches(): Boolean {
-            return player.isSneaking || (!requireHold && breakStartedWithHoldingShift)
+            return mc.options.sneakKey.isPressed || (!requireHold && breakStartedWithHoldingShift)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.BlockAttackEvent
 import net.ccbluex.liquidbounce.event.events.BlockBreakingProgressEvent
-import net.ccbluex.liquidbounce.event.events.MinecraftKeyPressed
+import net.ccbluex.liquidbounce.event.events.SetKeyPressedEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -104,7 +104,7 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
         }
 
         @Suppress("unused")
-        private val keyHandler = handler<MinecraftKeyPressed> {
+        private val keyHandler = handler<SetKeyPressedEvent> {
             if (it.key == mc.options.attackKey.boundKey && !it.pressed) {
                 breakStartedWithHoldingShift = false
             }


### PR DESCRIPTION
im using require sneak in auto tool long time, and always sneaking make u moveless.
but smt u wanna just hold shift, like mod key, move, and also break blocks by tool that was selected by auto tool

https://github.com/user-attachments/assets/f945b741-bed6-4d67-94a4-719a2329d0c6

_* i know that there is `RequireNearBed`, but this isnt only one case, maybe u wanna break some blocks in hot pvp_

 