### PR TITLE
fix(AutoTool): Prevent constant slot switching 

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -208,13 +208,6 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
             it.itemStack.getMiningSpeedMultiplier(blockState)
         } ?: return null
 
-        val miningSpeedMultiplier = slot.itemStack.getMiningSpeedMultiplier(blockState)
-
-        // The current slot already matches the best
-        if (miningSpeedMultiplier == player.inventory.mainHandStack.getMiningSpeedMultiplier(blockState)) {
-            return null
-        }
-
         return slot
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAutoTool.kt
@@ -39,6 +39,7 @@ import net.ccbluex.liquidbounce.utils.inventory.InventoryConstraints
 import net.ccbluex.liquidbounce.utils.inventory.ItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.SlotGroup
 import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.item.durability
 import net.ccbluex.liquidbounce.utils.math.sq
 import net.minecraft.block.BlockState
 import net.minecraft.util.math.BlockPos
@@ -202,10 +203,15 @@ object ModuleAutoTool : ClientModule("AutoTool", Category.WORLD) {
 
         val slot = filter {
             val stack = it.itemStack
-            val durabilityCheck = (ignoreDurability || stack.damage < (stack.maxDamage - 2))
-            stack.isEmpty || (!player.isCreative && durabilityCheck)
+            val durabilityCheck = (ignoreDurability || (stack.durability > 2 || stack.maxDamage <= 0))
+            !player.isCreative && durabilityCheck
         }.maxByOrNull {
             it.itemStack.getMiningSpeedMultiplier(blockState)
+            // Gives the priority to the currently selected slot
+            // if all slots are equal in terms of mining speed
+            val currentSlotBonus = if (player.inventory.mainHandStack === it.itemStack) 1 else 0
+
+            it.itemStack.getMiningSpeedMultiplier(blockState) + currentSlotBonus
         } ?: return null
 
         return slot


### PR DESCRIPTION
- [x] Fixed constant slot switching while mining longer than `SwapPreviousDelay`.
- [x] Implemented saving of the currently selected tool with low durability if the player tries to mine a block. _(It would **not** save every tool if the hotbar were full of nearly broken tools. :) 
In this case, 1 tool would be broken and the rest would be saved.
Handling this edge case is possible, but the cost would probably outweigh the benefit.)_

Before the changes: https://youtu.be/dXbb6gNvI6k

After the changes: https://youtu.be/jcHsP0DSpIU