### PR TITLE
refactor(ElytraFly): firework mode

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/projectile/MixinFireworkRocketEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/projectile/MixinFireworkRocketEntity.java
@@ -2,6 +2,7 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.entity.projectile;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.ccbluex.liquidbounce.additions.FireworkRocketEntityAddition;
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleExtendedFirework;
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager;
 import net.ccbluex.liquidbounce.utils.aiming.features.MovementCorrection;
@@ -9,6 +10,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.FireworkRocketEntity;
 import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(FireworkRocketEntity.class)
-public abstract class MixinFireworkRocketEntity {
+public abstract class MixinFireworkRocketEntity implements FireworkRocketEntityAddition {
     @Shadow
     private LivingEntity shooter;
 
@@ -46,5 +48,10 @@ public abstract class MixinFireworkRocketEntity {
         args.set(0, rotation.x * multiplier.x + (rotation.x * multiplier.y - velocity.x) * multiplier.z);
         args.set(1, rotation.y * multiplier.x + (rotation.y * multiplier.y - velocity.y) * multiplier.z);
         args.set(2, rotation.z * multiplier.x + (rotation.z * multiplier.y - velocity.z) * multiplier.z);
+    }
+
+    @Override
+    public @Nullable LivingEntity liquidbounce$getShooter() {
+        return shooter;
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/additions/FireworkRocketEntityAddition.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/additions/FireworkRocketEntityAddition.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE")
+
+package net.ccbluex.liquidbounce.additions
+
+import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.projectile.FireworkRocketEntity
+
+interface FireworkRocketEntityAddition {
+    fun `liquidbounce$getShooter`(): LivingEntity?
+}
+
+internal inline val FireworkRocketEntity.shooter: LivingEntity?
+    get() = (this as FireworkRocketEntityAddition).`liquidbounce$getShooter`()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -18,14 +18,13 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes
 
+import net.ccbluex.liquidbounce.additions.shooter
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.inventory.*
-
 import net.minecraft.entity.projectile.FireworkRocketEntity
 import net.minecraft.item.Items
-import java.lang.reflect.Field
 
 internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
 
@@ -35,27 +34,17 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
 
     private val cooldown by int("Cooldown", 20, 0..300, "ticks")
 
-    private val slotsToSearch = if (ConsiderInventory.enabled) {
-        Slots.OffHand + Slots.Hotbar + Slots.Inventory
-    } else {
-        Slots.OffHand + Slots.Hotbar
-    }
-
-    fun getShooter(firework: FireworkRocketEntity): Any? {
-        val shooterField: Field = firework.javaClass.getDeclaredField("shooter")
-        shooterField.isAccessible = true
-        return shooterField.get(firework)
-    }
+    private val ALL_WITHOUT_ARMOR = Slots.OffHand + Slots.Hotbar + Slots.Inventory
+    private val slotsToSearch get() = if (ConsiderInventory.enabled) ALL_WITHOUT_ARMOR else Slots.OffhandWithHotbar
 
     private fun shouldUseFirework(): Boolean {
-        if (!player.isGliding or player.isUsingItem) return false
-
-        for (i in world.entities) {
-            if (i is FireworkRocketEntity) {
-                if (getShooter(i) == player) return false
+        return if (!player.isGliding or player.isUsingItem) {
+            false
+        } else {
+            world.entities.none {
+                it is FireworkRocketEntity && it.shooter === player
             }
         }
-        return true
     }
 
     private var skipTicks = 0
@@ -66,16 +55,18 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
             skipTicks--
             return@handler
         }
+
         if (shouldUseFirework()) {
             val fireworkSlot = slotsToSearch.findSlot(Items.FIREWORK_ROCKET) ?: return@handler
             if (fireworkSlot is HotbarItemSlot) {
                 useHotbarSlotOrOffhand(fireworkSlot)
             } else {
-                val actions = listOfNotNull(
-                    InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot),
-                    InventoryAction.UseItem(OffHandSlot),
-                    InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
-                )
+                val actions = ArrayList<InventoryAction>(3)
+                actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
+                actions += InventoryAction.UseItem(OffHandSlot)
+                if (!player.offHandStack.isEmpty) {
+                    actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
+                }
                 event.schedule( ConsiderInventory.constraints, actions)
             }
             skipTicks = cooldown

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -18,50 +18,64 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.modes
 
-import net.ccbluex.liquidbounce.utils.inventory.Slots
-import net.ccbluex.liquidbounce.utils.inventory.findClosestSlot
-import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.utils.inventory.*
+
+import net.minecraft.entity.projectile.FireworkRocketEntity
 import net.minecraft.item.Items
-import kotlin.math.hypot
+import java.lang.reflect.Field
 
 internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
 
-    private val minSpeed by float("MinSpeed", 0.8f, 0.1f..2.0f)
-    private val fireDelay by float("FireDelay", 1.5f, 0.5f..3.0f, "seconds")
+    private object ConsiderInventory : ToggleableConfigurable(this, "ConsiderInventory", enabled = false) {
+        val constraints = tree(PlayerInventoryConstraints())
+    }
 
-    private var lastFireworkTime = 0L
+    private val cooldown by int("Cooldown", 20, 0..300)
 
-    private fun findFireworkSlot() = Slots.OffhandWithHotbar.findClosestSlot(Items.FIREWORK_ROCKET)
+    private val slotsToSearch = if (ConsiderInventory.enabled) Slots.OffHand + Slots.Hotbar + Slots.Inventory
+    else Slots.OffHand + Slots.Hotbar
 
-    private fun getCurrentSpeed(): Double {
-        val velocity = player.velocity
-        return hypot(velocity.x, velocity.z)
+    fun getShooter(firework: FireworkRocketEntity): Any? {
+        val shooterField: Field = firework.javaClass.getDeclaredField("shooter")
+        shooterField.isAccessible = true
+        return shooterField.get(firework)
     }
 
     private fun shouldUseFirework(): Boolean {
-        if (!player.isGliding) return false
-        
-        val currentTime = System.currentTimeMillis()
-        val timeSinceLastFirework = (currentTime - lastFireworkTime) / 1000.0f
-        
-        if (timeSinceLastFirework < fireDelay) return false
-        
-        val currentSpeed = getCurrentSpeed()
-        return currentSpeed < minSpeed
+        if (!player.isGliding or player.isUsingItem) return false
+
+        for (i in world.entities) {
+            if (i is FireworkRocketEntity) {
+                if (getShooter(i) == player) return false
+            }
+        }
+        return true
     }
 
-    private fun useFirework() {
-        val fireworkSlot = findFireworkSlot() ?: return
-        
-        useHotbarSlotOrOffhand(fireworkSlot)
-        lastFireworkTime = System.currentTimeMillis()
-    }
+    private var skipTicks = 0
 
-    override fun onTick() {
-        if (!player.isGliding) return
-
+    @Suppress("unused")
+    private val scheduleInventoryActionHandler = handler<ScheduleInventoryActionEvent> { event ->
+        if (skipTicks > 0) {
+            skipTicks--
+            return@handler
+        }
         if (shouldUseFirework()) {
-            useFirework()
+            val fireworkSlot = slotsToSearch.findSlot(Items.FIREWORK_ROCKET) ?: return@handler
+            if (fireworkSlot is HotbarItemSlot) {
+                useHotbarSlotOrOffhand(fireworkSlot)
+            } else {
+                val actions = listOfNotNull(
+                    InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot),
+                    InventoryAction.UseItem(OffHandSlot),
+                    InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
+                )
+                event.schedule( ConsiderInventory.constraints, actions)
+            }
+            skipTicks = cooldown
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -35,8 +35,11 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
 
     private val cooldown by int("Cooldown", 20, 0..300, "ticks")
 
-    private val slotsToSearch = if (ConsiderInventory.enabled) Slots.OffHand + Slots.Hotbar + Slots.Inventory
-    else Slots.OffHand + Slots.Hotbar
+    private val slotsToSearch = if (ConsiderInventory.enabled) {
+        Slots.OffHand + Slots.Hotbar + Slots.Inventory
+    } else {
+        Slots.OffHand + Slots.Hotbar
+    }
 
     fun getShooter(firework: FireworkRocketEntity): Any? {
         val shooterField: Field = firework.javaClass.getDeclaredField("shooter")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.features.module.modules.movement.elytrafly.mode
 
 import net.ccbluex.liquidbounce.additions.shooter
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.inventory.*
@@ -32,7 +33,11 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
         val constraints = tree(PlayerInventoryConstraints())
     }
 
-    private val cooldown by int("Cooldown", 20, 0..300, "ticks")
+    init {
+        tree(ConsiderInventory)
+    }
+
+    private val cooldown by intRange("Cooldown", 20..20, 0..300, "ticks")
 
     private val ALL_WITHOUT_ARMOR = Slots.OffHand + Slots.Hotbar + Slots.Inventory
     private val slotsToSearch get() = if (ConsiderInventory.enabled) ALL_WITHOUT_ARMOR else Slots.OffhandWithHotbar
@@ -50,26 +55,27 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
     private var skipTicks = 0
 
     @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
+        skipTicks--
+    }
+
+    @Suppress("unused")
     private val scheduleInventoryActionHandler = handler<ScheduleInventoryActionEvent> { event ->
-        if (skipTicks > 0) {
-            skipTicks--
-            return@handler
+        if (skipTicks > 0 || !shouldUseFirework()) return@handler
+
+        val fireworkSlot = slotsToSearch.findSlot(Items.FIREWORK_ROCKET) ?: return@handler
+        if (fireworkSlot is HotbarItemSlot) {
+            useHotbarSlotOrOffhand(fireworkSlot)
+        } else {
+            val actions = ArrayList<InventoryAction>(3)
+            actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
+            actions += InventoryAction.UseItem(OffHandSlot)
+            if (!player.offHandStack.isEmpty) {
+                actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
+            }
+            event.schedule(ConsiderInventory.constraints, actions)
         }
 
-        if (shouldUseFirework()) {
-            val fireworkSlot = slotsToSearch.findSlot(Items.FIREWORK_ROCKET) ?: return@handler
-            if (fireworkSlot is HotbarItemSlot) {
-                useHotbarSlotOrOffhand(fireworkSlot)
-            } else {
-                val actions = ArrayList<InventoryAction>(3)
-                actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
-                actions += InventoryAction.UseItem(OffHandSlot)
-                if (!player.offHandStack.isEmpty) {
-                    actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
-                }
-                event.schedule( ConsiderInventory.constraints, actions)
-            }
-            skipTicks = cooldown
-        }
+        skipTicks = cooldown.random()
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -33,7 +33,7 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
         val constraints = tree(PlayerInventoryConstraints())
     }
 
-    private val cooldown by int("Cooldown", 20, 0..300)
+    private val cooldown by int("Cooldown", 20, 0..300, "ticks")
 
     private val slotsToSearch = if (ConsiderInventory.enabled) Slots.OffHand + Slots.Hotbar + Slots.Inventory
     else Slots.OffHand + Slots.Hotbar

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/elytrafly/modes/ElytraFlyModeFirework.kt
@@ -67,12 +67,11 @@ internal object ElytraFlyModeFirework : ElytraFlyMode("Firework") {
         if (fireworkSlot is HotbarItemSlot) {
             useHotbarSlotOrOffhand(fireworkSlot)
         } else {
-            val actions = ArrayList<InventoryAction>(3)
-            actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
-            actions += InventoryAction.UseItem(OffHandSlot)
-            if (!player.offHandStack.isEmpty) {
-                actions += InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot)
-            }
+            val actions = listOf<InventoryAction>(
+                InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot),
+                InventoryAction.UseItem(OffHandSlot),
+                InventoryAction.Click.performSwap(from = fireworkSlot, to = OffHandSlot),
+            )
             event.schedule(ConsiderInventory.constraints, actions)
         }
 


### PR DESCRIPTION
- Add ConsiderInventory
- Checking for already launched rockets

The speed check was removed, at least for time, because it was not working correctly and only took into account only horizontal movement.