### PR TITLE
refactor(Autobuff)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
@@ -43,7 +43,7 @@ abstract class Buff(
      * Try to run feature if possible, otherwise return false
      */
     internal suspend fun runIfPossible(): Boolean {
-        if (!enabled || !passesRequirements) {
+        if (!enabled || !passesRequirements || player.usingItem) {
             return false
         }
 
@@ -56,7 +56,7 @@ abstract class Buff(
             // Check main hand and offhand
             execute(slot)
             return true
-        } else if (AutoSwap.enabled) {
+        } else if (AutoSwap.enabled && (AutoSwap.longSwap || !isLongConsumable)) {
             // Check if we should auto swap
             // todo: do not hardcode ticksUntilReset
             SilentHotbar.selectSlotSilently(ModuleAutoBuff, slot, 300)
@@ -71,6 +71,8 @@ abstract class Buff(
     }
 
     abstract fun isValidItem(stack: ItemStack, forUse: Boolean): Boolean
+
+    open val isLongConsumable = false
 
     abstract suspend fun execute(slot: HotbarItemSlot)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
@@ -47,7 +47,8 @@ object ModuleAutoBuff : ClientModule(
         Head,
         Pot,
         Drink,
-        Gapple
+        Gapple,
+        GappleSaturation
     )
 
     init {
@@ -72,6 +73,8 @@ object ModuleAutoBuff : ClientModule(
          * How long should we wait after using the item?
          */
         val delayOut by intRange("DelayOut", 1..1, 0..20, "ticks")
+
+        val longSwap by boolean("LongSwap", true)
 
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Drink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Drink.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.StatusEffectBasedBuff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
+import net.ccbluex.liquidbounce.utils.inventory.interactItem
 import net.minecraft.item.ItemStack
 import net.minecraft.item.PotionItem
 import net.minecraft.item.SplashPotionItem
@@ -34,8 +35,11 @@ internal object Drink : StatusEffectBasedBuff("Drink") {
 
     private var forceUseKey = false
 
+    override val isLongConsumable = true
+
     override suspend fun execute(slot: HotbarItemSlot) {
         forceUseKey = true
+        interactItem(slot.useHand)
         tickUntil { !passesRequirements }
         forceUseKey = false
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Gapple.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Gapple.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
+import net.ccbluex.liquidbounce.utils.inventory.interactItem
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 
@@ -33,13 +34,16 @@ internal object Gapple : HealthBasedBuff("Gapple") {
 
     private var forceUseKey = false
 
+    override val isLongConsumable = true
+
     override fun isValidItem(stack: ItemStack, forUse: Boolean): Boolean {
         return stack.isOf(Items.GOLDEN_APPLE)
     }
 
     override suspend fun execute(slot: HotbarItemSlot) {
         forceUseKey = true
-        tickUntil { !passesRequirements }
+        interactItem(slot.useHand)
+        tickUntil { !passesRequirements || !player.isUsingItem }
         forceUseKey = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/GappleSaturation.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/GappleSaturation.kt
@@ -21,32 +21,49 @@
 
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
-import kotlinx.coroutines.CoroutineScope
-import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
+import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickUntil
+import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.Buff
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
-import net.ccbluex.liquidbounce.utils.client.Chronometer
 import net.ccbluex.liquidbounce.utils.inventory.interactItem
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 
-internal object Head : HealthBasedBuff("Head") {
+internal object GappleSaturation : Buff("GappleBySaturation") {
 
-    private val maxAbsorption by float("MaxAbsorption", 1f, 0f..8f)
-    private val cooldown by float("Cooldown", 0f, 0f..120f, "s")
-    private val chronometer = Chronometer()
+    private var forceUseKey = false
+
+    override val isLongConsumable = true
 
     override val passesRequirements: Boolean
-        get() = passesHealthRequirements
-            && chronometer.hasElapsed((cooldown * 1000).toLong())
-            && player.absorptionAmount <= maxAbsorption
+        get() {
+            val passesSaturationRequirements = 20 - player.hungerManager.saturationLevel +
+                (player.maxHealth - player.health) * 1.5f >= 9.6f && player.hungerManager.saturationLevel <= 14.9f
+            return super.passesRequirements && passesSaturationRequirements
+        }
 
     override fun isValidItem(stack: ItemStack, forUse: Boolean): Boolean {
-        return stack.isOf(Items.PLAYER_HEAD)
+        return stack.isOf(Items.GOLDEN_APPLE)
     }
 
     override suspend fun execute(slot: HotbarItemSlot) {
+        forceUseKey = true
         interactItem(slot.useHand)
-        chronometer.reset()
+        tickUntil { !passesRequirements || !player.isUsingItem }
+        forceUseKey = false
+    }
+
+    override fun onDisabled() {
+        forceUseKey = false
+        super.onDisabled()
+    }
+
+    @Suppress("unused")
+    private val keyBindIsPressedHandler = handler<KeybindIsPressedEvent> { event ->
+        if (event.keyBinding == mc.options.useKey && forceUseKey) {
+            event.isPressed = true
+        }
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
@@ -170,8 +170,7 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
     /**
      * Check if splash potion is nearby to prevent throwing a potion that is not needed
      */
-    private fun
-        isSplashNearby() =
+    private fun isSplashNearby() =
         world.entities.filterIsInstance<PotionEntity>().any {
             it.squaredDistanceTo(player) <= BENEFICIAL_SQUARE_RANGE
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Pot.kt
@@ -35,7 +35,7 @@ import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.entity.FallingPlayer
 import net.ccbluex.liquidbounce.utils.entity.rotation
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
-import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.utils.inventory.interactItem
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.minecraft.entity.AreaEffectCloudEntity
@@ -73,7 +73,7 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
             val isCloseGround = player.y - (collisionBlock?.y ?: 0) <= tillGroundDistance
 
             // Do not check for health pass requirements, because this is already done in the potion check
-            return isCloseGround && !isSplashNearby()
+            return isCloseGround && !isSplashNearby() && super.passesRequirements
         }
 
     private val tillGroundDistance by float("TillGroundDistance", 2f, 1f..5f)
@@ -115,8 +115,8 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
             }
         }
 
-        useHotbarSlotOrOffhand(
-            slot,
+        interactItem(
+            slot.useHand,
             yaw = rotation.yaw,
             pitch = rotation.pitch,
         )
@@ -170,7 +170,8 @@ internal object Pot : StatusEffectBasedBuff("Pot") {
     /**
      * Check if splash potion is nearby to prevent throwing a potion that is not needed
      */
-    private fun isSplashNearby() =
+    private fun
+        isSplashNearby() =
         world.entities.filterIsInstance<PotionEntity>().any {
             it.squaredDistanceTo(player) <= BENEFICIAL_SQUARE_RANGE
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
@@ -28,7 +28,7 @@ import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Soup.DropAfterUse.wait
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.OffHandSlot
-import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.utils.inventory.interactItem
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import net.minecraft.util.Hand
@@ -50,7 +50,7 @@ internal object Soup : HealthBasedBuff("Soup") {
 
     override suspend fun execute(slot: HotbarItemSlot) {
         // Use item (be aware, it will always return false in this case)
-        useHotbarSlotOrOffhand(slot)
+        interactItem(slot.useHand)
 
         if (DropAfterUse.enabled) {
             waitTicks(wait.random())


### PR DESCRIPTION
- Add gapple by saturation mode
- Add toggle to disable autoswap to long consumable items
- Fix that it uses wrong hand if you hold needed long consumable item in offhand and any usable item in right hand
- replace useHotbarSlotOrOffhand with interactItem because we already handle autoswap