### PR TITLE
feat(Scoreboard/HUD):Numbers hide setting and address AntiStrike

### DIFF
--- a/src-theme/public/components/scoreboard.json
+++ b/src-theme/public/components/scoreboard.json
@@ -8,5 +8,22 @@
     "verticalAlignment": "CenterTranslated",
     "verticalOffset": 0
   },
+  "values": [
+    {
+      "type": "BOOLEAN",
+      "name": "Numbers",
+      "value": false
+    },
+    {
+      "type": "TEXT",
+      "name": "Address",
+      "value": "www.liquidbounce.net"
+    },
+    {
+      "type": "COLOR",
+      "name": "AddressColor",
+      "value": 4282062335
+    }
+  ],
   "tweaks": ["DISABLE_SCOREBOARD"]
 }

--- a/src-theme/src/routes/hud/Hud.svelte
+++ b/src-theme/src/routes/hud/Hud.svelte
@@ -68,7 +68,7 @@
                 {:else if c.name === "Hotbar"}
                     <HotBar/>
                 {:else if c.name === "Scoreboard"}
-                    <Scoreboard/>
+                    <Scoreboard settings={c.settings} />
                 {:else if c.name === "ArmorItems"}
                     <ArmorItems/>
                 {:else if c.name === "Inventory"}

--- a/src-theme/src/routes/hud/elements/Scoreboard.svelte
+++ b/src-theme/src/routes/hud/elements/Scoreboard.svelte
@@ -27,12 +27,7 @@
             {#each scoreboard.entries as {name, score}, i}
                 <div class="row">
                     {#if i === scoreboard.entries.length - 1 && settings?.address}
-                        <div class="custom-ip" style="
-                            text-align: center;
-                            color: {rgbaToHex(intToRgba(settings.addressColor))};
-                            font-weight: bold;
-                            width: 100%;
-                        ">
+                        <div class="custom-ip" style="color: {rgbaToHex(intToRgba(settings.addressColor))}">
                             {settings.address}
                         </div>
                     {:else}
@@ -84,6 +79,7 @@
     display: block;
     text-align: center;
     width: 100%;
+    font-weight: bold;
   }
 </style>
 

--- a/src-theme/src/routes/hud/elements/Scoreboard.svelte
+++ b/src-theme/src/routes/hud/elements/Scoreboard.svelte
@@ -3,6 +3,9 @@
     import type {PlayerData, Scoreboard} from "../../../integration/types";
     import TextComponent from "../../menu/common/TextComponent.svelte";
     import type {ClientPlayerDataEvent} from "../../../integration/events";
+    import {intToRgba, rgbaToHex} from "../../../integration/util";
+
+    export let settings: { [name: string]: any };
 
     let scoreboard: Scoreboard | null = null;
 
@@ -19,11 +22,26 @@
                 <TextComponent fontSize={14} allowPreformatting={true} textComponent={scoreboard.header}/>
             </div>
         {/if}
+
         <div class="entries">
-            {#each scoreboard.entries as {name, score}}
+            {#each scoreboard.entries as {name, score}, i}
                 <div class="row">
-                    <TextComponent fontSize={14} allowPreformatting={true} textComponent={name}/>
-                    <TextComponent fontSize={14} allowPreformatting={true} textComponent={score}/>
+                    {#if i === scoreboard.entries.length - 1 && settings?.address}
+                        <div class="custom-ip" style="
+                            text-align: center;
+                            color: {rgbaToHex(intToRgba(settings.addressColor))};
+                            font-weight: bold;
+                            width: 100%;
+                        ">
+                            {settings.address}
+                        </div>
+                    {:else}
+                        <TextComponent fontSize={14} allowPreformatting={true} textComponent={name}/>
+                    {/if}
+
+                    <div class:hidden={!settings?.numbers}>
+                        <TextComponent fontSize={14} allowPreformatting={true} textComponent={score}/>
+                    </div>
                 </div>
             {/each}
         </div>
@@ -56,4 +74,16 @@
     background-color: rgba($scoreboard-base-color, 0.68);
     padding: 7px 10px;
   }
+
+  .hidden {
+    visibility: hidden;
+    opacity: 0;
+  }
+
+  .custom-ip {
+    display: block;
+    text-align: center;
+    width: 100%;
+  }
 </style>
+


### PR DESCRIPTION
Introduces new settings for the scoreboard component, including toggling number visibility and displaying a custom address with configurable color. Updates Scoreboard.svelte to render the address and apply the settings, and passes settings from Hud.svelte.

closes #6555
closes #6556