### PR TITLE
chore(Commands): better tab completion

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterBuilder.kt
@@ -105,16 +105,22 @@ class ParameterBuilder<T: Any> private constructor(val name: String) {
 
     /**
      * Filter from given strings provided by [placeholdersProvider].
+     *
+     * If [minecraftPlaceholders] is `true`, the prefix `minecraft:` will be ignored,
+     * meaning that typing the beginning like `diam` (without the prefix `minecraft:`)
+     * will be enough to match strings such as `minecraft:diamond`, `minecraft:diamond_axe`, etc.
      */
     inline fun autocompletedFrom(
         ignoreCase: Boolean = true,
+        minecraftPlaceholders: Boolean = false,
         crossinline placeholdersProvider: () -> Iterable<String>?,
     ) = autocompletedWith { begin, _ ->
         val placeholders = placeholdersProvider()
         if (placeholders == null || placeholders.none()) {
             emptyList()
         } else {
-            placeholders.filter { it.startsWith(begin, ignoreCase) }
+            placeholders.filter { it.startsWith(begin, ignoreCase)
+                || minecraftPlaceholders && it.removePrefix("minecraft:").startsWith(begin, ignoreCase) }
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterPresets.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/builder/ParameterPresets.kt
@@ -165,7 +165,7 @@ private fun <T : Any> ParameterBuilder.Companion.fromRegistry(
             registry.getOptionalValue(id).getOrNull()
         ) { "$sourceText is not a valid $typeName" }
     }
-    .autocompletedFrom {
+    .autocompletedFrom(minecraftPlaceholders = true) {
         registry.ids.map { it.toString() }
     }
 
@@ -173,7 +173,7 @@ fun ParameterBuilder.Companion.enchantment(
     name: String = "enchantment",
 ) = begin<String>(name)
     .verifiedBy(STRING_VALIDATOR)
-    .autocompletedFrom {
+    .autocompletedFrom(minecraftPlaceholders = true) {
         world.registryManager.getOrThrow(RegistryKeys.ENCHANTMENT).indexedEntries.map { it.idAsString }
     }
 
@@ -185,7 +185,7 @@ fun ParameterBuilder.Companion.item(
     name: String = "item",
 ) = begin<String>(name)
     .verifiedBy(STRING_VALIDATOR)
-    .autocompletedFrom {
+    .autocompletedFrom(minecraftPlaceholders = true) {
         Registries.ITEM.ids.map { it.toString() }
     }
 


### PR DESCRIPTION
- [x] Improves tab completion for commands like `.give`, `.enchant`, and `.xray` by allowing matches without typing the `minecraft:` prefix.

Video: https://youtu.be/ikU9k1XreAM