### PR TITLE
fix(MultiChooseListValue): correct set() usage to trigger UI refresh

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/MultiChooseListValue.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/MultiChooseListValue.kt
@@ -103,7 +103,7 @@ class MultiChooseListValue<T : NamedChoice>(
         }
 
         // Trigger listeners
-        set(current)
+        set(current) { }
 
         return !isActive
     }


### PR DESCRIPTION

This PR fixes an issue in `MultiChooseListValue` where the frontend UI did not update when toggling a value.

Previously, the `toggle()` method called:

```kotlin
set(current)
```

However, in the `Value` implementation, UI listeners are only triggered when the `set()` function is invoked **with a lambda argument**, such as:

```kotlin
set(current) { }
```

Without the lambda, the internal change was not executed, resulting in the UI not reflecting the updated state.