### PR TITLE
refactor(Scaffold): improve Telly rotations (closes #6983)

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -200,7 +200,7 @@ fi
 
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='"-Xmx3072m" "-Xms3072m"'
 
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,

--- a/gradlew
+++ b/gradlew
@@ -200,7 +200,7 @@ fi
 
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx3072m" "-Xms3072m"'
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldTellyFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldTellyFeature.kt
@@ -61,8 +61,10 @@ object ScaffoldTellyFeature : ToggleableConfigurable(ScaffoldNormalTechnique, "T
 
     @Suppress("unused")
     private val gameHandler = handler<GameTickEvent> {
-        if (player.isOnGround) {
-            ticksUntilJump++
+        if (player.isOnGround && ticksUntilJump < jumpTicks + 10) ticksUntilJump++
+        else if (player.airTicks > straightTicks + 5) {
+            ticksUntilJump = 0
+            jumpTicks = jumpTicksOpt.random()
         }
     }
 


### PR DESCRIPTION
This seems to improve Telly speeds

I don't believe it flags any anticheats that didn't already ban Telly

I also edited the default Mac gradlew JVM args because my Mac wouldn't let me specify them (I hate MacOS)