### PR TITLE
fix(Module/Freeze): prevent crash when balance ticks after position change

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -135,15 +135,18 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT, disableOnQuit = 
 
     @Suppress("unused")
     private val packetHandler = handler<PacketEvent> { event ->
-        if (event.packet is PlayerPositionLookS2CPacket && disableOnFlag) {
-            if (notification) {
-                notification(
-                    this.name,
-                    message("disabledOnFlag"),
-                    NotificationEvent.Severity.INFO
-                )
+        if (event.packet is PlayerPositionLookS2CPacket) {
+            missedOutTick = 0
+            if (disableOnFlag) {
+                if (notification) {
+                    notification(
+                        this.name,
+                        message("disabledOnFlag"),
+                        NotificationEvent.Severity.INFO
+                    )
+                }
+                enabled = false
             }
-            enabled = false
         }
     }
 


### PR DESCRIPTION
* The crash occurred because `ClientWorld.random` was accessed from multiple threads after a position correction.
* Now missed ticks are cleared to avoid `CheckedRandom` cross-thread access.