### PR TITLE
refactor(async handler): replace Sequence with standard coroutine API

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
@@ -18,6 +18,9 @@
  */
 package net.ccbluex.liquidbounce.event
 
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import net.ccbluex.liquidbounce.utils.client.logger
@@ -140,7 +143,7 @@ private fun <T : Event> EventListener.suspendHandlerCancelPrevious(
     priority: Short,
     handler: suspend CoroutineScope.(T) -> Unit
 ): EventHook<T> {
-    val jobRef = AtomicReference<Job?>(null)
+    val jobRef = atomic<Job?>(null)
     return handler(eventClass, priority) { event ->
         jobRef.getAndSet(eventListenerScope.launch(wrappedContext) {
             handler(event)
@@ -154,12 +157,12 @@ private fun <T : Event> EventListener.suspendHandlerDiscardLatest(
     priority: Short,
     handler: suspend CoroutineScope.(T) -> Unit
 ): EventHook<T> {
-    val jobRef = AtomicReference<Job?>(null)
+    val jobRef = atomic<Job?>(null)
     return handler(eventClass, priority) { event ->
         var newJob: Job? = null
 
         while (true) {
-            val currentJob = jobRef.get()
+            val currentJob = jobRef.value
             if (currentJob?.isActive == true) break
 
             if (newJob == null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
@@ -126,10 +126,11 @@ suspend fun waitTicks(ticks: Int) {
  */
 suspend fun waitSeconds(seconds: Int) = waitTicks(seconds * 20)
 
-fun EventListener.Sequence(
+// A special version of [suspendHandler]...
+fun EventListener.launchSequence(
     dispatcher: CoroutineDispatcher? = null,
-    handler: SuspendableHandler,
     onCancellation: Runnable?,
+    handler: SuspendableHandler,
 ): Job =
     eventListenerScope.launch(
         context = continuationInterceptor(dispatcher),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
@@ -25,64 +25,114 @@ import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FIRST_PRIORITY
 import java.util.function.BooleanSupplier
 import java.util.function.IntPredicate
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 typealias SuspendableEventHandler<T> = suspend Sequence.(T) -> Unit
 typealias SuspendableHandler = suspend Sequence.() -> Unit
 
-object SequenceManager : EventListener {
+object CoroutineTicker : EventListener {
 
-    // Running sequences
-    private val runningList = ReferenceArrayList<Sequence>()
+    // Running callbacks
+    private val runningList = ReferenceArrayList<BooleanSupplier>()
 
-    // Next tick sequences
-    private val pendingList = ReferenceArrayList<Sequence>()
+    // Next tick callbacks
+    private val pendingList = ReferenceArrayList<BooleanSupplier>()
 
     /**
-     * Registers a sequence to be ticked.
+     * Registers a task to be ticked.
      *
-     * @param sequence The [Sequence] to be ticked from next tick.
+     * @param task The callback to be run from next tick. It will be removed once returns true.
      */
-    fun register(sequence: Sequence) {
-        mc.execute { pendingList.add(sequence) }
+    fun register(task: BooleanSupplier) {
+        mc.execute { pendingList.add(task) }
     }
 
     /**
-     * Tick sequences
-     *
      * We want it to run before everything else, so we set the priority to [FIRST_PRIORITY]
-     * This is because we want to tick the existing sequences before new ones are added and might be ticked
+     * This is because we want to tick the existing tasks before new ones are added and might be ticked
      * in the same tick
      */
     @Suppress("unused")
-    private val tickSequences = handler<GameTickEvent>(priority = FIRST_PRIORITY) {
+    private val taskTicker = handler<GameTickEvent>(priority = FIRST_PRIORITY) {
         runningList.addAll(pendingList)
         pendingList.clear()
-        runningList.removeIf {
-            if (!it.isActive) {
-                true
-            } else {
-                it.tick()
-                false
-            }
-        }
+        runningList.removeIf { it.asBoolean }
     }
 
 }
 
-@Suppress("TooManyFunctions")
+/**
+ * Ticks with [stopAt] until it returns true.
+ * The elapsed ticks (starting from 1) will be passed to [stopAt].
+ *
+ * Resumes on Render thread.
+ *
+ * Example:
+ * - `tickUntil { true }` --> `1`
+ * - `tickUntil { it >= 2 }` --> `2`
+ *
+ * @param stopAt the callback of elapsed ticks. Will be called on game tick.
+ * @return the times of [stopAt] to be executed (equals to elapsed ticks)
+ */
+private suspend fun tickUntil(
+    stopAt: IntPredicate,
+): Int = suspendCancellableCoroutine { continuation ->
+    var elapsedTicks = 0
+    CoroutineTicker.register {
+        when {
+            !continuation.isActive -> true
+            stopAt.test(++elapsedTicks) -> {
+                continuation.resume(elapsedTicks)
+                true
+            }
+
+            else -> false
+        }
+    }
+}
+
+/**
+ * Waits a fixed amount of ticks before continuing.
+ * Re-entry at the game tick.
+ */
+suspend fun delayTicks(ticks: Int) {
+    // Don't wait if ticks is 0
+    if (ticks == 0) {
+        return
+    }
+
+    tickUntil { it >= ticks }
+}
+
+//fun Sequence(
+//    owner: EventListener,
+//    dispatcher: CoroutineDispatcher? = null,
+//    handler: SuspendableHandler,
+//    onCancellation: Runnable?,
+//): Job =
+//    owner.eventListenerScope.launch(
+//        context = owner.continuationInterceptor(dispatcher),
+//        start = CoroutineStart.UNDISPATCHED
+//    ) {
+//        if (owner.running) {
+//            handler()
+//        }
+//    }.apply {
+//        onCancellation?.let {
+//            invokeOnCompletion { t ->
+//                if (t is CancellationException) {
+//                    it.run()
+//                }
+//            }
+//        }
+//    }
+
 class Sequence(
     val owner: EventListener,
     dispatcher: CoroutineDispatcher? = null,
     val handler: SuspendableHandler,
     val onCancellation: Runnable?,
 ) : CoroutineScope {
-
-    private var continuation: Continuation<Int>? = null
-    private var elapsedTicks = 0
-    private var shouldResume = IntPredicate { true }
 
     /**
      * Use [owner]'s [kotlin.coroutines.ContinuationInterceptor] and [CoroutineScope] to handle:
@@ -98,7 +148,6 @@ class Sequence(
         context = owner.continuationInterceptor(dispatcher) + CoroutineName("Sequence-${owner}"),
         start = CoroutineStart.UNDISPATCHED
     ) {
-        SequenceManager.register(this@Sequence)
         if (owner.running) {
             handler()
         }
@@ -112,17 +161,10 @@ class Sequence(
         }
     }
 
-    internal fun tick() {
-        if (this.shouldResume.test(++this.elapsedTicks)) {
-            val continuation = this.continuation ?: return
-            this.continuation = null
-            continuation.resume(this.elapsedTicks)
-        }
-    }
-
     /**
      * Waits until the fixed amount of ticks ran out or the [breakLoop] says to continue.
-     * Returns true when we passed the time of [ticks] without breaking the loop.
+     *
+     * @returns if we passed the time of [ticks] without breaking the loop.
      */
     suspend fun waitConditional(ticks: Int, breakLoop: BooleanSupplier): Boolean {
         // Don't wait if ticks is 0
@@ -130,27 +172,20 @@ class Sequence(
             return !breakLoop.asBoolean
         }
 
-        waitUntil { breakLoop.asBoolean || it >= ticks }
-
-        return elapsedTicks >= ticks
+        return waitUntil { breakLoop.asBoolean || it >= ticks } >= ticks
     }
 
     /**
      * Waits a fixed amount of ticks before continuing.
      * Re-entry at the game tick.
      */
-    suspend fun waitTicks(ticks: Int) {
-        // Don't wait if ticks is 0
-        if (ticks == 0) {
-            return
-        }
-
-        waitUntil { it >= ticks }
-    }
+    suspend fun waitTicks(ticks: Int) = delayTicks(ticks)
 
     /**
      * Waits a fixed amount of seconds on tick level before continuing.
      * Re-entry at the game tick.
+     *
+     * Note: When TPS is not 20, this won't be actual `seconds`.
      */
     suspend fun waitSeconds(seconds: Int) = waitTicks(seconds * 20)
 
@@ -164,11 +199,6 @@ class Sequence(
      *
      * @return the times of [stopAt] to be executed (equals to elapsed ticks)
      */
-    suspend fun waitUntil(stopAt: IntPredicate): Int {
-        this.elapsedTicks = 0
-        this.shouldResume = stopAt
-
-        return suspendCoroutine { this.continuation = it }
-    }
+    suspend fun waitUntil(stopAt: IntPredicate): Int = tickUntil(stopAt)
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
@@ -27,8 +27,8 @@ import java.util.function.BooleanSupplier
 import java.util.function.IntPredicate
 import kotlin.coroutines.resume
 
-typealias SuspendableEventHandler<T> = suspend Sequence.(T) -> Unit
-typealias SuspendableHandler = suspend Sequence.() -> Unit
+typealias SuspendableEventHandler<T> = suspend CoroutineScope.(T) -> Unit
+typealias SuspendableHandler = suspend CoroutineScope.() -> Unit
 
 object CoroutineTicker : EventListener {
 
@@ -74,7 +74,7 @@ object CoroutineTicker : EventListener {
  * @param stopAt the callback of elapsed ticks. Will be called on game tick.
  * @return the times of [stopAt] to be executed (equals to elapsed ticks)
  */
-private suspend fun tickUntil(
+suspend fun tickUntil(
     stopAt: IntPredicate,
 ): Int = suspendCancellableCoroutine { continuation ->
     var elapsedTicks = 0
@@ -92,10 +92,24 @@ private suspend fun tickUntil(
 }
 
 /**
+ * Ticks until the fixed amount of ticks ran out or the [breakLoop] says to continue.
+ *
+ * @returns if we passed the time of [ticks] without breaking the loop.
+ */
+suspend fun tickConditional(ticks: Int, breakLoop: BooleanSupplier): Boolean {
+    // Don't wait if ticks is 0
+    if (ticks == 0) {
+        return !breakLoop.asBoolean
+    }
+
+    return tickUntil { breakLoop.asBoolean || it >= ticks } >= ticks
+}
+
+/**
  * Waits a fixed amount of ticks before continuing.
  * Re-entry at the game tick.
  */
-suspend fun delayTicks(ticks: Int) {
+suspend fun waitTicks(ticks: Int) {
     // Don't wait if ticks is 0
     if (ticks == 0) {
         return
@@ -104,101 +118,32 @@ suspend fun delayTicks(ticks: Int) {
     tickUntil { it >= ticks }
 }
 
-//fun Sequence(
-//    owner: EventListener,
-//    dispatcher: CoroutineDispatcher? = null,
-//    handler: SuspendableHandler,
-//    onCancellation: Runnable?,
-//): Job =
-//    owner.eventListenerScope.launch(
-//        context = owner.continuationInterceptor(dispatcher),
-//        start = CoroutineStart.UNDISPATCHED
-//    ) {
-//        if (owner.running) {
-//            handler()
-//        }
-//    }.apply {
-//        onCancellation?.let {
-//            invokeOnCompletion { t ->
-//                if (t is CancellationException) {
-//                    it.run()
-//                }
-//            }
-//        }
-//    }
+/**
+ * Waits a fixed amount of seconds on tick level before continuing.
+ * Re-entry at the game tick.
+ *
+ * Note: When TPS is not 20, this won't be actual `seconds`.
+ */
+suspend fun waitSeconds(seconds: Int) = waitTicks(seconds * 20)
 
-class Sequence(
-    val owner: EventListener,
+fun EventListener.Sequence(
     dispatcher: CoroutineDispatcher? = null,
-    val handler: SuspendableHandler,
-    val onCancellation: Runnable?,
-) : CoroutineScope {
-
-    /**
-     * Use [owner]'s [kotlin.coroutines.ContinuationInterceptor] and [CoroutineScope] to handle:
-     * - Exception
-     * - [EventListener.running] aware cancellation
-     *
-     * The [handler] block will be executed on the thread
-     * where constructor of [Sequence] be called until first suspension.
-     *
-     * All `wait` functions will be resumed on render thread. (Based on [GameTickEvent] handler)
-     */
-    override val coroutineContext: Job = owner.eventListenerScope.launch(
-        context = owner.continuationInterceptor(dispatcher) + CoroutineName("Sequence-${owner}"),
+    handler: SuspendableHandler,
+    onCancellation: Runnable?,
+): Job =
+    eventListenerScope.launch(
+        context = continuationInterceptor(dispatcher),
         start = CoroutineStart.UNDISPATCHED
     ) {
-        if (owner.running) {
+        if (running) {
             handler()
         }
     }.apply {
         onCancellation?.let {
-            invokeOnCompletion { t ->
+            this.invokeOnCompletion { t ->
                 if (t is CancellationException) {
                     it.run()
                 }
             }
         }
     }
-
-    /**
-     * Waits until the fixed amount of ticks ran out or the [breakLoop] says to continue.
-     *
-     * @returns if we passed the time of [ticks] without breaking the loop.
-     */
-    suspend fun waitConditional(ticks: Int, breakLoop: BooleanSupplier): Boolean {
-        // Don't wait if ticks is 0
-        if (ticks == 0) {
-            return !breakLoop.asBoolean
-        }
-
-        return waitUntil { breakLoop.asBoolean || it >= ticks } >= ticks
-    }
-
-    /**
-     * Waits a fixed amount of ticks before continuing.
-     * Re-entry at the game tick.
-     */
-    suspend fun waitTicks(ticks: Int) = delayTicks(ticks)
-
-    /**
-     * Waits a fixed amount of seconds on tick level before continuing.
-     * Re-entry at the game tick.
-     *
-     * Note: When TPS is not 20, this won't be actual `seconds`.
-     */
-    suspend fun waitSeconds(seconds: Int) = waitTicks(seconds * 20)
-
-    /**
-     * Waits until [stopAt] returns true.
-     * The elapsed ticks (starting from 1) will be passed to [stopAt].
-     *
-     * Example:
-     * - `waitUntil { true }` --> `1`
-     * - `waitUntil { it >= 2 }` --> `2`
-     *
-     * @return the times of [stopAt] to be executed (equals to elapsed ticks)
-     */
-    suspend fun waitUntil(stopAt: IntPredicate): Int = tickUntil(stopAt)
-
-}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -112,7 +112,7 @@ inline fun <reified T : Event> EventListener.sequenceHandler(
     onCancellation: Runnable? = null,
     crossinline eventHandler: SuspendableEventHandler<T>,
 ) {
-    handler<T>(priority) { event -> this.Sequence(dispatcher, { eventHandler(event) }, onCancellation) }
+    handler<T>(priority) { event -> launchSequence(dispatcher, onCancellation) { eventHandler(event) } }
 }
 
 /**
@@ -128,7 +128,7 @@ fun EventListener.tickHandler(
     return handler<GameTickEvent> {
         // Check if the sequence is already running (completed or null)
         if (sequence == null || !sequence!!.isActive) {
-            sequence = this.Sequence(dispatcher, eventHandler, onCancellation)
+            sequence = launchSequence(dispatcher, onCancellation, eventHandler)
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -19,8 +19,7 @@
 package net.ccbluex.liquidbounce.event
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.Job
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
 import java.util.function.Consumer
@@ -113,7 +112,7 @@ inline fun <reified T : Event> EventListener.sequenceHandler(
     onCancellation: Runnable? = null,
     crossinline eventHandler: SuspendableEventHandler<T>,
 ) {
-    handler<T>(priority) { event -> Sequence(this, dispatcher, { eventHandler(event) }, onCancellation) }
+    handler<T>(priority) { event -> this.Sequence(dispatcher, { eventHandler(event) }, onCancellation) }
 }
 
 /**
@@ -124,13 +123,12 @@ fun EventListener.tickHandler(
     onCancellation: Runnable? = null,
     eventHandler: SuspendableHandler,
 ): EventHook<GameTickEvent> {
-    // The sequence's lifecycle is under SequenceManager's control.
-    var sequence: Sequence? = null
+    var sequence: Job? = null
 
     return handler<GameTickEvent> {
         // Check if the sequence is already running (completed or null)
         if (sequence == null || !sequence!!.isActive) {
-            sequence = Sequence(this, dispatcher, eventHandler, onCancellation)
+            sequence = this.Sequence(dispatcher, eventHandler, onCancellation)
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -160,7 +160,7 @@ object EventManager {
         ) { CopyOnWriteArrayList() }
 
     init {
-        SequenceManager
+        CoroutineTicker
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -30,6 +30,7 @@ import net.ccbluex.liquidbounce.event.events.MouseButtonEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.client.*
 import net.ccbluex.liquidbounce.features.module.modules.combat.*
 import net.ccbluex.liquidbounce.features.module.modules.combat.aimbot.ModuleAutoBow
@@ -154,7 +155,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
     private val handleWorldChange = sequenceHandler<WorldChangeEvent> { event ->
         // Delayed start handling
         if (event.world != null) {
-            waitUntil { inGame }
+            tickUntil { inGame }
             AutoConfig.withLoading {
                 for (module in modules) {
                     if (!module.enabled || module.calledSinceStartup) continue

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.event.SuspendHandlerBehavior.DISCARD_LATEST
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.suspendHandler
+import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.chat.ChatClient
 import net.ccbluex.liquidbounce.features.chat.packet.ServerRequestJWTPacket
 import net.ccbluex.liquidbounce.features.command.CommandManager
@@ -129,7 +130,7 @@ object ModuleLiquidChat : ClientModule("LiquidChat", Category.CLIENT, hide = tru
     }
 
     @Suppress("unused")
-    private val repeatable = suspendHandler<GameTickEvent>(context = Dispatchers.IO, behavior = DISCARD_LATEST) {
+    private val repeatable = tickHandler(Dispatchers.IO) {
         if (!chatClient.connected) {
             chatClient.connect()
         } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
@@ -36,6 +36,7 @@ import net.ccbluex.liquidbounce.api.core.retrying
 import net.ccbluex.liquidbounce.api.services.cdn.ClientCdn
 import net.ccbluex.liquidbounce.config.gson.util.json
 import net.ccbluex.liquidbounce.config.gson.util.jsonArrayOf
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoClicker.kt
@@ -20,10 +20,11 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.SprintEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals.CriticalsSelectionMode
@@ -102,10 +103,10 @@ object ModuleAutoClicker : ClientModule("AutoClicker", Category.COMBAT, aliases 
             return criticalsSelectionMode.isCriticalHit(entity)
         }
 
-        suspend fun Sequence.encounterItemUse(): Boolean {
+        suspend fun encounterItemUse(): Boolean {
             return when (onItemUse) {
                 Use.WAIT -> {
-                    this.waitUntil { !player.isUsingItem }
+                    tickUntil { !player.isUsingItem }
 
                     if (delayPostStopUse > 0) {
                         waitTicks(delayPostStopUse)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoLeave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoLeave.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -41,16 +42,16 @@ object ModuleAutoLeave : ClientModule("AutoLeave", Category.COMBAT) {
 
     @Suppress("unused")
     private val tickHandler = tickHandler {
-        val passed = waitConditional(delay.random()) {
+        val passed = tickConditional(delay.random()) {
             if (player.abilities.creativeMode || mc.isIntegratedServerRunning) {
-                return@waitConditional true
+                return@tickConditional true
             }
 
             // Player can heal himself
             if (player.mainHandStack.components.contains(DataComponentTypes.DEATH_PROTECTION)
                 || player.offHandStack.components.contains(DataComponentTypes.DEATH_PROTECTION)
             ) {
-                return@waitConditional true
+                return@tickConditional true
             }
 
             player.health >= health

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoRod.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoRod.kt
@@ -22,10 +22,12 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.computedOn
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -190,7 +192,7 @@ object ModuleAutoRod : ClientModule("AutoRod", Category.COMBAT) {
         val minRangeSq = range.start.sq()
 
         // 3. timeout / hit entity / no movement / out of range
-        waitConditional(hitTimeout) {
+        tickConditional(hitTimeout) {
             fishingBobberEntity?.hookedEntity != null ||
                 fishingBobberEntity?.movement == Vec3d.ZERO ||
                 pullOnOutOfRange && player.squaredDistanceTo(target) !in minRangeSq..maxRangeSq

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSuperKnockback.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSuperKnockback.kt
@@ -22,11 +22,13 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.SprintEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals
@@ -126,7 +128,7 @@ object ModuleSuperKnockback : ClientModule("SuperKnockback", Category.COMBAT, al
 
             this@SprintTap.debugParameter("State") { "Disallowing Sprint" }
             cancelSprint = true
-            waitUntil { !player.isSprinting && !player.lastSprinting }
+            tickUntil { !player.isSprinting && !player.lastSprinting }
             this@SprintTap.debugParameter("State") { "Waiting for ReSprint" }
             waitTicks(reSprintTicks.random())
             this@SprintTap.debugParameter("State") { "Allowing Sprint" }
@@ -179,7 +181,7 @@ object ModuleSuperKnockback : ClientModule("SuperKnockback", Category.COMBAT, al
             waitTicks(ticksUntilMovementBlock.random())
             this@WTap.debugParameter("State") { "Disallowing Movement" }
             cancelMovement = true
-            waitUntil { !player.input.hasForwardMovement() }
+            tickUntil { !player.input.hasForwardMovement() }
             this@WTap.debugParameter("State") { "Waiting for Allowed Movement" }
             waitTicks(ticksUntilAllowedMovement.random())
             this@WTap.debugParameter("State") { "Allowing Movement" }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSwordBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleSwordBlock.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category
@@ -72,8 +73,10 @@ object ModuleSwordBlock : ClientModule("SwordBlock", Category.COMBAT, aliases = 
                     waitTicks(1)
                     interaction.sendSequencedPacket(world) { sequence ->
                         // This time we use a new sequence
-                        PlayerInteractItemC2SPacket(Hand.OFF_HAND, sequence,
-                            player.yaw, player.pitch)
+                        PlayerInteractItemC2SPacket(
+                            Hand.OFF_HAND, sequence,
+                            player.yaw, player.pitch
+                        )
                     }
                 } else {
                     event.cancelEvent()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat
 
 import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerTickEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/AutoArmorSaveArmor.kt
@@ -2,7 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 
 import net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor.ModuleAutoArmor.UseHotbar
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.Slots
@@ -119,7 +119,7 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
     /**
      * Waits and closes the inventory after the armor is replaced.
      */
-    private suspend fun Sequence.closeInventory(hasArmorToEquip: Boolean) {
+    private suspend fun closeInventory(hasArmorToEquip: Boolean) {
         if (!hasOpenedInventory || hasArmorToEquip) {
             return
         }
@@ -136,7 +136,7 @@ object AutoArmorSaveArmor : ToggleableConfigurable(ModuleAutoArmor, "SaveArmor",
     /**
      * Closes the previous game screen and opens the inventory.
      */
-    private suspend fun Sequence.openInventory(hasArmorToReplace : Boolean) {
+    private suspend fun openInventory(hasArmorToReplace: Boolean) {
         while (hasArmorToReplace && mc.currentScreen !is InventoryScreen) {
 
             if (mc.currentScreen is HandledScreen<*>) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/AutoFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/elytratarget/AutoFirework.kt
@@ -1,7 +1,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat.elytratarget
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
@@ -34,7 +34,7 @@ internal object AutoFirework : ToggleableConfigurable(ModuleElytraTarget, "AutoF
         get() = fireworkChronometer.hasElapsed((fireworkCooldown * MILLISECONDS_PER_TICK).toLong())
 
     @Suppress("ComplexCondition")
-    private suspend inline fun Sequence.canUseFirework(): Boolean {
+    private suspend fun canUseFirework(): Boolean {
         if (!KillAura.running
             || !syncCooldownWithKillAura
             || (

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -18,7 +18,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
 
-import net.ccbluex.liquidbounce.event.Sequence
+import kotlinx.coroutines.CoroutineScope
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.rotationTiming
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura.simulateInventoryClosing
@@ -109,13 +110,13 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
      * This means, we make sure we are not blocking, we are not using another item,
      * and we are not in an inventory screen depending on the configuration.
      */
-    suspend fun attack(sequence: Sequence, rotation: Rotation? = null, attack: () -> Boolean) {
+    suspend fun attack(rotation: Rotation? = null, attack: () -> Boolean) {
         if (!isClickTick) {
             // If we are not going to click, we don't need to prepare the environment
             return
         }
 
-        val interactiveScene = InteractiveScene(sequence = sequence, rotation = rotation)
+        val interactiveScene = InteractiveScene(rotation = rotation)
         if (interactiveScene.prepare()) {
             return
         }
@@ -129,7 +130,6 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
      * Prepare the scene for e.g. attacking an entity.
      */
     private data class InteractiveScene(
-        val sequence: Sequence,
         val rotation: Rotation?,
         val isInInventoryScreen: Boolean = InventoryManager.isInventoryOpen,
     ) {
@@ -149,7 +149,7 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
                     // Wait for the tick off time to be over, if it's not 0
                     // Ideally this should not happen.
                     if (KillAuraAutoBlock.stopBlocking(pauses = true) && KillAuraAutoBlock.currentTickOff > 0) {
-                        sequence.waitTicks(KillAuraAutoBlock.currentTickOff)
+                        waitTicks(KillAuraAutoBlock.currentTickOff)
                     }
                 }
             } else if (player.isUsingItem && !ModuleMultiActions.mayAttackWhileUsing()) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
 
 import com.google.gson.JsonObject
 import net.ccbluex.liquidbounce.config.types.NamedChoice
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.events.SprintEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
@@ -198,7 +198,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
                 if (hasUnblocked) {
                     waitTicks(KillAuraAutoBlock.currentTickOff)
                 }
-                dealWithFakeSwing(this, null)
+                dealWithFakeSwing(null)
             }
             return@tickHandler
         }
@@ -231,7 +231,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             targetTracker.target = crosshairTarget
         }
 
-        attackTarget(this, crosshairTarget, rotation)
+        attackTarget(crosshairTarget, rotation)
     }
 
     val shouldBlockSprinting
@@ -247,7 +247,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     }
 
     @Suppress("CognitiveComplexMethod", "CyclomaticComplexMethod")
-    private suspend fun attackTarget(sequence: Sequence, target: Entity, rotation: Rotation) {
+    private suspend fun attackTarget(target: Entity, rotation: Rotation) {
         // Make it seem like we are blocking
         KillAuraAutoBlock.makeSeemBlock()
 
@@ -274,10 +274,10 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
             // Deal with fake swing
             if (KillAuraFailSwing.enabled) {
                 if (hasUnblocked) {
-                    sequence.waitTicks(KillAuraAutoBlock.currentTickOff)
+                    waitTicks(KillAuraAutoBlock.currentTickOff)
                 }
 
-                dealWithFakeSwing(sequence, target)
+                dealWithFakeSwing(target)
             }
             return
         }
@@ -286,7 +286,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
         // Attack enemy, according to the attack scheduler
         if (clickScheduler.isClickTick && validateAttack(target)) {
-            clickScheduler.attack(sequence, rotation) {
+            clickScheduler.attack(rotation) {
                 // On each click, we check if we are still ready to attack
                 if (!validateAttack(target)) {
                     return@attack false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFailSwing.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraFailSwing.kt
@@ -20,7 +20,6 @@ package net.ccbluex.liquidbounce.features.module.modules.combat.killaura.feature
 
 import net.ccbluex.liquidbounce.config.types.nesting.NoneChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraClicker.attack
@@ -64,7 +63,7 @@ internal object KillAuraFailSwing : ToggleableConfigurable(ModuleKillAura, "Fail
         currentAdditionalRange = this.additionalRange.random()
     }
 
-    suspend fun dealWithFakeSwing(sequence: Sequence, target: Entity?) {
+    suspend fun dealWithFakeSwing(target: Entity?) {
         if (!enabled || !validateAttack()) {
             return
         }
@@ -81,7 +80,7 @@ internal object KillAuraFailSwing : ToggleableConfigurable(ModuleKillAura, "Fail
         // Make it seem like we are blocking
         KillAuraAutoBlock.makeSeemBlock()
 
-        attack(sequence) {
+        attack {
             // [this.crosshairTarget == null] results in a limited attack speed
             if (interaction.hasLimitedAttackSpeed()) {
                 mc.attackCooldown = 10

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.ccbluex.fastutil.mapToArray
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -1,5 +1,6 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.modes
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode.*
@@ -94,7 +95,7 @@ object ModuleVelocity : ClientModule("Velocity", Category.COMBAT, aliases = list
                     if (ticks > 0) {
                         val timeToWait = System.currentTimeMillis() + (ticks * 50L)
 
-                        waitUntil { System.currentTimeMillis() >= timeToWait }
+                        tickUntil { System.currentTimeMillis() >= timeToWait }
                     }
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityGrim2344.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityGrim2344.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket
@@ -63,8 +64,12 @@ internal object VelocityGrim2344 : VelocityMode("Grim2344-117") {
             event.cancelEvent()
             waitTicks(1)
             repeat(if (alternativeBypass) 4 else 1) {
-                network.sendPacket(Full(player.x, player.y, player.z, player.yaw, player.pitch, player.isOnGround,
-                    player.horizontalCollision))
+                network.sendPacket(
+                    Full(
+                        player.x, player.y, player.z, player.yaw, player.pitch, player.isOnGround,
+                        player.horizontalCollision
+                    )
+                )
             }
             network.sendPacket(
                 PlayerActionC2SPacket(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityGrim2371.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityGrim2371.kt
@@ -19,6 +19,7 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerTickEvent
 import net.ccbluex.liquidbounce.event.events.QueuePacketEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityStrafe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityStrafe.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.combat.velocity.mode
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClickTp.kt
@@ -21,10 +21,11 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
@@ -89,18 +90,24 @@ object ModuleClickTp : ClientModule("ClickTp", Category.EXPLOIT, aliases = listO
 
         val pos = blockPos.up().toCenterPos()
 
-        notification("ClickTp", message("start", blockPos.x, blockPos.y, blockPos.z),
-            NotificationEvent.Severity.SUCCESS)
+        notification(
+            "ClickTp", message("start", blockPos.x, blockPos.y, blockPos.z),
+            NotificationEvent.Severity.SUCCESS
+        )
 
         teleportVulcan286(pos)
 
         waitTicks(5)
         if (player.pos.distanceTo(blockPos.toVec3d()) < 5) {
-            notification("ClickTp", message("success", blockPos.x, blockPos.y, blockPos.z),
-                NotificationEvent.Severity.SUCCESS)
+            notification(
+                "ClickTp", message("success", blockPos.x, blockPos.y, blockPos.z),
+                NotificationEvent.Severity.SUCCESS
+            )
         } else {
-            notification("ClickTp", message("failed", blockPos.x, blockPos.y, blockPos.z),
-                NotificationEvent.Severity.ERROR)
+            notification(
+                "ClickTp", message("failed", blockPos.x, blockPos.y, blockPos.z),
+                NotificationEvent.Severity.ERROR
+            )
         }
 
         waitTicks(cooldown)
@@ -109,7 +116,7 @@ object ModuleClickTp : ClientModule("ClickTp", Category.EXPLOIT, aliases = listO
     /**
      * Teleport to a position by abusing Vulcan.
      */
-    private suspend fun Sequence.teleportVulcan286(pos: Vec3d) {
+    private suspend fun teleportVulcan286(pos: Vec3d) {
         requiresLag = true
 
         // Set position and send packet
@@ -121,7 +128,7 @@ object ModuleClickTp : ClientModule("ClickTp", Category.EXPLOIT, aliases = listO
             player.jump()
 
             waitTicks(1)
-            waitUntil { player.isOnGround }
+            tickUntil { player.isOnGround }
             requiresCollision = false
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -105,6 +106,7 @@ object ModuleClip : ClientModule("Clip", Category.MOVEMENT) {
                     mc.options.rightKey.isPressed -> player.horizontalFacing.rotateClockwise(Direction.Axis.Y)
                     else -> return@tickHandler
                 }
+
                 mc.options.sneakKey.isPressed -> Direction.DOWN
                 mc.options.jumpKey.isPressed -> Direction.UP
                 else -> return@tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResetVL.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleResetVL.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVulcanRiptide.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/disabler/disablers/DisablerVulcanRiptide.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.disabl
 
 import net.ccbluex.liquidbounce.config.AutoConfig
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.disabler.ModuleDisabler
 import net.ccbluex.liquidbounce.lang.translation

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/GrimConsoleSpammer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/GrimConsoleSpammer.kt
@@ -3,6 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.e
 import io.netty.buffer.Unpooled
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperCompletion1204Exploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperCompletion1204Exploit.kt
@@ -2,6 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.e
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket
@@ -57,12 +58,12 @@ object PaperCompletion1204Exploit : Choice("PaperCompletion-1.20.2") {
     }
 
     val repeatable = tickHandler {
-        if(!autoMode) {
+        if (!autoMode) {
             return@tickHandler
         }
 
         //Send all known command completions.
-        if(messageIndex == knownWorkingMessages.size - 1) {
+        if (messageIndex == knownWorkingMessages.size - 1) {
             messageIndex = 0
             ModuleServerCrasher.enabled = false
             return@tickHandler
@@ -74,7 +75,7 @@ object PaperCompletion1204Exploit : Choice("PaperCompletion-1.20.2") {
         //Keep the length on the maximum limit (2048 characters)
         val len = 2044 - knownMessage.length
         val overflow = generateJsonObject(len)
-        val partialCommand = knownMessage.replace("{PAYLOAD}",overflow)
+        val partialCommand = knownMessage.replace("{PAYLOAD}", overflow)
 
         repeat(packets) {
             network.sendPacket(RequestCommandCompletionsC2SPacket(0, partialCommand))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperWindow1201Exploit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/servercrasher/exploits/PaperWindow1201Exploit.kt
@@ -3,6 +3,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.e
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.exploit.servercrasher.ModuleServerCrasher
 import net.minecraft.item.ItemStack

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleDerp.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleHandDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleHandDerp.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleSkinDerp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/ModuleSkinDerp.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.`fun`
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -57,12 +58,12 @@ object ModuleSkinDerp : ClientModule("SkinDerp", Category.FUN) {
         waitTicks(delay)
 
         parts.forEach {
-                if (sync) {
-                    mc.options.setPlayerModelPart(it.part, !mc.options.isPlayerModelPartEnabled(it.part))
-                } else {
-                    mc.options.setPlayerModelPart(it.part, Random.nextBoolean())
-                }
+            if (sync) {
+                mc.options.setPlayerModelPart(it.part, !mc.options.isPlayerModelPartEnabled(it.part))
+            } else {
+                mc.options.setPlayerModelPart(it.part, Random.nextBoolean())
             }
+        }
     }
 
     private enum class DerpParts(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/notebot/ModuleNotebot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/notebot/ModuleNotebot.kt
@@ -75,7 +75,7 @@ object ModuleNotebot : ClientModule("Notebot", Category.FUN, disableOnQuit = tru
 
     @Suppress("unused")
     private val tickHandler = tickHandler {
-        engine?.onTick(this)
+        engine?.onTick()
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/notebot/NotebotEngine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/fun/notebot/NotebotEngine.kt
@@ -18,7 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.`fun`.notebot
 
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.`fun`.notebot.ModuleNotebot.NotebotStage
 import net.ccbluex.liquidbounce.features.module.modules.`fun`.notebot.ModuleNotebot.NotebotStageHandler
 import net.ccbluex.liquidbounce.features.module.modules.`fun`.notebot.ModuleNotebot.renderer
@@ -59,11 +59,11 @@ class NotebotEngine(
         causingNoteBlock.setObservedNote((12f + 12f * log2(packet.pitch)).roundToInt())
     }
 
-    suspend fun onTick(sequence: Sequence) {
+    suspend fun onTick() {
         val ticks = ticksToWait
 
         if (ticks != null) {
-            sequence.waitTicks(ticks)
+            waitTicks(ticks)
 
             ticksToWait = null
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAntiStaff.kt
@@ -7,6 +7,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.ServerConnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.*
@@ -42,7 +43,7 @@ object ModuleAntiStaff : ClientModule("AntiStaff", Category.MISC) {
         serverStaffList[address] = emptySet()
 
         // Keeps us from loading the staff list multiple times
-        waitUntil { inGame && mc.currentScreen != null }
+        tickUntil { inGame && mc.currentScreen != null }
 
         // Load the staff list
         loadStaffList(address)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoAccount.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoAccount.kt
@@ -20,10 +20,11 @@ package net.ccbluex.liquidbounce.features.module.modules.misc
 
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.event.Event
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.TitleEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.command.commands.module.CommandAutoAccount
 import net.ccbluex.liquidbounce.features.misc.HideAppearance
 import net.ccbluex.liquidbounce.features.module.Category
@@ -70,9 +71,9 @@ object ModuleAutoAccount : ClientModule("AutoAccount", Category.MISC, aliases = 
         sending = false
     }
 
-    private suspend inline fun Sequence.action(operation: () -> Unit) {
+    private suspend inline fun action(operation: () -> Unit) {
         sending = true
-        waitUntil { mc.networkHandler != null }
+        tickUntil { mc.networkHandler != null }
         waitTicks(delay.random())
         operation()
         sending = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoChatGame.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.api.thirdparty.OpenAiApi
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -135,10 +136,10 @@ object ModuleAutoChatGame : ClientModule("AutoChatGame", Category.MISC) {
 
     @Suppress("unused")
     val tickHandler = tickHandler {
-        waitUntil {
+        tickUntil {
             // Has the trigger word been said and has the buffer time elapsed?
             triggerWordChronometer.hasElapsed(bufferTime.toLong())
-            // Is the buffer empty? - If it is we already answered the question.
+                // Is the buffer empty? - If it is we already answered the question.
                 && chatBuffer.isNotEmpty()
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoPearl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoPearl.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -126,7 +127,7 @@ object ModuleAutoPearl : ClientModule("AutoPearl", Category.COMBAT, aliases = li
                 return RotationManager.serverRotation.angleTo(rotation) <= 1.0f
             }
 
-            waitConditional(20) {
+            tickConditional(20) {
                 RotationManager.setRotationTarget(
                     Rotate.rotations.toRotationTarget(rotation),
                     Priority.IMPORTANT_FOR_USAGE_3,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFlagCheck.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleFlagCheck.kt
@@ -18,6 +18,9 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -38,6 +41,7 @@ import net.minecraft.util.math.Vec3d
 import org.apache.commons.lang3.StringUtils
 import kotlin.math.abs
 import kotlin.math.roundToLong
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Module Flag Check.
@@ -52,12 +56,12 @@ object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = list
 
     private object ResetFlags : ToggleableConfigurable(this, "ResetFlags", true) {
 
-        private var afterSeconds by int("After", 30, 1..300, "s")
+        private val afterSeconds by int("After", 30, 1..300, "s")
 
         @Suppress("unused")
-        private val repeatable = tickHandler {
-            flagCount = 0
-            waitSeconds(afterSeconds)
+        private val repeatable = tickHandler(Dispatchers.Default) {
+            flagCount.getAndSet(0)
+            delay(afterSeconds.seconds)
         }
 
     }
@@ -113,7 +117,7 @@ object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = list
         tree(Render)
     }
 
-    private var flagCount = 0
+    private val flagCount = atomic(0)
     private var lastYaw = 0F
     private var lastPitch = 0F
 
@@ -129,7 +133,7 @@ object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = list
                 val deltaYaw = calculateAngleDelta(change.yaw, lastYaw)
                 val deltaPitch = calculateAngleDelta(change.pitch, lastPitch)
 
-                flagCount++
+                flagCount.incrementAndGet()
                 if (deltaYaw >= 90 || deltaPitch >= 90) {
                     alert(AlertReason.FORCEROTATE, "(${deltaYaw.roundToLong()}° | ${deltaPitch.roundToLong()}°)")
                 } else {
@@ -145,7 +149,7 @@ object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = list
             }
 
             is DisconnectS2CPacket -> {
-                flagCount = 0
+                flagCount.getAndSet(0)
             }
         }
     }
@@ -174,7 +178,7 @@ object ModuleFlagCheck : ClientModule("FlagCheck", Category.MISC, aliases = list
         }
 
         if (invalidReasons.isNotEmpty()) {
-            flagCount++
+            flagCount.incrementAndGet()
 
             val reasonString = invalidReasons.joinToString()
             alert(AlertReason.INVALID, reasonString)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/MatrixAntiBotMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/MatrixAntiBotMode.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.misc.antibot.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.render.BoxRenderer
@@ -149,9 +150,9 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
         // Wait until entity is not in combat
         var inactivity = 0
         var buffer: MutableList<TrainingData>? = null
-        waitUntil {
+        tickUntil {
             if (entity.isDead || entity.isRemoved || doNotTrack) {
-                return@waitUntil true
+                return@tickUntil true
             }
 
             val rotation = RotationManager.currentRotation ?: player.rotation
@@ -164,13 +165,13 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
             if (raytraceTarget?.entity == null) {
                 inactivity++
                 ModuleDebug.debugParameter(this, "Inactivity", inactivity)
-                return@waitUntil inactivity > 20
+                return@tickUntil inactivity > 20
             } else {
                 buffer = trainingCollection[entityId]
                 inactivity = 0
             }
 
-            return@waitUntil false
+            return@tickUntil false
         }
 
         targetEntityId = null

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiTrainer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiTrainer.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.deeplearn.data.TrainingData
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
@@ -69,13 +70,13 @@ object MinaraiTrainer : ModuleDebugRecorder.DebugRecorderMode<TrainingData>("Min
         if (isFirstRun) {
             // We wait until the player has hit the slime entity for the first time,
             // then we record the data and spawn a new slime entity.
-            waitUntil { target == null }
+            tickUntil { target == null }
             isFirstRun = false
 
             chat("✧ Starting training...")
         } else {
-            waitUntil {
-                val target = target ?: return@waitUntil true
+            tickUntil {
+                val target = target ?: return@tickUntil true
 
                 val next = RotationManager.currentRotation ?: player.rotation
                 val current = RotationManager.previousRotation ?: player.lastRotation
@@ -84,17 +85,22 @@ object MinaraiTrainer : ModuleDebugRecorder.DebugRecorderMode<TrainingData>("Min
                 }
                 val distance = player.squaredBoxedDistanceTo(target).toFloat()
 
-                recordPacket(TrainingData(
-                    currentVector = current.directionVector,
-                    previousVector = previous.directionVector,
-                    targetVector = Rotation.lookingAt(point = target.box.center, from = player.eyePos).directionVector,
-                    velocityDelta = current.rotationDeltaTo(next).toVec2f(),
-                    playerDiff = player.pos.subtract(player.prevPos),
-                    targetDiff = target.pos.subtract(target.prevPos),
-                    age = target.age,
-                    hurtTime = target.hurtTime,
-                    distance = distance
-                ))
+                recordPacket(
+                    TrainingData(
+                        currentVector = current.directionVector,
+                        previousVector = previous.directionVector,
+                        targetVector = Rotation.lookingAt(
+                            point = target.box.center,
+                            from = player.eyePos
+                        ).directionVector,
+                        velocityDelta = current.rotationDeltaTo(next).toVec2f(),
+                        playerDiff = player.pos.subtract(player.prevPos),
+                        targetDiff = target.pos.subtract(target.prevPos),
+                        age = target.age,
+                        hurtTime = target.hurtTime,
+                        distance = distance
+                    )
+                )
 
                 false
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/reporthelper/ReportHelperAutoConfirm.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/reporthelper/ReportHelperAutoConfirm.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.utils.inventory.getSlotsInContainer
 import net.ccbluex.liquidbounce.utils.inventory.syncId
 import net.minecraft.client.gui.screen.ingame.HandledScreen
@@ -50,7 +51,7 @@ internal object ReportHelperAutoConfirm : ToggleableConfigurable(ModuleReportHel
                 }
 
                 // Wait for screen update
-                if (!waitConditional(5) { mc.currentScreen === screen }) {
+                if (!tickConditional(5) { mc.currentScreen === screen }) {
                     return@sequenceHandler
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/reporthelper/ReportHelperAutoReport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/reporthelper/ReportHelperAutoReport.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.misc.reporthelper
 
 import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.DisconnectEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement
 
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyEnderpearl.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.BlockShapeEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballCustomTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballCustomTechnique.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fire
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballLegitTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/fireball/techniques/FlyFireballLegitTechnique.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.fire
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/hypixel/FlyHypixel.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/hypixel/FlyHypixel.kt
@@ -23,10 +23,12 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.hypi
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.withStrafe
@@ -55,7 +57,7 @@ object FlyHypixel : Choice("Hypixel") {
 
     @Suppress("unused")
     private val tickHandler = tickHandler {
-        waitUntil { isFlying }
+        tickUntil { isFlying }
 
         player.velocity.y = 0.8
         waitTicks(1)
@@ -70,7 +72,7 @@ object FlyHypixel : Choice("Hypixel") {
         waitTicks(19)
         player.velocity.y += 0.42
 
-        waitUntil { player.isOnGround }
+        tickUntil { player.isOnGround }
         ModuleFly.enabled = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/hypixel/FlyHypixelFlat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/hypixel/FlyHypixelFlat.kt
@@ -23,9 +23,11 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.hypi
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.Timer
 import net.ccbluex.liquidbounce.utils.entity.sqrtSpeed
@@ -58,13 +60,13 @@ object FlyHypixelFlat : Choice("HypixelFlat") {
 
     @Suppress("unused")
     private val speedHandler = tickHandler {
-        waitUntil { isFlying }
+        tickUntil { isFlying }
 
         player.velocity = player.velocity.withStrafe(speed = 0.8)
         waitTicks(1)
         player.velocity = player.velocity.withStrafe(speed = flySpeed.toDouble())
 
-        waitUntil { player.isOnGround }
+        tickUntil { player.isOnGround }
         ModuleFly.enabled = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/polar/FlyHycraftDamage.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.pola
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.QueuePacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel10thMar.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel10thMar.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.sent
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel20thApr.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.sent
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel27thJan.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/sentinel/FlySentinel27thJan.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.sent
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/specific/FlyNcpClip.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.event.events.QueuePacketEvent
 import net.ccbluex.liquidbounce.event.events.TransferOrigin
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager
 import net.ccbluex.liquidbounce.utils.client.Timer
@@ -79,14 +80,14 @@ object FlyNcpClip : Choice("NcpClip") {
 
         // If fall damage is required, wait for damage to be true
         if (fallDamage) {
-            waitUntil { damage }
+            tickUntil { damage }
         }
 
         if (startPos == null) {
             startPosition = player.pos
 
             // Wait until there is a vertical collision
-            waitUntil { collidesVertical() }
+            tickUntil { collidesVertical() }
 
             if (clipping != 0f) {
                 network.sendPacket(
@@ -108,14 +109,14 @@ object FlyNcpClip : Choice("NcpClip") {
             }
 
             // Wait until there is no vertical collision
-            waitUntil { !collidesVertical() }
+            tickUntil { !collidesVertical() }
 
             // Proceed to jump (just like speeding up) and boost strafe entry
             player.jump()
             player.velocity = player.velocity.withStrafe(speed = (speed + additionalEntrySpeed).toDouble())
 
             // Wait until the player is not on ground
-            waitUntil { !player.isOnGround }
+            tickUntil { !player.isOnGround }
 
             // Proceed to strafe with the normal speed
             player.velocity = player.velocity.withStrafe(speed = speed.toDouble())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/verus/FlyVerusB3896Damage.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.veru
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286Teleport.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/vulcan/FlyVulcan286Teleport.kt
@@ -27,6 +27,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly.modes
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -72,12 +73,12 @@ internal object FlyVulcan286Teleport : Choice("Vulcan286-Teleport-18") {
             player.jump()
             // Ugly code, yes I know
             // If this wasn't like this, it would trigger at the same tick...
-            waitUntil { !player.isOnGround }
-            waitUntil { player.isOnGround }
+            tickUntil { !player.isOnGround }
+            tickUntil { player.isOnGround }
         }
 
         jumping = false
-        waitUntil { player.hurtTime > 0 }
+        tickUntil { player.hurtTime > 0 }
 
         // Flag to disable some checks...
         network.sendPacket(PositionAndOnGround(
@@ -88,7 +89,7 @@ internal object FlyVulcan286Teleport : Choice("Vulcan286-Teleport-18") {
             player.horizontalCollision
         ))
 
-        waitUntil { flagged }
+        tickUntil { flagged }
 
         // Cool, we took damage so lets fly
         val vector = Vec3d.fromPolar(0F, player.yaw).normalize()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.highjump
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/Matrix7145FlagLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/Matrix7145FlagLongJump.kt
@@ -2,9 +2,11 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.longjump.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.movement.longjump.ModuleLongJump
 import net.ccbluex.liquidbounce.utils.entity.airTicks
 import net.ccbluex.liquidbounce.utils.entity.withStrafe
@@ -35,7 +37,7 @@ internal object Matrix7145FlagLongJump : Choice("Matrix-7.14.5-Flag") {
         }
 
         // Wait until we are not on ground and reached the delay
-        waitUntil { !player.isOnGround && player.airTicks >= delay }
+        tickUntil { !player.isOnGround && player.airTicks >= delay }
 
         val yaw = player.yaw
         // Repeat the jump until we get at least 2 flags and have not floated for too long
@@ -46,13 +48,13 @@ internal object Matrix7145FlagLongJump : Choice("Matrix-7.14.5-Flag") {
 
             // On the first flag, we wait for the player to be on ground
             if (flagTicks == 1) {
-                waitUntil { player.isOnGround || player.airTicks >= ACCEPTED_AIR_TIME }
+                tickUntil { player.isOnGround || player.airTicks >= ACCEPTED_AIR_TIME }
             }
             waitTicks(1)
         }
 
         // Reset
-        waitUntil { player.isOnGround }
+        tickUntil { player.isOnGround }
         flagTicks = 0
         if (ModuleLongJump.autoDisable) {
             ModuleLongJump.enabled = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBow.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/modes/nocheatplus/NoCheatPlusBow.kt
@@ -23,6 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.longjump.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowSharedGrim2371.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noslow/modes/shared/NoSlowSharedGrim2371.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.noslow.modes.s
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noweb/ModuleNoWeb.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noweb/ModuleNoWeb.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.noweb
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventListener
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/sentinel/SpeedSentinelDamage.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.se
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/verus/SpeedVerusB3882.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.verus
 
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMoveEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan286.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan286.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.vulcan
 
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.SpeedBHopBase

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/vulcan/SpeedVulcan288.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.vulcan
 
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
@@ -21,6 +21,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.watchdog
 
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -120,7 +121,8 @@ class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBa
             val speed = if (velocityX == 0.0 && velocityZ == 0.0 && velocityY == -0.078375) {
                 player.sqrtSpeed.coerceAtLeast(
                     BASH *
-                        (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0))
+                        (player.getStatusEffect(StatusEffects.SPEED)?.amplifier ?: 0)
+                )
             } else {
                 player.sqrtSpeed
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVulcan288.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/modes/SpiderVulcan288.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.movement.spider.ModuleSpider
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/step/ModuleStep.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.step
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
@@ -295,7 +296,7 @@ object ModuleStep : ClientModule("Step", Category.MOVEMENT) {
                 stepping = true
                 player.velocity.y = 0.42
                 waitTicks(1)
-                if(currentStepHeight > 1.0) {
+                if (currentStepHeight > 1.0) {
                     player.velocity.y += 0.061
                 }
                 waitTicks(2)
@@ -305,7 +306,7 @@ object ModuleStep : ClientModule("Step", Category.MOVEMENT) {
                     player.velocity.y -= 0.095
                     if (currentStepHeight > 1.25) {
                         waitTicks(5)
-                        if(alternateBypass) {
+                        if (alternateBypass) {
                             player.isOnGround = true
                         } else {
                             player.velocity.y = 0.42

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiAFK.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAntiAFK.kt
@@ -22,7 +22,7 @@ import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.once
@@ -90,7 +90,7 @@ object ModuleAntiAFK : ClientModule("AntiAFK", Category.PLAYER) {
         @Suppress("unused")
         val repeatable = tickHandler {
             interactions.randomOrNull()?.let {
-                it.perform(this@tickHandler)
+                it.perform()
                 waitTicks(delay.random())
             }
         }
@@ -103,7 +103,7 @@ object ModuleAntiAFK : ClientModule("AntiAFK", Category.PLAYER) {
         @Suppress("unused", "MagicNumber")
         private enum class Interaction(
             override val choiceName: String,
-            val perform: suspend Sequence.() -> Unit,
+            val perform: suspend () -> Unit,
         ): NamedChoice {
             JUMP("Jump", {
                 once<MovementInputEvent> { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoFish.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoFish.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoRespawn.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoRespawn.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.features.module.Category

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWindCharge.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleAutoWindCharge.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
@@ -91,7 +92,7 @@ object ModuleAutoWindCharge : ClientModule("AutoWindCharge", Category.PLAYER) {
                 return RotationManager.serverRotation.angleTo(rotation) <= 1.0f
             }
 
-            waitConditional(20) {
+            tickConditional(20) {
                 CombatManager.pauseCombatForAtLeast(combatPauseTime)
                 RotationManager.setRotationTarget(
                     rotations.toRotationTarget(rotation),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastExp.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastExp.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
@@ -70,7 +71,7 @@ object ModuleFastExp : ClientModule(
         CombatManager.pauseCombatForAtLeast(combatPauseTime)
 
         if (Rotate.enabled) {
-            waitUntil {
+            tickUntil {
                 val rotation = Rotation(player.yaw, 90f)
                 RotationManager.setRotationTarget(
                     Rotate.rotations.toRotationTarget(rotation),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleFastUse.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleSmartEat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleSmartEat.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.events.PlayerInteractedItemEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
@@ -220,7 +221,7 @@ object ModuleSmartEat : ClientModule("SmartEat", Category.PLAYER) {
                 }
 
                 CombatManager.pauseCombatForAtLeast(combatPauseTime)
-                waitUntil {
+                tickUntil {
                     eat()
                     player.hungerManager.foodLevel > minHunger
                 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff.AutoSwap
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
@@ -42,7 +42,7 @@ abstract class Buff(
     /**
      * Try to run feature if possible, otherwise return false
      */
-    internal suspend fun Sequence.runIfPossible(): Boolean {
+    internal suspend fun runIfPossible(): Boolean {
         if (!enabled || !passesRequirements) {
             return false
         }
@@ -72,7 +72,7 @@ abstract class Buff(
 
     abstract fun isValidItem(stack: ItemStack, forUse: Boolean): Boolean
 
-    abstract suspend fun Sequence.execute(slot: HotbarItemSlot)
+    abstract suspend fun execute(slot: HotbarItemSlot)
 
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Drink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Drink.kt
@@ -21,9 +21,9 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
-import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.StatusEffectBasedBuff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.minecraft.item.ItemStack
@@ -34,9 +34,9 @@ internal object Drink : StatusEffectBasedBuff("Drink") {
 
     private var forceUseKey = false
 
-    override suspend fun Sequence.execute(slot: HotbarItemSlot) {
+    override suspend fun execute(slot: HotbarItemSlot) {
         forceUseKey = true
-        waitUntil { !passesRequirements }
+        tickUntil { !passesRequirements }
         forceUseKey = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Gapple.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Gapple.kt
@@ -21,9 +21,9 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
-import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.minecraft.item.ItemStack
@@ -37,9 +37,9 @@ internal object Gapple : HealthBasedBuff("Gapple") {
         return stack.isOf(Items.GOLDEN_APPLE)
     }
 
-    override suspend fun Sequence.execute(slot: HotbarItemSlot) {
+    override suspend fun execute(slot: HotbarItemSlot) {
         forceUseKey = true
-        waitUntil { !passesRequirements }
+        tickUntil { !passesRequirements }
         forceUseKey = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Head.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Head.kt
@@ -21,7 +21,7 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
-import net.ccbluex.liquidbounce.event.Sequence
+import kotlinx.coroutines.CoroutineScope
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.client.Chronometer
@@ -44,7 +44,7 @@ internal object Head : HealthBasedBuff("Head") {
         return stack.isOf(Items.PLAYER_HEAD)
     }
 
-    override suspend fun Sequence.execute(slot: HotbarItemSlot) {
+    override suspend fun execute(slot: HotbarItemSlot) {
         useHotbarSlotOrOffhand(slot)
         chronometer.reset()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
@@ -21,7 +21,8 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff.Rotations.RotationTimingMode.*
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.StatusEffectBasedBuff
@@ -80,7 +81,7 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
 
     private val allowLingering by boolean("AllowLingering", false)
 
-    override suspend fun Sequence.execute(slot: HotbarItemSlot) {
+    override suspend fun execute(slot: HotbarItemSlot) {
         // TODO: Use movement prediction to splash against walls and away from the player
         //   See https://github.com/CCBlueX/LiquidBounce/issues/2051
         var rotation = Rotation(player.yaw, (85f..90f).random())
@@ -94,12 +95,13 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
                     priority = Priority.IMPORTANT_FOR_PLAYER_LIFE
                 )
 
-                waitUntil {
+                tickUntil {
                     (currentRotation ?: player.rotation).pitch > 85
                 }
 
                 rotation = rotation.normalize()
             }
+
             ON_TICK -> {
                 rotation = rotation.normalize()
                 network.sendPacket(MovePacketType.FULL.generatePacket().apply {
@@ -107,6 +109,7 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
                     pitch = rotation.pitch
                 })
             }
+
             ON_USE -> {
                 rotation = rotation.normalize()
             }
@@ -125,7 +128,8 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
                     pitch = currentRotation?.pitch ?: player.pitch
                 })
             }
-            else -> { }
+
+            else -> {}
         }
 
         // Wait at least 1 tick to make sure, we do not continue with something else too early

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Soup.DropAfterUse.assumeEmptyBowl
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Soup.DropAfterUse.wait
@@ -48,7 +48,7 @@ internal object Soup : HealthBasedBuff("Soup") {
         return stack.isOf(Items.MUSHROOM_STEW)
     }
 
-    override suspend fun Sequence.execute(slot: HotbarItemSlot) {
+    override suspend fun execute(slot: HotbarItemSlot) {
         // Use item (be aware, it will always return false in this case)
         useHotbarSlotOrOffhand(slot)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueAction.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueAction.kt
@@ -22,13 +22,12 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.action
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.presets.AutoQueueCustom.triggers
 
 sealed class AutoQueueAction(name: String) : Choice(name) {
     override val parent: ChoiceConfigurable<*>
         get() = triggers
 
-    abstract suspend fun execute(sequence: Sequence)
+    abstract suspend fun execute()
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueActionChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueActionChat.kt
@@ -19,12 +19,10 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.actions
 
-import net.ccbluex.liquidbounce.event.Sequence
-
 object AutoQueueActionChat : AutoQueueAction("Chat") {
     private val message by text("Message", "/play solo_normal")
 
-    override suspend fun execute(sequence: Sequence) {
+    override suspend fun execute() {
         if (message.startsWith("/")) {
             network.sendCommand(message.substring(1))
         } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueActionUseItem.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/actions/AutoQueueActionUseItem.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.action
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.inventory.Slots
@@ -52,11 +52,11 @@ object AutoQueueActionUseItem : AutoQueueAction("UseItem") {
         }
     }
 
-    override suspend fun execute(sequence: Sequence) {
+    override suspend fun execute() {
         val slot = Slots.OffhandWithHotbar.findSlot(mode.activeChoice::test) ?: return
 
         SilentHotbar.selectSlotSilently(ModuleAutoQueue, slot, 20)
-        sequence.waitTicks(1)
+        waitTicks(1)
         interaction.interactItem(player, slot.useHand)
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueCustom.kt
@@ -23,9 +23,11 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.preset
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.movement.speed.ModuleSpeed
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue
@@ -91,7 +93,7 @@ object AutoQueueCustom : Choice("Custom") {
             actions.activeChoice.execute(this)
 
             if (waitUntilWorldChange) {
-                waitUntil { worldChangeOccurred }
+                tickUntil { worldChangeOccurred }
                 worldChangeOccurred = false
             }
             waitTicks(20)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueCustom.kt
@@ -90,7 +90,7 @@ object AutoQueueCustom : Choice("Custom") {
         if (trigger.isTriggered) {
             AutoQueueControl.wasInQueue = true
 
-            actions.activeChoice.execute(this)
+            actions.activeChoice.execute()
 
             if (waitUntilWorldChange) {
                 tickUntil { worldChangeOccurred }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueGommeDuels.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueGommeDuels.kt
@@ -22,7 +22,8 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.preset
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.waitSeconds
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
@@ -120,7 +121,7 @@ object AutoQueueGommeDuels : Choice("GommeDuels") {
         inMatch = false
     }
 
-    private suspend fun Sequence.handleLobbySituation() {
+    private suspend fun handleLobbySituation() {
         inMatch = false
 
         val duelsEntity = world.entities.filterIsInstance<ArmorStandEntity>().find {
@@ -142,7 +143,7 @@ object AutoQueueGommeDuels : Choice("GommeDuels") {
         waitSeconds(5)
     }
 
-    private suspend fun Sequence.handleDuelsSituation() {
+    private suspend fun handleDuelsSituation() {
         // Check if player inventory has a head
         if (!inMatch) {
             if (controlKillAura) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueHypixelSW.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoqueue/presets/AutoQueueHypixelSW.kt
@@ -24,6 +24,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.preset
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.config.types.NamedChoice
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.autoqueue.ModuleAutoQueue.presets
 import net.ccbluex.liquidbounce.utils.inventory.Slots

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/ModuleAutoShop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/ModuleAutoShop.kt
@@ -21,8 +21,9 @@ package net.ccbluex.liquidbounce.features.module.modules.player.autoshop
 import kotlinx.coroutines.delay
 import net.ccbluex.liquidbounce.config.AutoShopConfig.loadAutoShopConfig
 import net.ccbluex.liquidbounce.config.ShopConfigPreset
-import net.ccbluex.liquidbounce.event.Sequence
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.autoshop.purchasemode.NormalPurchaseMode
@@ -90,7 +91,7 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
 
         // wait after opening a shop (before the first click)
         if (!waitedBeforeTheFirstClick) {
-            waitConditional(startDelay.random()) { !isShopOpen() }
+            tickConditional(startDelay.random()) { !isShopOpen() }
             waitedBeforeTheFirstClick = true
         }
 
@@ -124,7 +125,7 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         reset()
     }
 
-    private suspend fun Sequence.doClicks(remainingElements: List<ShopElement>) {
+    private suspend fun doClicks(remainingElements: List<ShopElement>) {
         val currentElement = remainingElements.first()
         val categorySlot = currentElement.categorySlot
         val itemSlot = currentElement.itemSlot
@@ -148,7 +149,7 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         buyAllItemsInCategory(remainingElements)
     }
 
-    private suspend fun Sequence.switchCategory(nextCategorySlot: Int) {
+    private suspend fun switchCategory(nextCategorySlot: Int) {
         // we don't need to open, for example, "Blocks" category again if it's already open
         if (prevCategorySlot == nextCategorySlot) {
             return
@@ -168,11 +169,11 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         }
 
         prevCategorySlot = nextCategorySlot
-        waitUntil { !isShopOpen() || hasItemCategoryChanged(prevShopStacks) }
-        waitConditional(extraCategorySwitchDelay.random()) { !isShopOpen() }
+        tickUntil { !isShopOpen() || hasItemCategoryChanged(prevShopStacks) }
+        tickConditional(extraCategorySwitchDelay.random()) { !isShopOpen() }
     }
 
-    private suspend fun Sequence.buyItem(itemSlot: Int, shopElement: ShopElement) {
+    private suspend fun buyItem(itemSlot: Int, shopElement: ShopElement) {
         val currentInventory = autoShopInventoryManager.getInventoryItems()
 
         interaction.clickSlot(
@@ -188,11 +189,14 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         }
 
         // waits to receive items from a server after clicking before performing the next click
-        waitUntil { !isShopOpen() || hasReceivedItems(
+        tickUntil {
+            !isShopOpen() || hasReceivedItems(
                 prevInventory = currentInventory,
                 expectedItems = mapOf(
                     shopElement.item.id to shopElement.amountPerClick,
-                    shopElement.price.id to -shopElement.price.minAmount))
+                    shopElement.price.id to -shopElement.price.minAmount
+                )
+            )
         }
 
         // expects to get an item later
@@ -203,10 +207,10 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         }
 
         // waits extra ticks
-        waitConditional(NormalPurchaseMode.extraDelay.random()) { !isShopOpen() }
+        tickConditional(NormalPurchaseMode.extraDelay.random()) { !isShopOpen() }
     }
 
-    private suspend fun Sequence.buyAllItemsInCategory(remainingElements: List<ShopElement>) {
+    private suspend fun buyAllItemsInCategory(remainingElements: List<ShopElement>) {
         val simulationResult = simulateNextPurchases(remainingElements, onlySameCategory = true)
         val slotsToClick = simulationResult.first
         val prevInventory = autoShopInventoryManager.getInventoryItems()
@@ -244,11 +248,13 @@ object ModuleAutoShop : ClientModule("AutoShop", Category.PLAYER) {
         autoShopInventoryManager.addPendingItems(newPendingItems)
 
         // waits for an inventory update and for an item category update
-        waitUntil { !isShopOpen() || (hasReceivedItems(prevInventory, simulationResult.second)
-            && (nextCategorySlot == -1 || hasItemCategoryChanged(prevShopStacks))) }
+        tickUntil {
+            !isShopOpen() || (hasReceivedItems(prevInventory, simulationResult.second)
+                && (nextCategorySlot == -1 || hasItemCategoryChanged(prevShopStacks)))
+        }
 
         // waits extra ticks
-        waitConditional(extraCategorySwitchDelay.random()) { !isShopOpen() }
+        tickConditional(extraCategorySwitchDelay.random()) { !isShopOpen() }
     }
 
     private fun hasItemCategoryChanged(prevShopStacks: List<String>): Boolean {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/features/FeatureChestAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/features/FeatureChestAura.kt
@@ -21,9 +21,11 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickConditional
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.ModuleChestStealer
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
@@ -208,7 +210,7 @@ object FeatureChestAura : ToggleableConfigurable(ModuleChestStealer, "Aura", tru
             var wasInteractionSuccessful = false
 
             if (AwaitContainerSettings.enabled) {
-                waitConditional(AwaitContainerSettings.retryTimeout) {
+                tickConditional(AwaitContainerSettings.retryTimeout) {
                     val currentScreen = mc.currentScreen
                     if (currentScreen is HandledScreen<*>) { // TODO: check if the inner type matches?
                         // Interaction was successful if the inventory screen is open

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallGrim2371.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallGrim2371.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.event.EventState
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerNetworkMovementTickEvent
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.event.until
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket
@@ -61,7 +62,7 @@ internal object NoFallGrim2371 : Choice("Grim2371-1.9+") {
             player.isOnGround
         }
 
-        waitUntil { player.isOnGround }
+        tickUntil { player.isOnGround }
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallHypixelPacket.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.utils.client.MovePacketType

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallRettungsplatform.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallRettungsplatform.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/nofall/modes/NoFallSpartan524Flag.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.player.nofall.modes
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.nofall.ModuleNoFall
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.integration.backend.browser.Browser
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.isTyping
 import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.liquidbounce.additions.setPosition
+import net.ccbluex.liquidbounce.event.waitSeconds
 import net.ccbluex.liquidbounce.utils.client.asText
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.OBJECTION_AGAINST_EVERYTHING

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -18,11 +18,12 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
 import net.ccbluex.fastutil.step
 import net.ccbluex.liquidbounce.config.types.CurveValue.Axis.Companion.axis
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventListener
-import net.ccbluex.liquidbounce.event.Sequence
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
@@ -254,7 +255,8 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
                                 .append(
                                     owner.javaClass.simpleName.asText().formatted(Formatting.DARK_AQUA).italic(true)
                                 )
-                        is Sequence -> ownerName(owner.owner)
+                        is CoroutineScope -> owner.coroutineContext[CoroutineName]?.name?.asText()
+                            ?.formatted(Formatting.GRAY) ?: owner.toString().asText()
                         else -> owner.javaClass.simpleName.asText().formatted(Formatting.BLUE)
                     }
                 }
@@ -305,7 +307,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
             return
         }
 
-        debuggedGeometry[DebuggedOwner((owner as? Sequence)?.owner ?: owner, name)] = geometry
+        debuggedGeometry[DebuggedOwner(owner, name)] = geometry
     }
 
     inline fun Any.debugGeometry(name: String, lazyGeometry: () -> DebuggedGeometry) {
@@ -329,7 +331,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
             return
         }
 
-        debugParameters[DebuggedOwner((owner as? Sequence)?.owner ?: owner, name)] = ParameterCapture(value = value)
+        debugParameters[DebuggedOwner(owner, name)] = ParameterCapture(value = value)
     }
 
     inline fun Any.debugParameter(name: String, lazyValue: () -> Any?) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleBlockIn.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleBlockIn.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PlayerMovementTickEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
@@ -141,7 +142,7 @@ object ModuleBlockIn : ClientModule("BlockIn", Category.WORLD, disableOnQuit = t
     @Suppress("unused")
     private val tickHandler = tickHandler {
         blockPlacer.update(blockList)
-        waitUntil { blockPlacer.isDone() }
+        tickUntil { blockPlacer.isDone() }
 
         if (autoDisable) {
             notification(name, message("filled"), NotificationEvent.Severity.SUCCESS)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleTimer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleTimer.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/ModuleAutoFarm.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/ModuleAutoFarm.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.world.autofarm
 
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.Category

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/fucker/ModuleFucker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/fucker/ModuleFucker.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.fucker
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.CancelBlockBreakingEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/InstantNukerMode.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.nuker.mode
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.ModuleNuker.areaMode

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/LegitNukerMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/mode/LegitNukerMode.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.nuker.mode
 
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.CancelBlockBreakingEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/ModuleScaffold.kt
@@ -24,6 +24,7 @@ import net.ccbluex.fastutil.component2
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.BlockCountChangeEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerKarhu.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerKarhu.kt
@@ -2,6 +2,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.scaffold.tower
 
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.isBlockBelow
 import net.ccbluex.liquidbounce.utils.client.Timer
@@ -20,11 +21,11 @@ object ScaffoldTowerKarhu : ScaffoldTower("Karhu") {
             return@sequenceHandler
         }
 
-        waitUntil { !player.isOnGround }
+        tickUntil { !player.isOnGround }
         Timer.requestTimerSpeed(timerSpeed, Priority.IMPORTANT_FOR_USAGE_1, ModuleScaffold)
 
         if (pulldown) {
-            waitUntil { !player.isOnGround && player.velocity.y < triggerMotion }
+            tickUntil { !player.isOnGround && player.velocity.y < triggerMotion }
 
             if (!isBlockBelow) {
                 return@sequenceHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerPulldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/tower/ScaffoldTowerPulldown.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.scaffold.tower
 
 import net.ccbluex.liquidbounce.event.events.PlayerJumpEvent
 import net.ccbluex.liquidbounce.event.sequenceHandler
+import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold.isBlockBelow
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.READ_FINAL_STATE
 
@@ -34,7 +35,7 @@ object ScaffoldTowerPulldown : ScaffoldTower("Pulldown") {
         }
 
         // Wait until we can proceed with our tower
-        waitUntil { player.velocity.y < triggerMotion && !player.isOnGround }
+        tickUntil { player.velocity.y < triggerMotion && !player.isOnGround }
         if (!isBlockBelow) return@sequenceHandler
 
         player.velocity.y = -1.0

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/ModuleAutoTrap.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/traps/ModuleAutoTrap.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.world.traps
 
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickHandler

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/inventory/InventoryManager.kt
@@ -24,6 +24,7 @@ package net.ccbluex.liquidbounce.utils.inventory
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.events.ScreenEvent


### PR DESCRIPTION
Rename:
- `waitUntil` -> `tickUntil`
- `waitConditional` -> `tickConditional`
- `object SequenceManager` -> `object CoroutineTicker`

New feature:
- All original member functions of tick-based suspension in `Sequence` API are now general. Now you can use them in any coroutine (without `@RestrictsSuspension`, of course). Please still be careful if you don't use specified `CoroutineDispatcher` on these handlers. You won't want to debug with random continuation resumptions. :axocool: