### PR TITLE
refactor(tickHandler): replace backend implementation

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
@@ -181,26 +181,26 @@ private fun <T : Event> EventListener.suspendHandlerDiscardLatest(
     }
 }
 
-enum class SuspendHandlerBehavior {
+sealed interface SuspendHandlerBehavior {
     /**
      * Starts a new job for each event.
      */
-    PARALLEL,
+    object PARALLEL : SuspendHandlerBehavior
 
     /**
      * Suspends the new event if a job is active. Thus, all events will be handled one by one.
      */
-    SUSPEND,
+    object SUSPEND : SuspendHandlerBehavior
 
     /**
      * Cancels the previous job if it's active.
      */
-    CANCEL_PREVIOUS,
+    object CANCEL_PREVIOUS : SuspendHandlerBehavior
 
     /**
      * Discards the new event if a job is active.
      */
-    DISCARD_LATEST,
+    object DISCARD_LATEST : SuspendHandlerBehavior
 }
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
@@ -67,7 +67,7 @@ inline fun <reified T : Event> EventListener.suspendHandler(
     context: CoroutineContext = EmptyCoroutineContext,
     priority: Short = 0,
     behavior: SuspendHandlerBehavior = SuspendHandlerBehavior.Parallel.Default,
-    noinline handler: suspend CoroutineScope.(T) -> Unit
+    noinline handler: SuspendableEventHandler<T>
 ): EventHook<T> {
     // Support auto-cancel
     val context = context[ContinuationInterceptor]?.let { context + wrapContinuationInterceptor(it) } ?: context
@@ -82,7 +82,7 @@ sealed interface SuspendHandlerBehavior {
         eventClass: Class<T>,
         wrappedContext: CoroutineContext,
         priority: Short,
-        handler: suspend CoroutineScope.(T) -> Unit
+        handler: SuspendableEventHandler<T>
     ): EventHook<T>
 
     /**
@@ -94,7 +94,7 @@ sealed interface SuspendHandlerBehavior {
             eventClass: Class<T>,
             wrappedContext: CoroutineContext,
             priority: Short,
-            handler: suspend CoroutineScope.(T) -> Unit
+            handler: SuspendableEventHandler<T>
         ): EventHook<T> = handler(eventClass, priority) { event ->
             eventListenerScope.launch(wrappedContext, start) {
                 handler(event)
@@ -115,7 +115,7 @@ sealed interface SuspendHandlerBehavior {
             eventClass: Class<T>,
             wrappedContext: CoroutineContext,
             priority: Short,
-            handler: suspend CoroutineScope.(T) -> Unit
+            handler: SuspendableEventHandler<T>
         ): EventHook<T> {
             var channel: Channel<T>? = null
 
@@ -152,7 +152,7 @@ sealed interface SuspendHandlerBehavior {
             eventClass: Class<T>,
             wrappedContext: CoroutineContext,
             priority: Short,
-            handler: suspend CoroutineScope.(T) -> Unit
+            handler: SuspendableEventHandler<T>
         ): EventHook<T> {
             val jobRef = atomic<Job?>(null)
             return handler(eventClass, priority) { event ->
@@ -172,7 +172,7 @@ sealed interface SuspendHandlerBehavior {
             eventClass: Class<T>,
             wrappedContext: CoroutineContext,
             priority: Short,
-            handler: suspend CoroutineScope.(T) -> Unit
+            handler: SuspendableEventHandler<T>
         ): EventHook<T> {
             val jobRef = atomic<Job?>(null)
             return handler(eventClass, priority) { event ->

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
@@ -50,7 +50,7 @@ val EventListener.eventListenerScope: CoroutineScope
             }
             + CoroutineName(it.toString()) // Name
             // Render thread + Auto cancel on not listening
-            + it.continuationInterceptor(MinecraftDispatcher)
+                + it.wrapContinuationInterceptor(MinecraftDispatcher)
         )
     }
 
@@ -66,138 +66,143 @@ val EventListener.eventListenerScope: CoroutineScope
 inline fun <reified T : Event> EventListener.suspendHandler(
     context: CoroutineContext = EmptyCoroutineContext,
     priority: Short = 0,
-    behavior: SuspendHandlerBehavior = SuspendHandlerBehavior.Parallel,
+    behavior: SuspendHandlerBehavior = SuspendHandlerBehavior.Parallel.Default,
     noinline handler: suspend CoroutineScope.(T) -> Unit
-): EventHook<T> = `@internal-suspendHandler`(T::class.java, context, priority, behavior, handler)
-
-/**
- * To prevent bytecode explosion, we use this method to register event hooks.
- */
-@Suppress("FunctionName") // Exclude from normal auto-completion
-fun <T : Event> EventListener.`@internal-suspendHandler`(
-    eventClass: Class<T>,
-    context: CoroutineContext,
-    priority: Short,
-    behavior: SuspendHandlerBehavior,
-    handler: suspend CoroutineScope.(T) -> Unit
 ): EventHook<T> {
     // Support auto-cancel
-    val context = context[ContinuationInterceptor]?.let { context + continuationInterceptor(it) } ?: context
-    return when (behavior) {
-        SuspendHandlerBehavior.Parallel -> suspendHandlerParallel(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.Suspend -> suspendHandlerSuspend(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.CancelPrevious -> suspendHandlerCancelPrevious(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.DiscardLatest -> suspendHandlerDiscardLatest(eventClass, context, priority, handler)
-    }
-}
-
-private fun <T : Event> EventListener.suspendHandlerParallel(
-    eventClass: Class<T>,
-    wrappedContext: CoroutineContext,
-    priority: Short,
-    handler: suspend CoroutineScope.(T) -> Unit
-): EventHook<T> = handler(eventClass, priority) { event ->
-    eventListenerScope.launch(wrappedContext) {
-        handler(event)
-    }
-}
-
-private fun <T : Event> EventListener.suspendHandlerSuspend(
-    eventClass: Class<T>,
-    wrappedContext: CoroutineContext,
-    priority: Short,
-    handler: suspend CoroutineScope.(T) -> Unit
-): EventHook<T> {
-    var channel: Channel<T>? = null
-
-    fun restartReceiver() {
-        channel = Channel(Channel.BUFFERED) // Default buffered
-        eventListenerScope.launch(wrappedContext) {
-            for (event in channel ?: error("Channel is null")) {
-                handler(event)
-            }
-        }.invokeOnCompletion {
-            channel?.close(it) ?: error("Channel is null")
-            channel = null
-        }
-    }
-
-    restartReceiver()
-
-    // Producer
-    return handler(eventClass, priority) { event ->
-        channel?.let {
-            eventListenerScope.launch(wrappedContext) {
-                it.send(event)
-            }
-        } ?: restartReceiver() // Old consumer has been closed
-    }
-}
-
-private fun <T : Event> EventListener.suspendHandlerCancelPrevious(
-    eventClass: Class<T>,
-    wrappedContext: CoroutineContext,
-    priority: Short,
-    handler: suspend CoroutineScope.(T) -> Unit
-): EventHook<T> {
-    val jobRef = atomic<Job?>(null)
-    return handler(eventClass, priority) { event ->
-        jobRef.getAndSet(eventListenerScope.launch(wrappedContext) {
-            handler(event)
-        })?.cancel()
-    }
-}
-
-private fun <T : Event> EventListener.suspendHandlerDiscardLatest(
-    eventClass: Class<T>,
-    wrappedContext: CoroutineContext,
-    priority: Short,
-    handler: suspend CoroutineScope.(T) -> Unit
-): EventHook<T> {
-    val jobRef = atomic<Job?>(null)
-    return handler(eventClass, priority) { event ->
-        var newJob: Job? = null
-
-        while (true) {
-            val currentJob = jobRef.value
-            if (currentJob?.isActive == true) break
-
-            if (newJob == null) {
-                newJob = eventListenerScope.launch(wrappedContext, start = CoroutineStart.LAZY) {
-                    handler(event)
-                }
-            }
-
-            if (jobRef.compareAndSet(currentJob, newJob)) {
-                newJob.start()
-                break
-            } else {
-                newJob.cancel()
-            }
-        }
+    val context = context[ContinuationInterceptor]?.let { context + wrapContinuationInterceptor(it) } ?: context
+    return with(behavior) {
+        createEventHook(T::class.java, context, priority, handler)
     }
 }
 
 sealed interface SuspendHandlerBehavior {
+
+    fun <T : Event> EventListener.createEventHook(
+        eventClass: Class<T>,
+        wrappedContext: CoroutineContext,
+        priority: Short,
+        handler: suspend CoroutineScope.(T) -> Unit
+    ): EventHook<T>
+
     /**
      * Starts a new job for each event.
      */
-    object Parallel : SuspendHandlerBehavior
+    @JvmRecord
+    data class Parallel(val start: CoroutineStart, val onCancellation: Runnable?) : SuspendHandlerBehavior {
+        override fun <T : Event> EventListener.createEventHook(
+            eventClass: Class<T>,
+            wrappedContext: CoroutineContext,
+            priority: Short,
+            handler: suspend CoroutineScope.(T) -> Unit
+        ): EventHook<T> = handler(eventClass, priority) { event ->
+            eventListenerScope.launch(wrappedContext, start) {
+                handler(event)
+            }.onCancellation(onCancellation)
+        }
+
+        companion object {
+            @JvmField
+            val Default = Parallel(CoroutineStart.DEFAULT, null)
+        }
+    }
 
     /**
      * Suspends the new event if a job is active. Thus, all events will be handled one by one.
      */
-    object Suspend : SuspendHandlerBehavior
+    object Suspend : SuspendHandlerBehavior {
+        override fun <T : Event> EventListener.createEventHook(
+            eventClass: Class<T>,
+            wrappedContext: CoroutineContext,
+            priority: Short,
+            handler: suspend CoroutineScope.(T) -> Unit
+        ): EventHook<T> {
+            var channel: Channel<T>? = null
+
+            fun restartReceiver() {
+                channel = Channel(Channel.BUFFERED) // Default buffered
+                eventListenerScope.launch(wrappedContext) {
+                    for (event in channel ?: error("Channel is null")) {
+                        handler(event)
+                    }
+                }.invokeOnCompletion {
+                    channel?.close(it) ?: error("Channel is null")
+                    channel = null
+                }
+            }
+
+            restartReceiver()
+
+            // Producer
+            return handler(eventClass, priority) { event ->
+                channel?.let {
+                    eventListenerScope.launch(wrappedContext) {
+                        it.send(event)
+                    }
+                } ?: restartReceiver() // Old consumer has been closed
+            }
+        }
+    }
 
     /**
      * Cancels the previous job if it's active.
      */
-    object CancelPrevious : SuspendHandlerBehavior
+    object CancelPrevious : SuspendHandlerBehavior {
+        override fun <T : Event> EventListener.createEventHook(
+            eventClass: Class<T>,
+            wrappedContext: CoroutineContext,
+            priority: Short,
+            handler: suspend CoroutineScope.(T) -> Unit
+        ): EventHook<T> {
+            val jobRef = atomic<Job?>(null)
+            return handler(eventClass, priority) { event ->
+                jobRef.getAndSet(eventListenerScope.launch(wrappedContext) {
+                    handler(event)
+                })?.cancel()
+            }
+        }
+    }
 
     /**
      * Discards the new event if a job is active.
      */
-    object DiscardLatest : SuspendHandlerBehavior
+    @JvmRecord
+    data class DiscardLatest(val onCancellation: Runnable? = null) : SuspendHandlerBehavior {
+        override fun <T : Event> EventListener.createEventHook(
+            eventClass: Class<T>,
+            wrappedContext: CoroutineContext,
+            priority: Short,
+            handler: suspend CoroutineScope.(T) -> Unit
+        ): EventHook<T> {
+            val jobRef = atomic<Job?>(null)
+            return handler(eventClass, priority) { event ->
+                var newJob: Job? = null
+
+                while (true) {
+                    val currentJob = jobRef.value
+                    if (currentJob?.isActive == true) break
+
+                    if (newJob == null) {
+                        newJob = eventListenerScope.launch(wrappedContext, start = CoroutineStart.LAZY) {
+                            handler(event)
+                        }.onCancellation(onCancellation)
+                    }
+
+                    if (jobRef.compareAndSet(currentJob, newJob)) {
+                        newJob.start()
+                        break
+                    } else {
+                        newJob.cancel()
+                    }
+                }
+            }
+        }
+
+        companion object {
+            @JvmField
+            val Default = DiscardLatest(null)
+        }
+    }
 }
 
 /**
@@ -263,7 +268,7 @@ suspend inline fun <reified T : Event> EventListener.waitMatchesWithTimeout(
  * the listener's running state at suspension
  * to determine whether to resume the continuation.
  */
-internal fun EventListener.continuationInterceptor(
+fun EventListener.wrapContinuationInterceptor(
     original: ContinuationInterceptor? = null,
 ): ContinuationInterceptor = original as? EventListenerRunningContinuationInterceptor
     ?: EventListenerRunningContinuationInterceptor(original, this)
@@ -317,6 +322,16 @@ private class EventListenerRunningContinuationInterceptor(
                     Result.failure(EventListenerNotListeningException(eventListener))
                 }
                 delegate.resumeWith(result)
+            }
+        }
+    }
+}
+
+private fun Job.onCancellation(runnable: Runnable?) = apply {
+    runnable?.let {
+        this.invokeOnCompletion { t ->
+            if (t is CancellationException) {
+                it.run()
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineExtensions.kt
@@ -19,14 +19,11 @@
 package net.ccbluex.liquidbounce.event
 
 import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.update
-import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.kotlin.MinecraftDispatcher
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.*
 import kotlin.time.Duration
 
@@ -64,12 +61,12 @@ val EventListener.eventListenerScope: CoroutineScope
  *
  * @param context the coroutine context to use for the job, defaults to [EmptyCoroutineContext].
  * @param priority the priority of the event hook, defaults to 0.
- * @param behavior the behavior of the event handler, defaults to [SuspendHandlerBehavior.PARALLEL].
+ * @param behavior the behavior of the event handler, defaults to [SuspendHandlerBehavior.Parallel].
  */
 inline fun <reified T : Event> EventListener.suspendHandler(
     context: CoroutineContext = EmptyCoroutineContext,
     priority: Short = 0,
-    behavior: SuspendHandlerBehavior = SuspendHandlerBehavior.PARALLEL,
+    behavior: SuspendHandlerBehavior = SuspendHandlerBehavior.Parallel,
     noinline handler: suspend CoroutineScope.(T) -> Unit
 ): EventHook<T> = `@internal-suspendHandler`(T::class.java, context, priority, behavior, handler)
 
@@ -87,10 +84,10 @@ fun <T : Event> EventListener.`@internal-suspendHandler`(
     // Support auto-cancel
     val context = context[ContinuationInterceptor]?.let { context + continuationInterceptor(it) } ?: context
     return when (behavior) {
-        SuspendHandlerBehavior.PARALLEL -> suspendHandlerParallel(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.SUSPEND -> suspendHandlerSuspend(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.CANCEL_PREVIOUS -> suspendHandlerCancelPrevious(eventClass, context, priority, handler)
-        SuspendHandlerBehavior.DISCARD_LATEST -> suspendHandlerDiscardLatest(eventClass, context, priority, handler)
+        SuspendHandlerBehavior.Parallel -> suspendHandlerParallel(eventClass, context, priority, handler)
+        SuspendHandlerBehavior.Suspend -> suspendHandlerSuspend(eventClass, context, priority, handler)
+        SuspendHandlerBehavior.CancelPrevious -> suspendHandlerCancelPrevious(eventClass, context, priority, handler)
+        SuspendHandlerBehavior.DiscardLatest -> suspendHandlerDiscardLatest(eventClass, context, priority, handler)
     }
 }
 
@@ -185,22 +182,22 @@ sealed interface SuspendHandlerBehavior {
     /**
      * Starts a new job for each event.
      */
-    object PARALLEL : SuspendHandlerBehavior
+    object Parallel : SuspendHandlerBehavior
 
     /**
      * Suspends the new event if a job is active. Thus, all events will be handled one by one.
      */
-    object SUSPEND : SuspendHandlerBehavior
+    object Suspend : SuspendHandlerBehavior
 
     /**
      * Cancels the previous job if it's active.
      */
-    object CANCEL_PREVIOUS : SuspendHandlerBehavior
+    object CancelPrevious : SuspendHandlerBehavior
 
     /**
      * Discards the new event if a job is active.
      */
-    object DISCARD_LATEST : SuspendHandlerBehavior
+    object DiscardLatest : SuspendHandlerBehavior
 }
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
@@ -133,7 +133,7 @@ fun EventListener.launchSequence(
     handler: SuspendableHandler,
 ): Job =
     eventListenerScope.launch(
-        context = continuationInterceptor(dispatcher),
+        context = wrapContinuationInterceptor(dispatcher),
         start = CoroutineStart.UNDISPATCHED
     ) {
         if (running) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/CoroutineTicker.kt
@@ -28,7 +28,6 @@ import java.util.function.IntPredicate
 import kotlin.coroutines.resume
 
 typealias SuspendableEventHandler<T> = suspend CoroutineScope.(T) -> Unit
-typealias SuspendableHandler = suspend CoroutineScope.() -> Unit
 
 object CoroutineTicker : EventListener {
 
@@ -125,26 +124,3 @@ suspend fun waitTicks(ticks: Int) {
  * Note: When TPS is not 20, this won't be actual `seconds`.
  */
 suspend fun waitSeconds(seconds: Int) = waitTicks(seconds * 20)
-
-// A special version of [suspendHandler]...
-fun EventListener.launchSequence(
-    dispatcher: CoroutineDispatcher? = null,
-    onCancellation: Runnable?,
-    handler: SuspendableHandler,
-): Job =
-    eventListenerScope.launch(
-        context = wrapContinuationInterceptor(dispatcher),
-        start = CoroutineStart.UNDISPATCHED
-    ) {
-        if (running) {
-            handler()
-        }
-    }.apply {
-        onCancellation?.let {
-            this.invokeOnCompletion { t ->
-                if (t is CancellationException) {
-                    it.run()
-                }
-            }
-        }
-    }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.event
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.features.misc.DebuggedOwner
@@ -126,7 +127,7 @@ inline fun <reified T : Event> EventListener.sequenceHandler(
 inline fun EventListener.tickHandler(
     dispatcher: CoroutineDispatcher? = null,
     onCancellation: Runnable? = null,
-    crossinline eventHandler: SuspendableHandler,
+    crossinline eventHandler: suspend CoroutineScope.() -> Unit,
 ) = suspendHandler<GameTickEvent>(
     context = wrapContinuationInterceptor(dispatcher),
     behavior = SuspendHandlerBehavior.DiscardLatest(onCancellation)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Job
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.features.misc.DebuggedOwner
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
+import java.util.concurrent.CancellationException
 import java.util.function.Consumer
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -112,7 +113,9 @@ inline fun <reified T : Event> EventListener.sequenceHandler(
     dispatcher: CoroutineDispatcher? = null,
     onCancellation: Runnable? = null,
     crossinline eventHandler: SuspendableEventHandler<T>,
-) = handler<T>(priority) { event -> launchSequence(dispatcher, onCancellation) { eventHandler(event) } }
+) = handler<T>(priority) { event ->
+    launchSequence(dispatcher, onCancellation) { eventHandler(event) }
+}
 
 /**
  * Registers a repeatable sequence which repeats the execution of code on GameTickEvent.
@@ -122,13 +125,14 @@ fun EventListener.tickHandler(
     onCancellation: Runnable? = null,
     eventHandler: SuspendableHandler,
 ): EventHook<GameTickEvent> {
-    var sequence: Job? = null
-
-    return handler<GameTickEvent> {
-        // Check if the sequence is already running (completed or null)
-        if (sequence == null || !sequence!!.isActive) {
-            sequence = launchSequence(dispatcher, onCancellation, eventHandler)
+    return suspendHandler<GameTickEvent>(
+        context = continuationInterceptor(dispatcher),
+        behavior = SuspendHandlerBehavior.DISCARD_LATEST
+    ) {
+        onCancellation?.let { r ->
+            this.coroutineContext[Job]!!.invokeOnCompletion { if (it is CancellationException) r.run() }
         }
+        eventHandler()
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -127,7 +127,7 @@ fun EventListener.tickHandler(
 ): EventHook<GameTickEvent> {
     return suspendHandler<GameTickEvent>(
         context = continuationInterceptor(dispatcher),
-        behavior = SuspendHandlerBehavior.DISCARD_LATEST
+        behavior = SuspendHandlerBehavior.DiscardLatest
     ) {
         onCancellation?.let { r ->
             this.coroutineContext[Job]!!.invokeOnCompletion { if (it is CancellationException) r.run() }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventListener.kt
@@ -19,11 +19,10 @@
 package net.ccbluex.liquidbounce.event
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineStart
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.features.misc.DebuggedOwner
 import net.ccbluex.liquidbounce.features.misc.HideAppearance.isDestructed
-import java.util.concurrent.CancellationException
 import java.util.function.Consumer
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -113,27 +112,26 @@ inline fun <reified T : Event> EventListener.sequenceHandler(
     dispatcher: CoroutineDispatcher? = null,
     onCancellation: Runnable? = null,
     crossinline eventHandler: SuspendableEventHandler<T>,
-) = handler<T>(priority) { event ->
-    launchSequence(dispatcher, onCancellation) { eventHandler(event) }
+) = suspendHandler<T>(
+    context = wrapContinuationInterceptor(dispatcher),
+    priority = priority,
+    behavior = SuspendHandlerBehavior.Parallel(CoroutineStart.UNDISPATCHED, onCancellation),
+) {
+    eventHandler(it)
 }
 
 /**
  * Registers a repeatable sequence which repeats the execution of code on GameTickEvent.
  */
-fun EventListener.tickHandler(
+inline fun EventListener.tickHandler(
     dispatcher: CoroutineDispatcher? = null,
     onCancellation: Runnable? = null,
-    eventHandler: SuspendableHandler,
-): EventHook<GameTickEvent> {
-    return suspendHandler<GameTickEvent>(
-        context = continuationInterceptor(dispatcher),
-        behavior = SuspendHandlerBehavior.DiscardLatest
-    ) {
-        onCancellation?.let { r ->
-            this.coroutineContext[Job]!!.invokeOnCompletion { if (it is CancellationException) r.run() }
-        }
-        eventHandler()
-    }
+    crossinline eventHandler: SuspendableHandler,
+) = suspendHandler<GameTickEvent>(
+    context = wrapContinuationInterceptor(dispatcher),
+    behavior = SuspendHandlerBehavior.DiscardLatest(onCancellation)
+) {
+    eventHandler()
 }
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleLiquidChat.kt
@@ -23,8 +23,7 @@ package net.ccbluex.liquidbounce.features.module.modules.client
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import net.ccbluex.liquidbounce.event.SuspendHandlerBehavior.CANCEL_PREVIOUS
-import net.ccbluex.liquidbounce.event.SuspendHandlerBehavior.DISCARD_LATEST
+import net.ccbluex.liquidbounce.event.SuspendHandlerBehavior.CancelPrevious
 import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.suspendHandler
@@ -140,7 +139,7 @@ object ModuleLiquidChat : ClientModule("LiquidChat", Category.CLIENT, hide = tru
     }
 
     @Suppress("unused")
-    private val sessionChange = suspendHandler<SessionEvent>(behavior = CANCEL_PREVIOUS) {
+    private val sessionChange = suspendHandler<SessionEvent>(behavior = CancelPrevious) {
         chatClient.reconnect()
     }
 
@@ -171,7 +170,7 @@ object ModuleLiquidChat : ClientModule("LiquidChat", Category.CLIENT, hide = tru
     }
 
     @Suppress("unused")
-    private val handleIncomingJwtToken = suspendHandler<ClientChatJwtTokenEvent>(behavior = CANCEL_PREVIOUS) { event ->
+    private val handleIncomingJwtToken = suspendHandler<ClientChatJwtTokenEvent>(behavior = CancelPrevious) { event ->
         jwtToken = event.jwt
         chatClient.reconnect()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -75,12 +75,17 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
     private val requiresKillAura by boolean("RequiresKillAura", true)
 
     private var ticksToSkip = 0
+
+    @Volatile
     private var tickBalance = 0f
     private var reachedTheLimit = false
 
-    private val tickBuffer = mutableListOf<TickData>()
+    private val tickBuffer = ArrayList<TickData>()
 
     override fun onDisabled() {
+        ticksToSkip = 0
+        tickBalance = 0f
+        reachedTheLimit = false
         tickBuffer.clear()
     }
 
@@ -193,7 +198,7 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
         if (tickBalance <= 0) {
             reachedTheLimit = true
         }
-        if (tickBalance > balanceMaxValue / 2) {
+        if (tickBalance * 2 > balanceMaxValue) {
             reachedTheLimit = false
         }
         if (tickBalance <= balanceMaxValue) {
@@ -207,6 +212,7 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
         val tickRange = 0 until min(tickBalance.toInt(), maxTicksAtATime)
         val snapshots = simulatedPlayer.getSnapshotsBetween(tickRange)
 
+        tickBuffer.ensureCapacity(snapshots.size)
         snapshots.mapTo(tickBuffer) { snapshot ->
             TickData(
                 snapshot.pos,
@@ -256,7 +262,7 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
     @Suppress("unused")
     private enum class TickBaseCall(
         override val choiceName: String,
-        val tick: () -> Unit
+        private val tick: Runnable
     ) : NamedChoice {
 
         /**
@@ -275,7 +281,9 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
          * This was the previous default behavior of the TickBase,
          * so it is kept for compatibility reasons.
          */
-        PLAYER("Player", { player.tick() })
+        PLAYER("Player", { player.tick() });
+
+        fun tick() = tick.run()
     }
 
 }


### PR DESCRIPTION
The current(replaced from Sequence API) doesn't wait 1 tick as before. Now it is migrated into new coroutine handler API.

fixes #7054 