### PR TITLE
fix(TargetHud): Hides too early

### DIFF
--- a/src-theme/src/routes/hud/elements/targethud/TargetHud.svelte
+++ b/src-theme/src/routes/hud/elements/targethud/TargetHud.svelte
@@ -15,7 +15,7 @@
     function startHideTimeout() {
         hideTimeout = setTimeout(() => {
             visible = false;
-        }, 500);
+        }, 1000);
     }
 
     listen("targetChange", (data: TargetChangeEvent) => {


### PR DESCRIPTION
In 1.9 pvp attacks happen approximately every 600 ms, which is why the target hud constantly closes and opens, which is very annoying.
This will also happen if you have a hurt time set in killaura or if your clicker speed is very low.
I chose one second because the minimum clicker speed is once per second.