### PR TITLE
refactor(NameProtect): reuse lists and string builders

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatScreen.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatScreen.java
@@ -21,24 +21,18 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.gui;
 
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.ChatSendEvent;
-import net.ccbluex.liquidbounce.event.events.NotificationEvent;
 import net.ccbluex.liquidbounce.features.module.modules.misc.betterchat.ModuleBetterChat;
 import net.ccbluex.liquidbounce.interfaces.ChatHudAddition;
-import net.ccbluex.liquidbounce.utils.client.ClientChat;
 import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.hud.ChatHudLine;
 import net.minecraft.client.gui.screen.ChatScreen;
-import net.minecraft.text.CharacterVisitor;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.List;
 
 @Mixin(ChatScreen.class)
 public abstract class MixinChatScreen extends MixinScreen {
@@ -97,48 +91,7 @@ public abstract class MixinChatScreen extends MixinScreen {
         if (messageParts.isEmpty())
             return;
 
-        copyMessage(messageParts, button);
-    }
-
-    @Unique
-    private void copyMessage(List<ChatHudLine.Visible> messageParts, int button) {
-        final StringBuilder builder = new StringBuilder();
-
-        CharacterVisitor visitor = (index, style, codePoint) -> {
-            builder.append((char) codePoint);
-            return true;
-        };
-
-        for (ChatHudLine.Visible line : messageParts) {
-            line.content().accept(visitor);
-        }
-
-        if (isPressed(GLFW.GLFW_KEY_LEFT_SHIFT, GLFW.GLFW_KEY_RIGHT_SHIFT) && button == GLFW.GLFW_MOUSE_BUTTON_1) {
-            client.keyboard.setClipboard(builder.toString());
-
-            if (ModuleBetterChat.Copy.INSTANCE.getNotification()) {
-                ClientChat.notification(
-                        "ChatCopy",
-                        "The line is copied",
-                        NotificationEvent.Severity.SUCCESS
-                );
-            }
-        } else if (button == GLFW.GLFW_MOUSE_BUTTON_2) {
-            if (client.currentScreen instanceof ChatScreen chat) {
-                ((MixinChatScreenAccessor) chat).getChatField().setText(builder.toString());
-            }
-        }
-    }
-
-    @Unique
-    private boolean isPressed(int... keys) {
-        for (int key : keys) {
-            if (GLFW.glfwGetKey(client.getWindow().getHandle(), key) == GLFW.GLFW_PRESS) {
-                return true;
-            }
-        }
-
-        return false;
+        ModuleBetterChat.Copy.copyMessage(messageParts, button);
     }
 
     // [0] - y,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/ModuleBetterChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/betterchat/ModuleBetterChat.kt
@@ -22,17 +22,19 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.events.ChatReceiveEvent
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
+import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.suspendHandler
 import net.ccbluex.liquidbounce.features.command.CommandManager
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.client.ModuleTranslation
-import net.ccbluex.liquidbounce.utils.client.MessageMetadata
-import net.ccbluex.liquidbounce.utils.client.chat
-import net.ccbluex.liquidbounce.utils.client.openChat
-import net.ccbluex.liquidbounce.utils.client.stripMinecraftColorCodes
+import net.ccbluex.liquidbounce.utils.client.*
+import net.ccbluex.liquidbounce.utils.collection.Pool
+import net.minecraft.client.gui.hud.ChatHudLine
 import net.minecraft.client.gui.screen.DeathScreen
+import net.minecraft.text.CharacterVisitor
+import org.lwjgl.glfw.GLFW
 
 /**
  * BetterChat Module
@@ -74,16 +76,56 @@ object ModuleBetterChat : ClientModule("BetterChat", Category.RENDER, aliases = 
 
     private val autoTranslate by multiEnumChoice<ChatReceiveEvent.ChatType>("AutoTranslate")
 
+    object Copy : ToggleableConfigurable(this, "Copy", true) {
+        private val notification by boolean("Notificate", true)
+        val highlight by boolean("Highlight", true)
+
+        @JvmStatic
+        fun copyMessage(parts: List<ChatHudLine.Visible>, button: Int) {
+            val builder = Pool.StringBuilder.take()
+
+            val visitor = CharacterVisitor { _, _, codePoint ->
+                builder.appendCodePoint(codePoint)
+                true
+            }
+
+            for (line in parts) {
+                line.content().accept(visitor)
+            }
+
+            val content = builder.toString()
+            Pool.StringBuilder.offer(builder)
+
+            if (isAnyPressed(
+                    GLFW.GLFW_KEY_LEFT_SHIFT,
+                    GLFW.GLFW_KEY_RIGHT_SHIFT
+                ) && button == GLFW.GLFW_MOUSE_BUTTON_1
+            ) {
+                mc.keyboard.clipboard = content
+
+                if (notification) {
+                    notification(
+                        "ChatCopy",
+                        "The line is copied",
+                        NotificationEvent.Severity.SUCCESS
+                    )
+                }
+            } else if (button == GLFW.GLFW_MOUSE_BUTTON_2) {
+                mc.openChat(content)
+            }
+        }
+
+        private fun isAnyPressed(vararg keys: Int): Boolean =
+            keys.any {
+                GLFW.glfwGetKey(mc.window.handle, it) == GLFW.GLFW_PRESS
+            }
+    }
+
     init {
         tree(AppendPrefix)
         tree(AppendSuffix)
         tree(AntiSpam)
         tree(Copy)
-    }
-
-    object Copy : ToggleableConfigurable(this, "Copy", true) {
-        val notification by boolean("Notificate", true)
-        val highlight by boolean("Highlight", true)
     }
 
     var antiChatClearPaused = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
@@ -33,12 +33,14 @@ import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.client.bypassesNameProtection
 import net.ccbluex.liquidbounce.utils.client.toText
 import net.ccbluex.liquidbounce.utils.collection.LfuCache
+import net.ccbluex.liquidbounce.utils.collection.Pool
+import net.minecraft.text.CharacterVisitor
 import net.minecraft.text.OrderedText
 import net.minecraft.text.Style
 import net.minecraft.text.Text
+import java.util.ArrayDeque
 
-private const val DEFAULT_CACHE_SIZE = 256
-private const val DEFAULT_BUFFER_SIZE = 64
+private const val DEFAULT_CACHE_SIZE = 512
 
 /**
  * NameProtect module
@@ -123,7 +125,19 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
     }
 
     private val stringMappingCache = LfuCache<String, String>(DEFAULT_CACHE_SIZE)
-    private val orderedTextMappingCache = LfuCache<OrderedText, OrderedText>(DEFAULT_CACHE_SIZE)
+    private val stringBuilderPool = Pool(
+        queue = ArrayDeque(),
+        initializer = ::StringBuilder,
+        finalizer = StringBuilder::clear,
+    )
+    private val orderedTextMappingCache = LfuCache<OrderedText, WrappedOrderedText>(DEFAULT_CACHE_SIZE) { _, v ->
+        mappedCharsPool.offer(v.mappedCharacters)
+    }
+    private val mappedCharsPool = Pool(
+        queue = ArrayDeque(),
+        initializer = ::ObjectArrayList,
+        finalizer = ObjectArrayList<MappedCharacter>::clear,
+    )
 
     fun replace(original: String): String =
         when {
@@ -139,7 +153,7 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             return original
         }
 
-        val output = StringBuilder(DEFAULT_BUFFER_SIZE)
+        val output = stringBuilderPool.take()
 
         var currReplacementIndex = 0
         var currentIndex = 0
@@ -163,7 +177,7 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             }
         }
 
-        return output.toString()
+        return output.toString().also { stringBuilderPool.offer(output) }
     }
 
     fun wrap(original: OrderedText): OrderedText =
@@ -176,10 +190,10 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
     /**
      * Wraps an [OrderedText] to apply name protection.
      */
-    private fun uncachedWrap(original: OrderedText): OrderedText {
-        val mappedCharacters = ObjectArrayList<MappedCharacter>(DEFAULT_BUFFER_SIZE)
+    private fun uncachedWrap(original: OrderedText): WrappedOrderedText {
+        val mappedCharacters = mappedCharsPool.take()
 
-        val originalCharacters = ObjectArrayList<MappedCharacter>(DEFAULT_BUFFER_SIZE)
+        val originalCharacters = mappedCharsPool.take()
 
         original.accept { _, style, codePoint ->
             originalCharacters += MappedCharacter(
@@ -191,8 +205,10 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             true
         }
 
-        val text = buildString(originalCharacters.size) {
-            originalCharacters.forEach { appendCodePoint(it.codePoint) }
+        val text = stringBuilderPool.use {
+            it.ensureCapacity(originalCharacters.size)
+            originalCharacters.forEach { c -> it.appendCodePoint(c.codePoint) }
+            it.toString()
         }
         val replacements = replacementMappings.findReplacements(text)
 
@@ -233,24 +249,26 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             }
         }
 
-        // Access the inner array
-        val innerMappedCharacters: Array<out Any?> = mappedCharacters.elements()
-        val size = mappedCharacters.size
+        mappedCharsPool.offer(originalCharacters)
 
-        return OrderedText { visitor ->
-            for (index in 0 until size) {
-                val char = innerMappedCharacters[index] as MappedCharacter
-                if (!visitor.accept(index, char.style, char.codePoint)) {
-                    return@OrderedText false
-                }
-            }
-
-            true
-        }
+        return WrappedOrderedText(mappedCharacters)
     }
 
     @JvmRecord
     private data class MappedCharacter(val style: Style, val bypassesNameProtection: Boolean, val codePoint: Int)
+
+    private class WrappedOrderedText(@JvmField val mappedCharacters: ObjectArrayList<MappedCharacter>) : OrderedText {
+        override fun accept(visitor: CharacterVisitor): Boolean {
+            for (index in 0 until mappedCharacters.size) {
+                val char = mappedCharacters[index] as MappedCharacter
+                if (!visitor.accept(index, char.style, char.codePoint)) {
+                    return false
+                }
+            }
+
+            return true
+        }
+    }
 }
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/nameprotect/ModuleNameProtect.kt
@@ -125,11 +125,6 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
     }
 
     private val stringMappingCache = LfuCache<String, String>(DEFAULT_CACHE_SIZE)
