### PR TITLE
refactor: Health from scoreboard and absorption

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.withColor
 import net.ccbluex.liquidbounce.utils.combat.EntityTaggingManager
 import net.ccbluex.liquidbounce.utils.entity.getActualHealth
+import net.ccbluex.liquidbounce.utils.entity.hasHealthScoreboard
 import net.ccbluex.liquidbounce.utils.entity.ping
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
@@ -118,7 +119,8 @@ class NametagTextFormatter(private val entity: Entity) {
                 return regular("")
             }
 
-            val actualHealth = entity.getActualHealth().toInt()
+            val actualHealth = (entity.getActualHealth() +
+                if (entity.hasHealthScoreboard()) 0f else entity.absorptionAmount).toInt()
 
             val healthColor = when {
                 // Perhaps you should modify the values here

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/PlayerFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/PlayerFunctions.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.features.module.modules.misc.nameprotect.sanitiz
 import net.ccbluex.liquidbounce.utils.client.interaction
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.entity.getActualHealth
+import net.ccbluex.liquidbounce.utils.entity.hasHealthScoreboard
 import net.ccbluex.liquidbounce.utils.entity.netherPosition
 import net.ccbluex.liquidbounce.utils.entity.ping
 import net.ccbluex.netty.http.model.RequestObject
@@ -108,7 +109,7 @@ data class PlayerData(
             player.health.fixNaN(),
             player.getActualHealth().fixNaN(),
             player.maxHealth.fixNaN(),
-            player.absorptionAmount.fixNaN(),
+            if (player.hasHealthScoreboard()) 0f else player.absorptionAmount.fixNaN(),
             player.armor.coerceAtMost(20),
             min(player.hungerManager.foodLevel, 20),
             player.air,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -368,12 +368,17 @@ fun LivingEntity.getEffectiveDamage(source: DamageSource, damage: Float, ignoreS
             return 0.0F
 
         if (source.isScaledWithDifficulty) {
-            if (world.difficulty == Difficulty.PEACEFUL) {
-                amount = 0.0f
-            } else if (world.difficulty == Difficulty.EASY) {
-                amount = (amount / 2.0f + 1.0f).coerceAtMost(amount)
-            } else if (world.difficulty == Difficulty.HARD) {
-                amount = amount * 3.0f / 2.0f
+            when (world.difficulty) {
+                Difficulty.PEACEFUL -> {
+                    amount = 0.0f
+                }
+                Difficulty.EASY -> {
+                    amount = (amount / 2.0f + 1.0f).coerceAtMost(amount)
+                }
+                Difficulty.HARD -> {
+                    amount = amount * 3.0f / 2.0f
+                }
+                else -> {}
             }
         }
     }
@@ -555,15 +560,18 @@ fun LivingEntity.getActualHealth(fromScoreboard: Boolean = true): Float {
     return health
 }
 
-private fun LivingEntity.getHealthFromScoreboard(): Float? {
-    val objective = world.scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.BELOW_NAME) ?: return null
-    val score = objective.scoreboard.getScore(this, objective) ?: return null
-
+fun LivingEntity.hasHealthScoreboard(): Boolean {
+    val objective = world.scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.BELOW_NAME) ?: return false
     val displayName = objective.displayName
 
-    if (score.score <= 0 || displayName?.string?.contains("❤") != true) {
-        return null
-    }
+    return (displayName?.string.let { name -> name != null && listOf("❤", "HP", "Health", "Здоровья", "Здоровье")
+        .any { name.contains(it) } })
+}
+
+private fun LivingEntity.getHealthFromScoreboard(): Float? {
+    if (!this.hasHealthScoreboard()) return null
+    val objective = world.scoreboard.getObjectiveForSlot(ScoreboardDisplaySlot.BELOW_NAME)
+    val score = objective?.scoreboard?.getScore(this, objective) ?: return null
 
     return score.score.toFloat()
 }


### PR DESCRIPTION
- Don't use the entity's absorption value if there is a scoreboard showing health because on most servers absorption is included in it.
- Add displayName variations
- Add absorption value in nametags