### PR TITLE
refactor(Clicker)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
 
-import kotlinx.coroutines.CoroutineScope
 import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.KillAuraRotationsConfigurable.rotationTiming
@@ -59,7 +58,7 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
         private val ignoreOnMaceSmash by boolean("IgnoreOnMaceSmash", true)
         private val ignoreWhenExitingRange by boolean("IgnoreWhenExitingRange", true)
 
-        override fun isCooldownPassed(ticks: Int) = when {
+        override fun isCooldownPassed(ticks: Float) = when {
             super.isCooldownPassed(ticks) -> true
             ignoreOnShieldBreak && ModuleKillAura.targetTracker.target?.wouldBlockHit == true
                 && ModuleAutoWeapon.willShieldBreak -> true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -357,9 +357,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
         when (rotations.rotationTiming) {
 
-            // If our click scheduler is not going to click the moment we reach the target,
-            // we should not start aiming towards the target just yet.
-            SNAP -> if (!clickScheduler.willClickAt(ticks.coerceAtLeast(1))) {
+            SNAP -> if (clickScheduler.ticksUntilClick > ticks) {
                 return true
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -357,6 +357,8 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
         when (rotations.rotationTiming) {
 
+            // If our click scheduler is not going to click the moment we reach the target,
+            // we should not start aiming towards the target just yet.
             SNAP -> if (clickScheduler.ticksUntilClick > ticks) {
                 return true
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -110,32 +110,25 @@ open class Clicker<T>(
 
     val ticksUntilClick: Int
         get() {
-            for (i in 0 until clickArray.iterations) {
+            for (i in 0 until clickArray.array.size) {
                 if (willClickAt(i)) {
                     return i
                 }
             }
 
-            return clickArray.iterations
+            return clickArray.array.size
         }
 
     fun willClickAt(tick: Int = 1) = getClickAmount(tick) > 0
 
     fun getClickAmount(tick: Int = 0): Int {
-        if (isEnforcedClick()) {
-            return 1
-        }
-        return clickArray.get(tick)
-    }
-
-    private fun isEnforcedClick(tick: Int = 0): Boolean {
         val hasCooldown = player.hasCooldown
         debugParameter("HasCooldown") { hasCooldown }
-        if (hasCooldown && itemCooldown?.isCooldownPassed(tick) == true) {
-            return true
+        return if (hasCooldown) {
+            if (itemCooldown?.isCooldownPassed(tick) == true) 1 else 0
+        } else {
+            clickArray.get(tick)
         }
-
-        return lastClickPassed + (tick * 50L) >= 1000L
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -125,7 +125,7 @@ open class Clicker<T>(
         val hasCooldown = player.hasCooldown
         debugParameter("HasCooldown") { hasCooldown }
         return if (hasCooldown) {
-            if (itemCooldown?.isCooldownPassed(tick) == true) 1 else 0
+            if (itemCooldown?.isCooldownPassed(tick + 0.5f) == true) 1 else 0
         } else {
             clickArray.get(tick)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/Clicker.kt
@@ -124,10 +124,15 @@ open class Clicker<T>(
     fun getClickAmount(tick: Int = 0): Int {
         val hasCooldown = player.hasCooldown
         debugParameter("HasCooldown") { hasCooldown }
-        return if (hasCooldown) {
-            if (itemCooldown?.isCooldownPassed(tick + 0.5f) == true) 1 else 0
+        
+        if (hasCooldown) {
+            return if (itemCooldown?.isCooldownPassed(tick + 0.5f) == true) 1 else 0
         } else {
-            clickArray.get(tick)
+            val clicks = clickArray.get(tick)
+            if (clicks < 1) {
+                if (lastClickPassed + (tick * 50L) >= 1000L) return 1
+            }
+            return clicks
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.clicking
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.kotlin.random
-import kotlin.math.floor
+import kotlin.math.round
 
 open class ItemCooldown : Configurable("ItemCooldown", aliases = listOf("Cooldown")) {
 
@@ -32,15 +32,16 @@ open class ItemCooldown : Configurable("ItemCooldown", aliases = listOf("Cooldow
 
     private var nextCooldown = minimumCooldown.random()
 
-    open fun isCooldownPassed(ticks: Int = 0) = cooldownProgress(ticks) >= nextCooldown
+    open fun isCooldownPassed(ticks: Float = 0.5f) = cooldownProgress(ticks) >= nextCooldown
 
     /**
      * Calculates the current cooldown progress.
      *
      * This can be out of percentage range [0, 1] to allow for higher minimum cooldowns.
      */
-    fun cooldownProgress(baseTime: Int = 0) =
-        (player.lastAttackedTicks + baseTime) / floor(player.attackCooldownProgressPerTick)
+    private val tolerancy = 100f
+    fun cooldownProgress(baseTime: Float = 0.5f) =
+        round((player.lastAttackedTicks + baseTime) / player.attackCooldownProgressPerTick * tolerancy) / tolerancy
 
     /**
      * Generates a new cooldown based on the range that was set by the user.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/clicking/ItemCooldown.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.utils.clicking
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.kotlin.random
+import kotlin.math.floor
 
 open class ItemCooldown : Configurable("ItemCooldown", aliases = listOf("Cooldown")) {
 
@@ -39,7 +40,7 @@ open class ItemCooldown : Configurable("ItemCooldown", aliases = listOf("Cooldow
      * This can be out of percentage range [0, 1] to allow for higher minimum cooldowns.
      */
     fun cooldownProgress(baseTime: Int = 0) =
-        (player.lastAttackedTicks + baseTime).toFloat() / player.attackCooldownProgressPerTick
+        (player.lastAttackedTicks + baseTime) / floor(player.attackCooldownProgressPerTick)
 
     /**
      * Generates a new cooldown based on the range that was set by the user.


### PR DESCRIPTION
- Fix that snap in killaura working strange with some rotations (interpolation was just shaking, minarai was a little slower than needed), i don't know how i fixed it
- Fix that ticksUntilClick couldn't be more than 2 ticks
- Fix that getClickAmount returns clicks from clickArray if player has cooldown but it isn't passed
- Make itemCooldown faster (it still deals full damage)

And i have a question what `lastClickPassed + (tick * 50L) >= 1000L` was intended for