### PR TITLE
fix(nametags): Correct renderZ

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
@@ -107,7 +107,7 @@ object ModuleNametags : ClientModule("Nametags", Category.RENDER) {
             val pos = nametagInfo.position!!
 
             // We want nametags that are closer to the player to be rendered above nametags that are further away.
-            val renderZ = index / nametagsCount * 1000.0F
+            val renderZ = 0.01f + index / nametagsCount * 1000.0F
 
             with(nametagRenderer) {
                 drawNametag(nametagInfo, pos.copy(z = renderZ))


### PR DESCRIPTION
0.01f ensures that the minimum Z value is not 0, preventing depth conflicts