### PR TITLE
feat(Interop): client authentication

### DIFF
--- a/src-theme/src/App.svelte
+++ b/src-theme/src/App.svelte
@@ -30,9 +30,8 @@
         "/browser": Browser
     };
 
-    const url = window.location.href;
-    const staticTag = url.split("?")[1];
-    const isStatic = staticTag === "static";
+    const hash = window.location.hash;
+    const isStatic = hash.includes("?static") || hash.includes("&static");
 
     async function changeRoute(name: string) {
         cleanupListeners();

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
@@ -38,7 +38,7 @@ fun formatAvatarUrl(uuid: UUID?, username: String): String {
  *
  * @param baseUrl The base URL of the API
  */
-abstract class BaseApi(protected val baseUrl: String) {
+abstract class BaseApi(protected val baseUrl: String, val defaultHeaders: Headers = Headers.EMPTY) {
 
     /**
      * Makes a request and parses the response to the specified type
@@ -50,6 +50,7 @@ abstract class BaseApi(protected val baseUrl: String) {
         body: RequestBody? = null
     ): T = HttpClient.request("$baseUrl$endpoint", method, headers = {
         add("X-Session-Token", config.sessionToken)
+        addAll(defaultHeaders)
         headers(this)
     }, body = body).parse()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/ClientInteropServer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/ClientInteropServer.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.integration.interop
 import com.google.gson.JsonObject
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.features.marketplace.MarketplaceManager
+import net.ccbluex.liquidbounce.integration.interop.middleware.AuthMiddleware
 import net.ccbluex.liquidbounce.integration.interop.protocol.event.SocketEventListener
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.registerInteropFunctions
 import net.ccbluex.liquidbounce.integration.theme.ThemeManager
@@ -62,19 +63,22 @@ object ClientInteropServer {
     fun start() {
         runCatching {
             // RestAPI
-            httpServer.routeController.apply {
-                get("/", ::getRootResponse)
-                registerInteropFunctions(this)
+            httpServer.apply {
+                routeController.apply {
+                    get("/", ::getRootResponse)
+                    registerInteropFunctions(this)
 
-                resource("/resources/liquidbounce/themes/liquidbounce.zip").use { stream ->
-                    zip("/resource/liquidbounce", stream)
+                    resource("/resources/liquidbounce/themes/liquidbounce.zip").use { stream ->
+                        zip("/resource/liquidbounce", stream)
+                    }
+                    file("/local", ThemeManager.themesFolder)
+                    file("/marketplace", MarketplaceManager.marketplaceRoot)
                 }
-                file("/local", ThemeManager.themesFolder)
-                file("/marketplace", MarketplaceManager.marketplaceRoot)
-            }
 
-            // Add CORS middleware
-            httpServer.middleware(CorsMiddleware())
+                // Add CORS and auth middleware
+                middleware(CorsMiddleware())
+                middleware(AuthMiddleware())
+            }
 
             // Register events with @WebSocketEvent annotation
             SocketEventListener.registerAll()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/middleware/AuthMiddleware.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/middleware/AuthMiddleware.kt
@@ -1,0 +1,81 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.integration.interop.middleware
+
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.cookie.DefaultCookie
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder
+import net.ccbluex.netty.http.middleware.Middleware
+import net.ccbluex.netty.http.model.RequestContext
+import net.ccbluex.netty.http.util.httpUnauthorized
+import okhttp3.Headers.Companion.toHeaders
+import org.apache.commons.lang3.RandomStringUtils
+
+class AuthMiddleware : Middleware {
+
+    companion object {
+
+        val AUTH_CODE: String = RandomStringUtils.secure().nextAlphanumeric(16)
+        const val AUTH_COOKIE_NAME = "lb_auth"
+        const val AUTH_CODE_PARAM = "lb_code"
+
+        private val PUBLIC_PATHS = emptySet<String>()
+
+        private fun isAuthenticated(context: RequestContext): Boolean {
+            val cookieHeader = context.headers.toHeaders()[HttpHeaderNames.COOKIE.toString()] ?: return false
+
+            val cookies = ServerCookieDecoder.STRICT.decode(cookieHeader)
+            val authCookie = cookies.firstOrNull { it.name() == AUTH_COOKIE_NAME }
+
+            return authCookie?.value() == AUTH_CODE
+        }
+    }
+
+    override fun invoke(
+        context: RequestContext,
+        response: FullHttpResponse
+    ): FullHttpResponse {
+        val path = context.path
+
+        val initCode = context.params[AUTH_CODE_PARAM]
+        if (initCode != null) {
+            if (initCode != AUTH_CODE) {
+                return httpUnauthorized("Invalid authentication code")
+            }
+
+            val cookie = DefaultCookie(AUTH_COOKIE_NAME, AUTH_CODE).apply {
+                setPath("/")
+                isHttpOnly = true
+            }
+
+            response.headers().add(HttpHeaderNames.SET_COOKIE, ServerCookieEncoder.STRICT.encode(cookie))
+
+            return response
+        }
+
+        if (!PUBLIC_PATHS.contains(path) && !isAuthenticated(context)) {
+            return httpUnauthorized("Code required")
+        }
+        return response
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
@@ -19,11 +19,13 @@
 
 package net.ccbluex.liquidbounce.integration.theme
 
+import io.netty.handler.codec.http.HttpHeaderNames
 import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer
+import net.ccbluex.liquidbounce.integration.interop.middleware.AuthMiddleware
 import net.ccbluex.liquidbounce.integration.theme.component.Component
 import net.ccbluex.liquidbounce.integration.theme.component.ComponentFactory.JsonComponentFactory
 import net.ccbluex.liquidbounce.render.FontManager
@@ -34,6 +36,7 @@ import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.io.resourceToString
 import net.minecraft.client.texture.NativeImageBackedTexture
 import net.minecraft.util.Identifier
+import okhttp3.Headers
 import java.io.Closeable
 import java.io.File
 import java.io.InputStream
@@ -45,7 +48,16 @@ import java.util.*
  * Can be local from [ClientInteropServer] or remote from the internet.
  */
 @Suppress("TooManyFunctions")
-class Theme private constructor(val origin: Origin, url: String): BaseApi(url.removeSuffix("/")), Closeable {
+class Theme private constructor(val origin: Origin, url: String) :
+    BaseApi(
+        url.removeSuffix("/"),
+        defaultHeaders = Headers.Builder()
+            .add(
+                HttpHeaderNames.COOKIE.toString(),
+                "${AuthMiddleware.AUTH_COOKIE_NAME}=${AuthMiddleware.AUTH_CODE}"
+            )
+            .build()
+    ), Closeable {
 
     enum class Origin(override val choiceName: String) : NamedChoice {
         RESOURCE("resource"),
@@ -188,12 +200,11 @@ class Theme private constructor(val origin: Origin, url: String): BaseApi(url.re
     /**
      * Get the URL to the given page name in the theme.
      */
-    fun getUrl(name: String? = null, markAsStatic: Boolean = false) = "$baseUrl/#/${name.orEmpty()}".let {
-        if (markAsStatic) {
-            "$it?static"
-        } else {
-            it
-        }
+    fun getUrl(name: String? = null, markAsStatic: Boolean = false): String {
+        val baseUrlWithFragment = "$baseUrl/?${AuthMiddleware.AUTH_CODE_PARAM}=" +
+            "${AuthMiddleware.AUTH_CODE}#/${name.orEmpty()}"
+        val staticParam = if (markAsStatic) "?static" else ""
+        return "$baseUrlWithFragment$staticParam"
     }
 
     fun isSupported(name: String?) = isScreenSupported(name) || isOverlaySupported(name)
@@ -221,4 +232,3 @@ class Theme private constructor(val origin: Origin, url: String): BaseApi(url.re
     }
 
 }
-


### PR DESCRIPTION
This prevents being able to access the interop server without being an authenticated client. Using the correct URL you are still able to access it through e.g., an external browser.

Fixes https://github.com/CCBlueX/LiquidBounce/issues/7007 entirely, while also giving additional layer of protection. ~~Note though that the middleware runs after the request was processed, so this does not grantee client authorization, only prevents the client from receiving the response. For full authentication we require to make changes to https://github.com/CCBlueX/netty-httpserver to allow easy implementation.~~
Fixed by https://github.com/CCBlueX/LiquidBounce/pull/7081

Unfortunately THIS breaks existing themes when not updated.