### PR TITLE
feat(ThemeManager): set remote/development theme

### DIFF
--- a/src-theme/src/App.svelte
+++ b/src-theme/src/App.svelte
@@ -6,6 +6,7 @@
     import {cleanupListeners, listenAlways} from "./integration/ws";
     import {onMount} from "svelte";
     import {insertPersistentData} from "./integration/persistent_storage";
+    import {isStatic} from "./integration/host";
     import Inventory from "./routes/inventory/Inventory.svelte";
     import Title from "./routes/menu/title/Title.svelte";
     import Multiplayer from "./routes/menu/multiplayer/Multiplayer.svelte";
@@ -29,9 +30,6 @@
         "/disconnected": Disconnected,
         "/browser": Browser
     };
-
-    const hash = window.location.hash;
-    const isStatic = hash.includes("?static") || hash.includes("&static");
 
     async function changeRoute(name: string) {
         cleanupListeners();

--- a/src-theme/src/integration/host.ts
+++ b/src-theme/src/integration/host.ts
@@ -1,6 +1,13 @@
-const IN_DEV = false;
-const DEV_PORT = 15000;
+import {getHashParams} from './util';
 
-export const REST_BASE = IN_DEV ? `http://localhost:${DEV_PORT}` : window.location.origin;
+const hashParams = getHashParams();
+const portParam = hashParams.get('port');
+export const isStatic = hashParams.has('static');
 
-export const WS_BASE = IN_DEV ? `ws://localhost:${DEV_PORT}` : `ws://${window.location.host}`;
+export const REST_BASE = portParam
+    ? `http://localhost:${portParam}`
+    : window.location.origin;
+
+export const WS_BASE = portParam
+    ? `ws://localhost:${portParam}`
+    : `ws://${window.location.host}`;

--- a/src-theme/src/integration/util.ts
+++ b/src-theme/src/integration/util.ts
@@ -1,4 +1,4 @@
-import type { Module, GroupedModules } from "./types"
+import type {GroupedModules, Module} from "./types"
 
 export function groupByCategory(modules: Module[]): GroupedModules {
     return modules.reduce((acc: GroupedModules, current: Module) => {
@@ -36,3 +36,8 @@ export function intToRgba(value: number): number[] {
     const alpha = (value >> 24) & 0xff;
     return [red, green, blue, alpha];
 }
+
+export const getHashParams = (): URLSearchParams => {
+    const hash = window.location.hash.split('?')[1] || '';
+    return new URLSearchParams(hash);
+};

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/client/CommandClientThemeSubcommand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/client/CommandClientThemeSubcommand.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.features.command.CommandExecutor.suspendHandler
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
 import net.ccbluex.liquidbounce.features.command.preset.pagedQuery
+import net.ccbluex.liquidbounce.integration.theme.Theme
 import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.liquidbounce.utils.client.*
 import net.minecraft.text.ClickEvent
@@ -52,13 +53,19 @@ object CommandClientThemeSubcommand {
                 .autocompletedFrom { ThemeManager.themeIds }
                 .build()
         )
-        .handler {
+        .suspendHandler {
             val id = args[0] as String
-            val theme = ThemeManager.themes.find { it.metadata.id.equals(id, true) } ?:
-                throw CommandException("No theme found with name \"$id\"!".asText())
+
+            // Check if ID is a URL
+            val theme = if (id.startsWith("http")) {
+                Theme.load(id)
+            } else {
+                ThemeManager.themes.find { it.metadata.id.equals(id, true) }
+                    ?: throw CommandException("No theme found with name \"$id\"!".asText())
+            }
 
             runCatching {
-                ThemeManager.currentTheme = theme.metadata.id
+                ThemeManager.theme = theme
                 ConfigSystem.store(ThemeManager)
             }.onFailure {
                 chat(markAsError("Failed to switch theme: ${it.message}"))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/middleware/AuthMiddleware.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/middleware/AuthMiddleware.kt
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.cookie.DefaultCookie
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder
+import net.ccbluex.liquidbounce.integration.theme.ThemeManager
 import net.ccbluex.netty.http.middleware.Middleware
 import net.ccbluex.netty.http.model.RequestContext
 import net.ccbluex.netty.http.util.httpUnauthorized
@@ -72,7 +73,8 @@ class AuthMiddleware : Middleware {
             return response
         }
 
-        if (!PUBLIC_PATHS.contains(path) && !isAuthenticated(context)) {
+        if (!PUBLIC_PATHS.contains(path) && !isAuthenticated(context)
+            && !ThemeManager.theme.origin.external) {
             return httpUnauthorized("Code required")
         }
         return response

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
@@ -59,11 +59,11 @@ class Theme private constructor(val origin: Origin, url: String) :
             .build()
     ), Closeable {
 
-    enum class Origin(override val choiceName: String) : NamedChoice {
-        RESOURCE("resource"),
-        LOCAL("local"),
-        MARKETPLACE("marketplace"),
-        REMOTE("remote")
+    enum class Origin(override val choiceName: String, val external: Boolean) : NamedChoice {
+        RESOURCE("resource", false),
+        LOCAL("local", false),
+        MARKETPLACE("marketplace", false),
+        REMOTE("remote", true)
     }
 
     var metadata: ThemeMetadata
@@ -203,8 +203,12 @@ class Theme private constructor(val origin: Origin, url: String) :
     fun getUrl(name: String? = null, markAsStatic: Boolean = false): String {
         val baseUrlWithFragment = "$baseUrl/?${AuthMiddleware.AUTH_CODE_PARAM}=" +
             "${AuthMiddleware.AUTH_CODE}#/${name.orEmpty()}"
-        val staticParam = if (markAsStatic) "?static" else ""
-        return "$baseUrlWithFragment$staticParam"
+        val params = buildList {
+            if (origin.external) add("port=${ClientInteropServer.port}")
+            if (markAsStatic) add("static")
+        }.joinToString("&")
+
+        return if (params.isNotEmpty()) "$baseUrlWithFragment?$params" else baseUrlWithFragment
     }
 
     fun isSupported(name: String?) = isScreenSupported(name) || isOverlaySupported(name)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
@@ -48,7 +48,7 @@ object ThemeManager : Configurable("theme") {
     val themes = mutableListOf<Theme>()
     val themeIds get() = themes.map { theme -> theme.metadata.id }
 
-    var currentTheme by text("Theme", "liquidbounce").onChanged {
+    private var currentTheme by text("Theme", "liquidbounce").onChanged {
         // Update integration browser
         mc.execute {
             IntegrationListener.update()
@@ -59,10 +59,25 @@ object ThemeManager : Configurable("theme") {
 
     internal lateinit var includedTheme: Theme
         private set
+    /**
+     * Used for development.
+     */
+    private var temporaryTheme: Theme? = null
 
-    val theme: Theme
-        get() = themes.find { theme -> theme.metadata.id.equals(currentTheme, true) }
+    var theme: Theme
+        get() = temporaryTheme
+            ?: themes.find { theme -> theme.metadata.id.equals(currentTheme, true) }
             ?: includedTheme
+        set(value) {
+            // When external, set as a temporary theme.
+            if (value.origin.external) {
+                temporaryTheme = value
+                currentTheme = includedTheme.metadata.id
+            } else {
+                temporaryTheme = null
+                currentTheme = value.metadata.id
+            }
+        }
 
     private val takesInputHandler = InputAcceptor { mc.currentScreen != null && mc.currentScreen !is ChatScreen }
 


### PR DESCRIPTION
Allows setting a theme via URL e.g., `.client theme set http://localhost:5173/` for development purposes.