-    private val stringBuilderPool = Pool(
-        queue = ArrayDeque(),
-        initializer = ::StringBuilder,
-        finalizer = StringBuilder::clear,
-    )
     private val orderedTextMappingCache = LfuCache<OrderedText, WrappedOrderedText>(DEFAULT_CACHE_SIZE) { _, v ->
         mappedCharsPool.offer(v.mappedCharacters)
     }
@@ -153,7 +148,7 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             return original
         }
 
-        val output = stringBuilderPool.take()
+        val output = Pool.StringBuilder.take()
 
         var currReplacementIndex = 0
         var currentIndex = 0
@@ -177,7 +172,7 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             }
         }
 
-        return output.toString().also { stringBuilderPool.offer(output) }
+        return output.toString().also { Pool.StringBuilder.offer(output) }
     }
 
     fun wrap(original: OrderedText): OrderedText =
@@ -205,7 +200,7 @@ object ModuleNameProtect : ClientModule("NameProtect", Category.MISC) {
             true
         }
 
-        val text = stringBuilderPool.use {
+        val text = Pool.StringBuilder.use {
             it.ensureCapacity(originalCharacters.size)
             originalCharacters.forEach { c -> it.appendCodePoint(c.codePoint) }
             it.toString()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/LegacyTextSanitizer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/LegacyTextSanitizer.kt
@@ -73,11 +73,11 @@ class LegacyTextSanitizer(
     class SanitizedLegacyText(private val text: Text): OrderedText {
         override fun accept(visitor: CharacterVisitor): Boolean {
             val degenerator = LegacyTextSanitizer { style, text ->
-                var idx = 0
-
-                text.chars().forEach { codePoint ->
-                    visitor.accept(idx, style, codePoint)
-                    idx++
+                var index = 0
+                while (index < text.length) {
+                    val codePoint = text.codePointAt(index)
+                    visitor.accept(index, style, codePoint)
+                    index += Character.charCount(codePoint)
                 }
 
                 Optional.empty()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AStarPathBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/AStarPathBuilder.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.utils.block
 
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.client.world
-import net.ccbluex.liquidbounce.utils.collection.ObjectPool
+import net.ccbluex.liquidbounce.utils.collection.Pool
 import net.ccbluex.liquidbounce.utils.math.sq
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3i
@@ -138,7 +138,7 @@ interface AStarPathBuilder {
     }
 
     private fun MutableList<Node>.getAdjacentNodesDirect(node: Node) {
-        ObjectPool.MutableBlockPos.use { pos ->
+        Pool.MutableBlockPos.use { pos ->
             for (direction in directions) {
                 val adjacentPosition = pos.set(node.position, direction)
                 if (adjacentPosition.isPassable) {
@@ -149,7 +149,7 @@ interface AStarPathBuilder {
     }
 
     private fun MutableList<Node>.getAdjacentNodesDiagonal(node: Node) {
-        ObjectPool.MutableBlockPos.use { pos ->
+        Pool.MutableBlockPos.use { pos ->
             for (direction in diagonalDirections) {
                 val adjacentPosition = pos.set(node.position, direction)
                 if (adjacentPosition.isPassable &&

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/LfuCache.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/LfuCache.kt
@@ -24,13 +24,15 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
 import net.ccbluex.fastutil.fastIterator
+import java.util.function.BiConsumer
 
 /**
  * A simple least frequency used cache. Non-thread-safe.
  */
-class LfuCache<K : Any, V : Any>(
+class LfuCache<K : Any, V : Any> @JvmOverloads constructor(
     @get:JvmName("capacity")
     val capacity: Int,
+    val onDiscard: BiConsumer<K, V> = BiConsumer { _, _ -> },
 ) {
     init {
         require(capacity > 0) { "capacity should be positive" }
@@ -96,12 +98,14 @@ class LfuCache<K : Any, V : Any>(
             if (iter.hasNext()) {
                 val toRemove = iter.next()
                 iter.remove()
-                cache.remove(toRemove)
+                val removedValue = cache.remove(toRemove)!!
                 counts.removeInt(toRemove)
                 if (!iter.hasNext()) {
                     setPool.add(set)
                     entryIter.remove()
                 }
+
+                onDiscard.accept(toRemove, removedValue)
 
                 break
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/Pool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/Pool.kt
@@ -20,28 +20,31 @@
 package net.ccbluex.liquidbounce.utils.collection
 
 import net.minecraft.util.math.BlockPos
+import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.function.Consumer
+import java.util.function.Supplier
 
 /**
- * A thread-safe object pool for reusing mutable objects.
+ * A object pool for reusing mutable objects.
  *
  * @param T Type of objects to be pooled
+ * @property queue The backend queue, determines if the instance is thread-safe.
  * @property initializer Function to create new instances when pool is empty
  * @property finalizer Function to reset object state before returning to pool
  */
-class ObjectPool<T : Any> @JvmOverloads constructor(
-    private val initializer: () -> T,
-    private val finalizer: (T) -> Unit = {},
+class Pool<T : Any> @JvmOverloads constructor(
+    private val queue: Queue<T>,
+    private val initializer: Supplier<T>,
+    private val finalizer: Consumer<T> = Consumer {},
 ) {
-
-    private val pool = ConcurrentLinkedQueue<T>()
 
     /**
      * Retrieves an object from the pool or creates a new one if pool is empty
      *
      * @return Reusable object instance processed by finalizer
      */
-    fun take(): T = pool.poll() ?: initializer().apply(finalizer)
+    fun take(): T = queue.poll() ?: initializer.get()
 
     /**
      * Returns an object to the pool after processing it with the finalizer
@@ -49,7 +52,7 @@ class ObjectPool<T : Any> @JvmOverloads constructor(
      * @param value Object to be returned to the pool
      * @return True if object was successfully added to the pool (always true)
      */
-    fun offer(value: T): Boolean = pool.add(value.apply(finalizer))
+    fun offer(value: T): Boolean = queue.add(value.apply(finalizer::accept))
 
     /**
      * Scoped function that automatically returns the object to the pool after use
@@ -68,7 +71,10 @@ class ObjectPool<T : Any> @JvmOverloads constructor(
 
     companion object {
         @JvmField
-        val MutableBlockPos = ObjectPool(BlockPos::Mutable) { it.set(0, 0, 0) }
+        val MutableBlockPos = Pool(
+            queue = ConcurrentLinkedQueue(),
+            initializer = BlockPos::Mutable,
+        ) { it.set(0, 0, 0) }
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/Pool.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/collection/Pool.kt
@@ -20,6 +20,7 @@
 package net.ccbluex.liquidbounce.utils.collection
 
 import net.minecraft.util.math.BlockPos
+import java.util.ArrayDeque
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.function.Consumer
@@ -75,6 +76,15 @@ class Pool<T : Any> @JvmOverloads constructor(
             queue = ConcurrentLinkedQueue(),
             initializer = BlockPos::Mutable,
         ) { it.set(0, 0, 0) }
+
+        /**
+         * Only for render thread
+         */
+        @JvmField
+        val StringBuilder = Pool(
+            queue = ArrayDeque(),
+            initializer = ::StringBuilder,
+        ) { it.setLength(0) }
     }
 
 }


### PR DESCRIPTION
New features:
- `onDiscard` hook in `LfuCache`
- custom backend queue in `Pool`

Breaking changes:
- `ObjectPool` renamed to `Pool`