### PR TITLE
refactor(render): drop legacy custom render system code (except of FontRenderer)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -48,10 +48,10 @@ object ImmediateMode : TpAuraChoice("Immediate") {
         renderEnvironmentForWorld(matrixStack) {
             desyncPlayerPosition?.let { playerPosition ->
                 withColor(Color4b.WHITE) {
-                    drawLineStrip(listOf(
+                    drawLineStrip(
                         relativeToCamera(player.pos.add(0.0, 1.0, 0.0)).toVec3(),
                         relativeToCamera(playerPosition.add(0.0, 1.0, 0.0)).toVec3()
-                    ))
+                    )
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
@@ -32,7 +32,7 @@ import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.event.tickUntil
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.ModuleDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
@@ -187,34 +187,32 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
         val matrixStack = event.matrixStack
 
         renderEnvironmentForWorld(matrixStack) {
-            drawBoxes {
-                targetTracker.targets().forEach { entity ->
-                    val pos = entity.interpolateCurrentPosition(event.partialTicks)
-                    val eyePos = pos.add(0.0, entity.standingEyeHeight.toDouble(), 0.0)
-                    val box = Box(
-                        0.0,
-                        entity.standingEyeHeight.toDouble(),
-                        0.0,
-                        0.0,
-                        entity.standingEyeHeight.toDouble(),
-                        0.0
-                    ).expand(0.1)
+            targetTracker.targets().forEach { entity ->
+                val pos = entity.interpolateCurrentPosition(event.partialTicks)
+                val eyePos = pos.add(0.0, entity.standingEyeHeight.toDouble(), 0.0)
+                val box = Box(
+                    0.0,
+                    entity.standingEyeHeight.toDouble(),
+                    0.0,
+                    0.0,
+                    entity.standingEyeHeight.toDouble(),
+                    0.0
+                ).expand(0.1)
 
-                    val color = if (targetEntityId == entity.id) {
-                        Color4b.GREEN
-                    } else if (fightMap.contains(entity.id)) {
-                        Color4b.YELLOW
-                    } else {
-                        Color4b.RED
-                    }
+                val color = if (targetEntityId == entity.id) {
+                    Color4b.GREEN
+                } else if (fightMap.contains(entity.id)) {
+                    Color4b.YELLOW
+                } else {
+                    Color4b.RED
+                }
 
-                    withPositionRelativeToCamera(pos) {
-                        drawBox(
-                            box,
-                            color.with(a = 50),
-                            color.with(a = 150)
-                        )
-                    }
+                withPositionRelativeToCamera(pos) {
+                    drawBox(
+                        box,
+                        color.with(a = 50),
+                        color.with(a = 150)
+                    )
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
+import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.nesting.Choice
 import net.ccbluex.liquidbounce.config.types.nesting.ChoiceConfigurable
 import net.ccbluex.liquidbounce.event.events.*
@@ -128,7 +129,7 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT, disableOnQuit = 
 
         renderEnvironmentForWorld(event.matrixStack) {
             withColor(Color4b(0x00, 0x80, 0xFF, 0xFF)) {
-                drawLineStrip(positions = cachedPositions.map { relativeToCamera(it.pos).toVec3() })
+                drawLineStrip(positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() })
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -27,7 +27,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
 import net.ccbluex.liquidbounce.utils.block.ChunkScanner
@@ -105,37 +105,35 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
         ): Boolean {
             var dirty = false
 
-            drawBoxes {
-                for (blockPos in blocks) {
-                    val blockState = blockPos.getState() ?: continue
+            for (blockPos in blocks) {
+                val blockState = blockPos.getState() ?: continue
 
-                    if (blockState.isAir) {
-                        continue
-                    }
-
-                    val outlineShape = blockState.getOutlineShape(world, blockPos)
-                    val boundingBox = if (outlineShape.isEmpty) {
-                        FULL_BOX
-                    } else {
-                        outlineShape.boundingBox
-                    }
-
-                    var color = colorMode.getColor(Pair(blockPos, blockState))
-
-                    if (fullAlpha) {
-                        color = color.with(a = 255)
-                    }
-
-                    withPositionRelativeToCamera(blockPos.toVec3d()) {
-                        drawBox(
-                            boundingBox,
-                            faceColor = color,
-                            outlineColor = color.with(a = 150).takeIf { drawOutline }
-                        )
-                    }
-
-                    dirty = true
+                if (blockState.isAir) {
+                    continue
                 }
+
+                val outlineShape = blockState.getOutlineShape(world, blockPos)
+                val boundingBox = if (outlineShape.isEmpty) {
+                    FULL_BOX
+                } else {
+                    outlineShape.boundingBox
+                }
+
+                var color = colorMode.getColor(Pair(blockPos, blockState))
+
+                if (fullAlpha) {
+                    color = color.with(a = 255)
+                }
+
+                withPositionRelativeToCamera(blockPos.toVec3d()) {
+                    drawBox(
+                        boundingBox,
+                        faceColor = color,
+                        outlineColor = color.with(a = 150).takeIf { drawOutline }
+                    )
+                }
+
+                dirty = true
             }
 
             return dirty

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockOutline.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockOutline.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.render.MixinWorldRenderer
 import net.ccbluex.liquidbounce.render.drawBoxSide
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.math.Easing
@@ -111,7 +111,7 @@ object ModuleBlockOutline : ClientModule("BlockOutline", Category.RENDER, aliase
             if (sideOnly) {
                 drawBoxSide(translatedPosition, side, color, outlineColor)
             } else {
-                drawBoxes { drawBox(translatedPosition, color, outlineColor) }
+                drawBox(translatedPosition, color, outlineColor)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBreadcrumbs.kt
@@ -36,8 +36,8 @@ import net.ccbluex.liquidbounce.render.drawCustomMesh
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.utils.rainbow
-import net.minecraft.client.render.BufferBuilder
 import net.minecraft.client.render.Camera
+import net.minecraft.client.render.VertexConsumer
 import net.minecraft.client.render.VertexFormat.DrawMode
 import net.minecraft.entity.Entity
 import net.minecraft.util.math.Vec3d
@@ -152,7 +152,7 @@ object ModuleBreadcrumbs : ClientModule("Breadcrumbs", Category.RENDER, aliases 
 
     private class RenderData(
         val matrix: Matrix4f,
-        val bufferBuilder: BufferBuilder,
+        val bufferBuilder: VertexConsumer,
         val color: Vector4f,
         val lines: Boolean
     )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import net.ccbluex.fastutil.forEachFloat
+import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.fastutil.step
 import net.ccbluex.liquidbounce.config.types.CurveValue.Axis.Companion.axis
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
@@ -88,7 +89,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
 
             renderEnvironmentForWorld(event.matrixStack) {
                 withColor(Color4b.BLUE) {
-                    drawLineStrip(positions = cachedPositions.map { relativeToCamera(it.pos).toVec3() })
+                    drawLineStrip(positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() })
                 }
             }
         }
@@ -299,7 +300,7 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
                         draw(
                             process(text),
                             120f,
-                            40 + ((fontRenderer.height * 0.17f) * index).toFloat(),
+                            40 + ((fontRenderer.height * 0.17f) * index),
                             shadow = true,
                             scale = 0.17f
                         )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -25,7 +25,7 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.*
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.minecraft.entity.Entity
@@ -70,13 +70,11 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
             val filtered = world.entities.filter(::shouldRender)
 
             renderEnvironmentForWorld(matrixStack) {
-                drawBoxes {
-                    for (entity in filtered) {
-                        val pos = entity.interpolateCurrentPosition(event.partialTicks)
+                for (entity in filtered) {
+                    val pos = entity.interpolateCurrentPosition(event.partialTicks)
 
-                        withPositionRelativeToCamera(pos) {
-                            drawBox(box, baseColor, outlineColor)
-                        }
+                    withPositionRelativeToCamera(pos) {
+                        drawBox(box, baseColor, outlineColor)
                     }
                 }
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.ModuleChestStealer
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features.FeatureChestAura
 import net.ccbluex.liquidbounce.render.*
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
@@ -112,14 +112,12 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
             val queuedBoxes = collectBoxesToDraw(event)
 
             renderEnvironmentForWorld(matrixStack) {
-                drawBoxes {
-                    for ((pos, box, color) in queuedBoxes) {
-                        val baseColor = color.with(a = 50)
-                        val outlineColor = color.with(a = 100)
+                for ((pos, box, color) in queuedBoxes) {
+                    val baseColor = color.with(a = 50)
+                    val outlineColor = color.with(a = 100)
 
-                        withPositionRelativeToCamera(pos) {
-                            drawBox(box, baseColor, outlineColor.takeIf { outline })
-                        }
+                    withPositionRelativeToCamera(pos) {
+                        drawBox(box, baseColor, outlineColor.takeIf { outline })
                     }
                 }
             }
@@ -187,32 +185,30 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
             renderEnvironmentForWorld(event.matrixStack) {
                 // non-model blocks are already processed by WorldRenderer where we injected code which renders
                 // their outline
-                drawBoxes {
-                    for ((pos, type) in StorageScanner.iterate()) {
-                        if (!type.enabled) continue
+                for ((pos, type) in StorageScanner.iterate()) {
+                    if (!type.enabled) continue
 
-                        val state = pos.getState() ?: continue
+                    val state = pos.getState() ?: continue
 
-                        // non-model blocks are already processed by WorldRenderer where we injected code which renders
-                        // their outline
-                        if (state.renderType != BlockRenderType.MODEL || state.isAir) {
-                            continue
-                        }
-
-                        val outlineShape = state.getOutlineShape(world, pos)
-
-                        val boundingBox = if (outlineShape.isEmpty) {
-                            FULL_BOX
-                        } else {
-                            outlineShape.boundingBox
-                        }
-
-                        withPosition(relativeToCamera(Vec3d.of(pos))) {
-                            drawBox(boundingBox, type.color)
-                        }
-
-                        event.markDirty()
+                    // non-model blocks are already processed by WorldRenderer where we injected code which renders
+                    // their outline
+                    if (state.renderType != BlockRenderType.MODEL || state.isAir) {
+                        continue
                     }
+
+                    val outlineShape = state.getOutlineShape(world, pos)
+
+                    val boundingBox = if (outlineShape.isEmpty) {
+                        FULL_BOX
+                    } else {
+                        outlineShape.boundingBox
+                    }
+
+                    withPosition(relativeToCamera(Vec3d.of(pos))) {
+                        drawBox(boundingBox, type.color)
+                    }
+
+                    event.markDirty()
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.features.module.modules.render.esp.modes
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.esp.ModuleESP.getColor
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.entity.RenderedEntities
@@ -44,21 +44,19 @@ object EspBoxMode : EspMode("Box") {
         }
 
         renderEnvironmentForWorld(matrixStack) {
-            drawBoxes {
-                entitiesWithBoxes.forEach { (entity, box) ->
-                    val pos = entity.interpolateCurrentPosition(event.partialTicks)
-                    val color = getColor(entity)
+            entitiesWithBoxes.forEach { (entity, box) ->
+                val pos = entity.interpolateCurrentPosition(event.partialTicks)
+                val color = getColor(entity)
 
-                    val baseColor = color.with(a = 50)
-                    val outlineColor = color.with(a = 100)
+                val baseColor = color.with(a = 50)
+                val outlineColor = color.with(a = 100)
 
-                    withPositionRelativeToCamera(pos) {
-                        drawBox(
-                            box,
-                            baseColor,
-                            outlineColor.takeIf { outline }
-                        )
-                    }
+                withPositionRelativeToCamera(pos) {
+                    drawBox(
+                        box,
+                        baseColor,
+                        outlineColor.takeIf { outline }
+                    )
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
@@ -177,16 +177,14 @@ object ModuleMurderMystery : ClientModule("MurderMystery", Category.RENDER) {
         val matrixStack = event.matrixStack
 
         renderEnvironmentForWorld(matrixStack) {
-            drawBoxes {
-                val box = Box(-0.6, 0.0, -0.6, 0.6, 2.5, 0.6)
-                val pos = armorStandEntity.interpolateCurrentPosition(event.partialTicks)
+            val box = Box(-0.6, 0.0, -0.6, 0.6, 2.5, 0.6)
+            val pos = armorStandEntity.interpolateCurrentPosition(event.partialTicks)
 
-                withPositionRelativeToCamera(pos) {
-                    drawBox(
-                        box,
-                        Color4b(127, 255, 212, 100), Color4b(0, 255, 255)
-                    )
-                }
+            withPositionRelativeToCamera(pos) {
+                drawBox(
+                    box,
+                    Color4b(127, 255, 212, 100), Color4b(0, 255, 255)
+                )
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -20,16 +20,16 @@ package net.ccbluex.liquidbounce.features.module.modules.render.nametags
 
 import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.liquidbounce.render.RenderEnvironment
-import net.ccbluex.liquidbounce.render.VertexInputType
-import net.ccbluex.liquidbounce.render.drawCustomMesh
+import net.ccbluex.liquidbounce.render.drawColoredQuad
+import net.ccbluex.liquidbounce.render.drawColoredQuadOutlines
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.font.FontRendererBuffers
 import net.ccbluex.liquidbounce.render.engine.font.processor.TextProcessor.ProcessedText
 import net.ccbluex.liquidbounce.render.engine.type.Rect
+import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.item.getEnchantment
 import net.ccbluex.liquidbounce.utils.item.getEnchantmentCount
 import net.ccbluex.liquidbounce.utils.kotlin.LruCache
-import net.minecraft.client.render.VertexFormat.DrawMode
 import net.minecraft.enchantment.Enchantment
 import net.minecraft.enchantment.Enchantments
 import net.minecraft.entity.EquipmentSlot
@@ -324,16 +324,9 @@ object NametagEnchantmentRenderer {
         rect: Rect,
         color: Color4b
     ) {
-        val argb = color.toARGB()
-        drawCustomMesh(
-            DrawMode.QUADS,
-            VertexInputType.PosColor,
-        ) { matrix ->
-            vertex(matrix, rect.x1, rect.y1, 0.0f).color(argb)
-            vertex(matrix, rect.x1, rect.y2, 0.0f).color(argb)
-            vertex(matrix, rect.x2, rect.y2, 0.0f).color(argb)
-            vertex(matrix, rect.x2, rect.y1, 0.0f).color(argb)
-        }
+        val leftTop = Vec3(rect.x1, rect.y1, 0F)
+        val rightBottom = Vec3(rect.x2, rect.y2, 0F)
+        drawColoredQuad(leftTop, rightBottom, color.toARGB())
     }
 
     private fun RenderEnvironment.drawEnchantmentColumns(
@@ -370,36 +363,16 @@ object NametagEnchantmentRenderer {
 
     private fun drawGroupBorder(env: RenderEnvironment, rect: Rect) {
         // Drawing a semi-transparent background instead of just lines for better visibility
-        env.drawCustomMesh(
-            DrawMode.QUADS,
-            VertexInputType.PosColor,
-        ) { matrix ->
-            val bgColor = Color4b.BLACK.with(a = 120).toARGB()
+        val leftTop = Vec3(rect.x1, rect.y1, 0F)
+        val rightBottom = Vec3(rect.x2, rect.y2, 0F)
+        env.drawColoredQuad(
+            leftTop, rightBottom,
+            Color4b.BLACK.with(a = 120).toARGB(),
+        )
 
-            vertex(matrix, rect.x1, rect.y1, 0.0f).color(bgColor)
-            vertex(matrix, rect.x1, rect.y2, 0.0f).color(bgColor)
-            vertex(matrix, rect.x2, rect.y2, 0.0f).color(bgColor)
-            vertex(matrix, rect.x2, rect.y1, 0.0f).color(bgColor)
-        }
-
-        // Still drawing the border lines
-        env.drawCustomMesh(
-            DrawMode.DEBUG_LINES,
-            VertexInputType.PosColor,
-        ) { matrix ->
-            val color = Color4b.RED.toARGB()
-
-            vertex(matrix, rect.x1, rect.y1, 0.0f).color(color)
-            vertex(matrix, rect.x2, rect.y1, 0.0f).color(color)
-
-            vertex(matrix, rect.x2, rect.y1, 0.0f).color(color)
-            vertex(matrix, rect.x2, rect.y2, 0.0f).color(color)
-
-            vertex(matrix, rect.x2, rect.y2, 0.0f).color(color)
-            vertex(matrix, rect.x1, rect.y2, 0.0f).color(color)
-
-            vertex(matrix, rect.x1, rect.y2, 0.0f).color(color)
-            vertex(matrix, rect.x1, rect.y1, 0.0f).color(color)
-        }
+        env.drawColoredQuadOutlines(
+            leftTop, rightBottom,
+            Color4b.RED.toARGB(),
+        )
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -46,7 +46,7 @@ import org.joml.component2
 import kotlin.math.hypot
 
 private object EnchantmentDisplayHelper {
-    private val enchantmentAbbreviationCache = LruCache<RegistryKey<Enchantment>, String>(100)
+    private val enchantmentAbbreviationCache = LruCache<RegistryKey<Enchantment>, String>(128)
 
     private val knownCurses = setOf(
         Enchantments.BINDING_CURSE,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -148,8 +148,7 @@ object NametagEnchantmentRenderer {
         val width: Float
     )
 
-    fun drawEnchantments(
-        env: RenderEnvironment,
+    fun RenderEnvironment.drawEnchantments(
         itemStack: ItemStack,
         x: Float,
         y: Float,
@@ -166,7 +165,7 @@ object NametagEnchantmentRenderer {
 
         RenderSystem.enableBlend()
         RenderSystem.defaultBlendFunc()
-        renderEnchantmentColumn(env, cells, x, y, fontRenderer)
+        renderEnchantmentColumn(cells, x, y, fontRenderer)
     }
 
     fun drawEntityEnchantments(
@@ -204,7 +203,7 @@ object NametagEnchantmentRenderer {
         if (columnData.isNotEmpty()) {
             // Add this position to the drawn areas list
             ModuleNametags.drawnEnchantmentAreas.add(Vector2f(worldX, worldY))
-            drawEnchantmentColumns(env, worldX, worldY, fontRenderer, columnData)
+            env.drawEnchantmentColumns(worldX, worldY, fontRenderer, columnData)
         }
     }
 
@@ -280,8 +279,7 @@ object NametagEnchantmentRenderer {
         )
     }
 
-    private fun renderEnchantmentColumn(
-        env: RenderEnvironment,
+    private fun RenderEnvironment.renderEnchantmentColumn(
         cells: List<EnchantCell>,
         x: Float,
         y: Float,
@@ -302,7 +300,7 @@ object NametagEnchantmentRenderer {
             )
             val bgColor = if (cell.isCurse) BG_COLOR_CURSE else BG_COLOR_NORMAL
 
-            drawCellBackground(env, rect, bgColor)
+            drawCellBackground(rect, bgColor)
 
             val textX = cellX + (cellWidth - cell.textWidth * FIXED_SCALE) / 2
             val textY = cellY + PADDING + (LINE_HEIGHT - (ModuleNametags.fontRenderer.height * FIXED_SCALE)) / 2
@@ -317,16 +315,17 @@ object NametagEnchantmentRenderer {
             )
         }
 
-        ModuleNametags.fontRenderer.commit(env, fontRenderer)
+        with(ModuleNametags.fontRenderer) {
+            commit(fontRenderer)
+        }
     }
 
-    private fun drawCellBackground(
-        env: RenderEnvironment,
+    private fun RenderEnvironment.drawCellBackground(
         rect: Rect,
         color: Color4b
     ) {
         val argb = color.toARGB()
-        env.drawCustomMesh(
+        drawCustomMesh(
             DrawMode.QUADS,
             VertexInputType.PosColor,
         ) { matrix ->
@@ -337,8 +336,7 @@ object NametagEnchantmentRenderer {
         }
     }
 
-    private fun drawEnchantmentColumns(
-        env: RenderEnvironment,
+    private fun RenderEnvironment.drawEnchantmentColumns(
         x: Float,
         y: Float,
         fontRenderer: FontRendererBuffers,
@@ -360,12 +358,12 @@ object NametagEnchantmentRenderer {
             y + maxColumnHeight + FRAME_MARGIN
         )
 
-        drawGroupBorder(env, groupRect)
+        drawGroupBorder(this, groupRect)
 
         var columnX = x - halfTotalWidth
         columnData.forEach { column ->
             val columnCenterX = columnX + column.width / 2
-            renderEnchantmentColumn(env, column.cells, columnCenterX, y, fontRenderer)
+            renderEnchantmentColumn(column.cells, columnCenterX, y, fontRenderer)
             columnX += column.width + COLUMN_SPACING
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -137,36 +137,18 @@ object NametagEnchantmentRenderer {
         mc.world?.registryManager?.getOrThrow(RegistryKeys.ENCHANTMENT)?.keys?.toList() ?: emptyList()
     }
 
+    @JvmRecord
     private data class EnchantCell(
         val processedText: ProcessedText,
         val textWidth: Float,
         val isCurse: Boolean
     )
 
+    @JvmRecord
     private data class EnchantColumn(
         val cells: List<EnchantCell>,
         val width: Float
     )
-
-    fun RenderEnvironment.drawEnchantments(
-        itemStack: ItemStack,
-        x: Float,
-        y: Float,
-        fontRenderer: FontRendererBuffers
-    ) {
-        if (itemStack.isEmpty || !NametagShowOptions.ENCHANTMENTS.isShowing() || itemStack.getEnchantmentCount() <= 0) {
-            return
-        }
-
-        val cells = processItemEnchantments(itemStack)
-        if (cells.isEmpty()) {
-            return
-        }
-
-        RenderSystem.enableBlend()
-        RenderSystem.defaultBlendFunc()
-        renderEnchantmentColumn(cells, x, y, fontRenderer)
-    }
 
     fun drawEntityEnchantments(
         env: RenderEnvironment,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
@@ -35,19 +35,6 @@ private const val ITEM_SCALE: Float = 1.0F
 
 class NametagRenderer {
 
-    private val quadBuffers =
-        RenderBufferBuilder(
-            VertexFormat.DrawMode.QUADS,
-            VertexInputType.Pos,
-            RenderBufferBuilder.TESSELATOR_A,
-        )
-    private val lineBuffers =
-        RenderBufferBuilder(
-            VertexFormat.DrawMode.DEBUG_LINES,
-            VertexInputType.Pos,
-            RenderBufferBuilder.TESSELATOR_B,
-        )
-
     private val dc = newDrawContext()
 
     private val fontBuffers = FontRendererBuffers()
@@ -78,10 +65,14 @@ class NametagRenderer {
         val q1 = Vec3(-0.1f * fontSize, ModuleNametags.fontRenderer.height * -0.1f, 0f)
         val q2 = Vec3(x + 0.2f * fontSize, ModuleNametags.fontRenderer.height * 1.1f, 0f)
 
-        quadBuffers.drawQuad(this@drawNametag, q1, q2)
+        withColor(Color4b.BLACK.copy(a = 120)) {
+            drawQuad(q1, q2)
+        }
 
         if (NametagShowOptions.BORDER.isShowing()) {
-            lineBuffers.drawQuadOutlines(this@drawNametag, q1, q2)
+            withColor(Color4b.BLACK) {
+                drawQuadOutlines(q1, q2)
+            }
         }
 
         if (NametagShowOptions.ITEMS.isShowing()) {
@@ -151,12 +142,6 @@ class NametagRenderer {
             GL11.GL_ZERO
         )
 
-        env.withColor(Color4b(0, 0, 0, 120)) {
-            quadBuffers.draw()
-        }
-        env.withColor(Color4b(0, 0, 0, 255)) {
-            lineBuffers.draw()
-        }
         env.withColor(Color4b.WHITE) {
             fontBuffers.draw()
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
@@ -24,7 +24,6 @@ import net.ccbluex.liquidbounce.render.engine.font.FontRendererBuffers
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.client.mc
-import net.minecraft.client.render.VertexFormat
 import net.minecraft.entity.LivingEntity
 import net.minecraft.item.ItemStack
 import org.lwjgl.opengl.GL11

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
@@ -65,8 +65,16 @@ class NametagRenderer {
         val q1 = Vec3(-0.1f * fontSize, ModuleNametags.fontRenderer.height * -0.1f, 0f)
         val q2 = Vec3(x + 0.2f * fontSize, ModuleNametags.fontRenderer.height * 1.1f, 0f)
 
-        withColor(Color4b.BLACK.copy(a = 120)) {
-            drawQuad(q1, q2)
+        dc.matrices.withPush {
+            translate(pos.x, pos.y, pos.z)
+            scale(scale, scale, 1f)
+            translate(-x * 0.5f, -ModuleNametags.fontRenderer.height * 0.5f, 0f)
+
+            dc.fill(
+                x1 = q1.x, y1 = q1.y,
+                x2 = q2.x, y2 = q2.y,
+                z = 0f, color = Color4b.BLACK.copy(a = 120).toARGB()
+            )
         }
 
         if (NametagShowOptions.BORDER.isShowing()) {
@@ -97,11 +105,10 @@ class NametagRenderer {
         matrixStack.pop()
     }
 
-    private fun drawItemList(pos: Vec3, itemsToRender: List<ItemStack>) {
-        dc.matrices.push()
-        dc.matrices.translate(pos.x, pos.y - NAMETAG_PADDING, pos.z)
-        dc.matrices.scale(ITEM_SCALE * ModuleNametags.scale, ITEM_SCALE * ModuleNametags.scale, 1.0F)
-        dc.matrices.translate(-itemsToRender.size * ITEM_SIZE / 2.0F, -ITEM_SIZE.toFloat(), 0.0F)
+    private fun drawItemList(pos: Vec3, itemsToRender: List<ItemStack>) = dc.matrices.withPush {
+        translate(pos.x, pos.y - NAMETAG_PADDING, pos.z)
+        scale(ITEM_SCALE * ModuleNametags.scale, ITEM_SCALE * ModuleNametags.scale, 1.0F)
+        translate(-itemsToRender.size * ITEM_SIZE / 2.0F, -ITEM_SIZE.toFloat(), 0.0F)
 
         dc.fill(
             0,
@@ -111,7 +118,7 @@ class NametagRenderer {
             Color4b.BLACK.with(a = 0).toARGB()
         )
 
-        dc.matrices.translate(0.0F, 0.0F, 100.0F)
+        translate(0.0F, 0.0F, 100.0F)
 
         val itemInfo = NametagShowOptions.ITEM_INFO.isShowing()
 
@@ -126,8 +133,6 @@ class NametagRenderer {
                 dc.drawStackOverlay(mc.textRenderer, itemStack, x, 0)
             }
         }
-
-        dc.matrices.pop()
     }
 
     fun commit(env: RenderEnvironment) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
@@ -60,7 +60,9 @@ class NametagRenderer {
         // Make the model view matrix center the text when rendering
         matrixStack.translate(-x * 0.5f, -ModuleNametags.fontRenderer.height * 0.5f, 0f)
 
-        ModuleNametags.fontRenderer.commit(this@drawNametag, fontBuffers)
+        with(ModuleNametags.fontRenderer) {
+            commit(fontBuffers)
+        }
 
         val q1 = Vec3(-0.1f * fontSize, ModuleNametags.fontRenderer.height * -0.1f, 0f)
         val q2 = Vec3(x + 0.2f * fontSize, ModuleNametags.fontRenderer.height * 1.1f, 0f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAirPlace.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleAirPlace.kt
@@ -24,7 +24,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.item.isConsumable
@@ -91,7 +91,7 @@ object ModuleAirPlace : ClientModule("AirPlace", Category.WORLD) {
         val outline = Preview.outlineColor
 
         renderEnvironmentForWorld(event.matrixStack) {
-            drawBoxes { drawBox(viewSpaceBox, fill, outline) }
+            drawBox(viewSpaceBox, fill, outline)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapComponent.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapComponent.kt
@@ -38,7 +38,7 @@ import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentRotation
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.ccbluex.liquidbounce.utils.render.Alignment
-import net.minecraft.client.render.BufferBuilder
+import net.minecraft.client.render.VertexConsumer
 import net.minecraft.client.render.VertexFormat
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.entity.LivingEntity
@@ -131,7 +131,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
                 VertexFormat.DrawMode.QUADS,
                 VertexInputType.PosTexColor,
             ) { matrix ->
-                buildMinimapMesh(this, matrix, Vector2i(baseX, baseZ), chunksToRenderAround, viewDistance)
+                buildMinimapMesh(matrix, Vector2i(baseX, baseZ), chunksToRenderAround, viewDistance)
             }
 
             drawCustomMesh(
@@ -140,7 +140,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
             ) {
                 for (renderedEntity in RenderedEntities) {
                     drawEntityOnMinimap(
-                        this, matStack, renderedEntity, event.tickDelta, Vec2f(baseX.toFloat(), baseZ.toFloat())
+                        matStack, renderedEntity, event.tickDelta, Vec2f(baseX.toFloat(), baseZ.toFloat())
                     )
                 }
             }
@@ -239,8 +239,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
         )
     }
 
-    private fun buildMinimapMesh(
-        builder: BufferBuilder,
+    private fun VertexConsumer.buildMinimapMesh(
         matrix: Matrix4f,
         centerPos: Vector2i,
         chunksToRenderAround: Int,
@@ -259,20 +258,19 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
                 val from = Vec2f(x.toFloat(), y.toFloat())
                 val to = from.add(Vec2f(1.0F, 1.0F))
 
-                builder.vertex(matrix, from.x, from.y, 0.0F).texture(texPosition.xMin, texPosition.yMin)
+                vertex(matrix, from.x, from.y, 0.0F).texture(texPosition.xMin, texPosition.yMin)
                     .color(1.0F, 1.0F, 1.0F, 1.0F)
-                builder.vertex(matrix, from.x, to.y, 0.0F).texture(texPosition.xMin, texPosition.yMax)
+                vertex(matrix, from.x, to.y, 0.0F).texture(texPosition.xMin, texPosition.yMax)
                     .color(1.0F, 1.0F, 1.0F, 1.0F)
-                builder.vertex(matrix, to.x, to.y, 0.0F).texture(texPosition.xMax, texPosition.yMax)
+                vertex(matrix, to.x, to.y, 0.0F).texture(texPosition.xMax, texPosition.yMax)
                     .color(1.0F, 1.0F, 1.0F, 1.0F)
-                builder.vertex(matrix, to.x, from.y, 0.0F).texture(texPosition.xMax, texPosition.yMin)
+                vertex(matrix, to.x, from.y, 0.0F).texture(texPosition.xMax, texPosition.yMin)
                     .color(1.0F, 1.0F, 1.0F, 1.0F)
             }
         }
     }
 
-    private fun drawEntityOnMinimap(
-        bufferBuilder: BufferBuilder,
+    private fun VertexConsumer.drawEntityOnMinimap(
         matStack: MatrixStack,
         entity: LivingEntity,
         partialTicks: Float,
@@ -302,7 +300,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
             -w / 5.0 * ChunkRenderer.SUN_DIRECTION.y / 16.0,/* z = */
             0.0
         )
-        bufferBuilder.coloredTriangle(
+        coloredTriangle(
             matStack.peek().positionMatrix,
             p1,
             p2,
@@ -311,7 +309,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
         )
         matStack.pop()
 
-        bufferBuilder.coloredTriangle(matStack.peek().positionMatrix, p1, p2, p3, color)
+        coloredTriangle(matStack.peek().positionMatrix, p1, p2, p3, color)
 
         matStack.pop()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/AbstractFontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/AbstractFontRenderer.kt
@@ -55,8 +55,7 @@ abstract class AbstractFontRenderer<T> {
 
     /**
      */
-    abstract fun commit(
-        env: RenderEnvironment,
+    abstract fun RenderEnvironment.commit(
         buffers: FontRendererBuffers
     )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/AbstractFontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/AbstractFontRenderer.kt
@@ -55,9 +55,8 @@ abstract class AbstractFontRenderer<T> {
 
     /**
      */
-    abstract fun RenderEnvironment.commit(
-        buffers: FontRendererBuffers
-    )
+    context(environment: RenderEnvironment)
+    abstract fun commit(buffers: FontRendererBuffers)
 
     /**
      * Approximates the width of a text. Accurate except for obfuscated (`§k`) formatting

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -124,52 +124,6 @@ class RenderBufferBuilder<I : VertexInputType> private constructor(
     }
 }
 
-/**
- * Draws colored boxes. Renders automatically
- */
-inline fun WorldRenderEnvironment.drawBoxes(fn: BoxRenderer.() -> Unit) {
-    val renderer = BoxRenderer(this)
-
-    try {
-        fn(renderer)
-    } finally {
-        renderer.draw()
-    }
-}
-
-class BoxRenderer(val env: WorldRenderEnvironment) {
-    private val faceRenderer = RenderBufferBuilder(
-        DrawMode.QUADS,
-        VertexInputType.PosColor,
-        RenderBufferBuilder.TESSELATOR_A
-    )
-    private val outlinesRenderer = RenderBufferBuilder(
-        DrawMode.DEBUG_LINES,
-        VertexInputType.PosColor,
-        RenderBufferBuilder.TESSELATOR_B
-    )
-
-    fun drawBox(
-        box: Box,
-        faceColor: Color4b,
-        outlineColor: Color4b? = null,
-        vertices: Int = -1,
-        outlineVertices: Int = -1
-    ) {
-        faceRenderer.drawBox(env, box, color = faceColor, verticesToUse = vertices)
-
-        if (outlineColor != null) {
-            outlinesRenderer.drawBox(env, box, true, outlineColor, outlineVertices)
-        }
-    }
-
-    fun draw() {
-        faceRenderer.draw()
-        outlinesRenderer.draw()
-    }
-
-}
-
 fun RenderEnvironment.drawSolidBox(consumer: VertexConsumer, box: Box, color: Color4b) {
     val matrix = currentMvpMatrix
     val argb = color.toARGB()
@@ -205,45 +159,6 @@ fun RenderBufferBuilder<VertexInputType.PosTexColor>.drawQuad(
         vertex(matrix, pos1.x.toFloat(), pos1.y.toFloat(), pos1.z.toFloat())
             .texture(uv1.u, uv1.v)
             .color(color.toARGB())
-    }
-}
-
-fun RenderBufferBuilder<VertexInputType.Pos>.drawQuad(
-    env: RenderEnvironment,
-    pos1: Vec3,
-    pos2: Vec3,
-) {
-    val matrix = env.currentMvpMatrix
-
-    // Draw the vertices of the box
-    with(vertexConsumer) {
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos2.z)
-        vertex(matrix, pos2.x, pos1.y, pos2.z)
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
-    }
-}
-
-fun RenderBufferBuilder<VertexInputType.Pos>.drawQuadOutlines(
-    env: RenderEnvironment,
-    pos1: Vec3,
-    pos2: Vec3,
-) {
-    val matrix = env.currentMvpMatrix
-
-    // Draw the vertices of the box
-    with(vertexConsumer) {
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
-
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos1.z)
-
-        vertex(matrix, pos2.x, pos1.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos1.z)
-
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
-        vertex(matrix, pos2.x, pos1.y, pos1.z)
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -39,13 +39,23 @@ import net.minecraft.util.math.Position
  *
  * This should only be used on render thread.
  */
-class RenderBufferBuilder<I : VertexInputType>(
+class RenderBufferBuilder<I : VertexInputType> private constructor(
     private val drawMode: DrawMode,
     private val vertexFormat: I,
-    private val tesselator: Tessellator
+    private val tessellator: Tessellator,
+    internal val vertexConsumer: BufferBuilder,
 ) {
-    // Begin drawing lines with position format
-    val buffer: BufferBuilder = tesselator.begin(drawMode, vertexFormat.vertexFormat)
+
+    constructor(
+        drawMode: DrawMode,
+        vertexFormat: I,
+        tessellator: Tessellator,
+    ) : this(
+        drawMode,
+        vertexFormat,
+        tessellator,
+        tessellator.begin(drawMode, vertexFormat.vertexFormat),
+    )
 
     /**
      * Function to draw a solid box using the specified [box].
@@ -72,7 +82,7 @@ class RenderBufferBuilder<I : VertexInputType>(
                     return@forEachOutlineVertex
                 }
 
-                val bb = buffer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
+                val bb = vertexConsumer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
 
                 if (color != null) {
                     bb.color(color.toARGB())
@@ -84,7 +94,7 @@ class RenderBufferBuilder<I : VertexInputType>(
                     return@forEachFaceVertex
                 }
 
-                val bb = buffer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
+                val bb = vertexConsumer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
 
                 if (color != null) {
                     bb.color(color.toARGB())
@@ -94,16 +104,16 @@ class RenderBufferBuilder<I : VertexInputType>(
     }
 
     fun draw() {
-        val built = buffer.endNullable() ?: return
+        val built = vertexConsumer.endNullable() ?: return
 
         RenderSystem.setShader(vertexFormat.shaderProgram)
 
         BufferRenderer.drawWithGlobalProgram(built)
-        tesselator.clear()
+        tessellator.clear()
     }
 
     fun reset() {
-        buffer.endNullable()
+        vertexConsumer.endNullable()
     }
 
     companion object {
@@ -182,7 +192,7 @@ fun RenderBufferBuilder<VertexInputType.PosTexColor>.drawQuad(
     val matrix = env.currentMvpMatrix
 
     // Draw the vertices of the box
-    with(buffer) {
+    with(vertexConsumer) {
         vertex(matrix, pos1.x.toFloat(), pos2.y.toFloat(), pos1.z.toFloat())
             .texture(uv1.u, uv2.v)
             .color(color.toARGB())
@@ -206,7 +216,7 @@ fun RenderBufferBuilder<VertexInputType.Pos>.drawQuad(
     val matrix = env.currentMvpMatrix
 
     // Draw the vertices of the box
-    with(buffer) {
+    with(vertexConsumer) {
         vertex(matrix, pos1.x, pos2.y, pos1.z)
         vertex(matrix, pos2.x, pos2.y, pos2.z)
         vertex(matrix, pos2.x, pos1.y, pos2.z)
@@ -222,7 +232,7 @@ fun RenderBufferBuilder<VertexInputType.Pos>.drawQuadOutlines(
     val matrix = env.currentMvpMatrix
 
     // Draw the vertices of the box
-    with(buffer) {
+    with(vertexConsumer) {
         vertex(matrix, pos1.x, pos1.y, pos1.z)
         vertex(matrix, pos1.x, pos2.y, pos1.z)
 
@@ -246,7 +256,7 @@ fun RenderBufferBuilder<VertexInputType.PosColor>.drawLine(
     val matrix = env.currentMvpMatrix
 
     // Draw the vertices of the box
-    with(buffer) {
+    with(vertexConsumer) {
         vertex(matrix, pos1.x, pos1.y, pos1.z).color(color.toARGB())
         vertex(matrix, pos2.x, pos2.y, pos2.z).color(color.toARGB())
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderBufferBuilder.kt
@@ -28,7 +28,6 @@ import net.minecraft.client.gl.ShaderProgramKey
 import net.minecraft.client.gl.ShaderProgramKeys
 import net.minecraft.client.render.*
 import net.minecraft.client.render.VertexFormat.DrawMode
-import net.minecraft.util.math.Box
 import net.minecraft.util.math.Position
 
 
@@ -57,52 +56,6 @@ class RenderBufferBuilder<I : VertexInputType> private constructor(
         tessellator.begin(drawMode, vertexFormat.vertexFormat),
     )
 
-    /**
-     * Function to draw a solid box using the specified [box].
-     *
-     * @param box The bounding box of the box.
-     */
-    @Suppress("CognitiveComplexMethod")
-    @JvmOverloads
-    fun drawBox(
-        env: RenderEnvironment,
-        box: Box,
-        useOutlineVertices: Boolean = false,
-        color: Color4b? = null,
-        verticesToUse: Int = -1
-    ) {
-        val matrix = env.currentMvpMatrix
-
-        val check = verticesToUse != -1
-
-        // Draw the vertices of the box
-        if (useOutlineVertices) {
-            box.forEachOutlineVertex { i, x, y, z ->
-                if (check && (verticesToUse and (1 shl i)) != 0) {
-                    return@forEachOutlineVertex
-                }
-
-                val bb = vertexConsumer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
-
-                if (color != null) {
-                    bb.color(color.toARGB())
-                }
-            }
-        } else {
-            box.forEachFaceVertex { i, x, y, z ->
-                if (check && (verticesToUse and (1 shl i)) != 0) {
-                    return@forEachFaceVertex
-                }
-
-                val bb = vertexConsumer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
-
-                if (color != null) {
-                    bb.color(color.toARGB())
-                }
-            }
-        }
-    }
-
     fun draw() {
         val built = vertexConsumer.endNullable() ?: return
 
@@ -114,24 +67,6 @@ class RenderBufferBuilder<I : VertexInputType> private constructor(
 
     fun reset() {
         vertexConsumer.endNullable()
-    }
-
-    companion object {
-        @JvmField
-        val TESSELATOR_A: Tessellator = Tessellator(0x200000)
-        @JvmField
-        val TESSELATOR_B: Tessellator = Tessellator(0x200000)
-    }
-}
-
-fun RenderEnvironment.drawSolidBox(consumer: VertexConsumer, box: Box, color: Color4b) {
-    val matrix = currentMvpMatrix
-    val argb = color.toARGB()
-
-    // Draw the vertices of the box
-    box.forEachFaceVertex { _, x, y, z ->
-        consumer.vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
-            .color(argb)
     }
 }
 
@@ -162,8 +97,8 @@ fun RenderBufferBuilder<VertexInputType.PosTexColor>.drawQuad(
     }
 }
 
+context(env: RenderEnvironment)
 fun RenderBufferBuilder<VertexInputType.PosColor>.drawLine(
-    env: RenderEnvironment,
     pos1: Vec3,
     pos2: Vec3,
     color: Color4b

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -41,6 +41,7 @@ import net.minecraft.util.math.Direction
 import net.minecraft.util.math.MathHelper
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3i
+import org.joml.Matrix3x2fStack
 import org.joml.Matrix4f
 import org.lwjgl.opengl.GL11C
 import kotlin.contracts.ExperimentalContracts
@@ -148,6 +149,15 @@ inline fun MatrixStack.withPush(block: MatrixStack.() -> Unit) {
         block()
     } finally {
         pop()
+    }
+}
+
+inline fun Matrix3x2fStack.withPush(block: Matrix3x2fStack.() -> Unit) {
+    pushMatrix()
+    try {
+        block()
+    } finally {
+        popMatrix()
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -361,6 +361,18 @@ fun RenderEnvironment.drawQuad(pos1: Vec3, pos2: Vec3) {
     }
 }
 
+fun RenderEnvironment.drawColoredQuad(pos1: Vec3, pos2: Vec3, argb: Int) {
+    drawCustomMesh(
+        DrawMode.QUADS,
+        VertexInputType.PosColor,
+    ) { matrix ->
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos2.z).color(argb)
+        vertex(matrix, pos2.x, pos1.y, pos2.z).color(argb)
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
+    }
+}
+
 fun RenderEnvironment.drawQuadOutlines(pos1: Vec3, pos2: Vec3) {
     drawCustomMesh(
         DrawMode.DEBUG_LINES,
@@ -377,6 +389,25 @@ fun RenderEnvironment.drawQuadOutlines(pos1: Vec3, pos2: Vec3) {
 
         vertex(matrix, pos1.x, pos1.y, pos1.z)
         vertex(matrix, pos2.x, pos1.y, pos1.z)
+    }
+}
+
+fun RenderEnvironment.drawColoredQuadOutlines(pos1: Vec3, pos2: Vec3, argb: Int) {
+    drawCustomMesh(
+        DrawMode.DEBUG_LINES,
+        VertexInputType.PosColor,
+    ) { matrix ->
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
+
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos1.z).color(argb)
+
+        vertex(matrix, pos2.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos1.z).color(argb)
+
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos1.y, pos1.z).color(argb)
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -247,7 +247,7 @@ inline fun RenderEnvironment.withDisabledCull(draw: RenderEnvironment.() -> Unit
 inline fun RenderEnvironment.drawCustomMesh(
     drawMode: DrawMode,
     vertexInputType: VertexInputType,
-    drawer: BufferBuilder.(Matrix4f) -> Unit
+    drawer: VertexConsumer.(Matrix4f) -> Unit
 ) {
     val tessellator = Tessellator.getInstance()
     val buffer = tessellator.begin(drawMode, vertexInputType.vertexFormat)
@@ -379,7 +379,7 @@ fun RenderEnvironment.drawTriangle(p1: Vec3, p2: Vec3, p3: Vec3) {
     }
 }
 
-fun BufferBuilder.coloredTriangle(matrix: Matrix4f, p1: Vec3d, p2: Vec3d, p3: Vec3d, color4b: Color4b) {
+fun VertexConsumer.coloredTriangle(matrix: Matrix4f, p1: Vec3d, p2: Vec3d, p3: Vec3d, color4b: Color4b) {
     vertex(matrix, p1.x.toFloat(), p1.y.toFloat(), p1.z.toFloat()).color(color4b.toARGB())
     vertex(matrix, p2.x.toFloat(), p2.y.toFloat(), p2.z.toFloat()).color(color4b.toARGB())
     vertex(matrix, p3.x.toFloat(), p3.y.toFloat(), p3.z.toFloat()).color(color4b.toARGB())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -298,10 +298,6 @@ fun RenderEnvironment.drawLineStrip(vararg positions: Vec3) {
     drawLines(positions.unmodifiable(), mode = DrawMode.DEBUG_LINE_STRIP)
 }
 
-fun RenderEnvironment.drawLineStrip(positions: List<Vec3>) {
-    drawLines(positions, mode = DrawMode.DEBUG_LINE_STRIP)
-}
-
 /**
  * Helper function to draw lines using the specified [lines] vectors and draw mode.
  *

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -57,10 +57,14 @@ import kotlin.contracts.contract
  * This has to be removed or limited to old driver versions when AMD actually fixes the bug in their drivers.
  * But as of now, 01.02.2025, they haven't.
  */
+@JvmField
 val HAS_AMD_VEGA_APU = GL11C.glGetString(GL11C.GL_RENDERER)?.startsWith("AMD Radeon(TM) RX Vega") ?: false &&
     GL11C.glGetString(GL11C.GL_VENDOR) == "ATI Technologies Inc."
 
+@JvmField
 val FULL_BOX = Box(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+
+@JvmField
 val EMPTY_BOX = Box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -82,8 +82,6 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
             fontBuffers.draw()
         }
     }
-
-    fun FontRenderer.commit(buffer: FontRendererBuffers) = commit(this@RenderEnvironment, buffer)
 }
 
 class GUIRenderEnvironment(matrixStack: MatrixStack) : RenderEnvironment(matrixStack) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -395,6 +395,67 @@ fun VertexConsumer.coloredTriangle(matrix: Matrix4f, p1: Vec3d, p2: Vec3d, p3: V
     vertex(matrix, p3.x.toFloat(), p3.y.toFloat(), p3.z.toFloat()).color(color4b.toARGB())
 }
 
+
+/**
+ * Helper unction to draw a solid box using the specified [box].
+ *
+ * @param box The bounding box of the box.
+ */
+@Suppress("CognitiveComplexMethod")
+private fun RenderEnvironment.drawBox(
+    box: Box,
+    drawMode: DrawMode,
+    useOutlineVertices: Boolean = false,
+    color: Color4b? = null,
+    verticesToUse: Int = -1
+) = drawCustomMesh(drawMode, VertexInputType.PosColor) { matrix ->
+    val check = verticesToUse != -1
+
+    // Draw the vertices of the box
+    if (useOutlineVertices) {
+        box.forEachOutlineVertex { i, x, y, z ->
+            if (check && (verticesToUse and (1 shl i)) != 0) {
+                return@forEachOutlineVertex
+            }
+
+            val bb = vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
+
+            if (color != null) {
+                bb.color(color.toARGB())
+            }
+        }
+    } else {
+        box.forEachFaceVertex { i, x, y, z ->
+            if (check && (verticesToUse and (1 shl i)) != 0) {
+                return@forEachFaceVertex
+            }
+
+            val bb = vertex(matrix, x.toFloat(), y.toFloat(), z.toFloat())
+
+            if (color != null) {
+                bb.color(color.toARGB())
+            }
+        }
+    }
+}
+
+/**
+ * Function to draw a colored [box].
+ */
+fun RenderEnvironment.drawBox(
+    box: Box,
+    faceColor: Color4b,
+    outlineColor: Color4b? = null,
+    vertices: Int = -1,
+    outlineVertices: Int = -1
+) {
+    drawBox(box, DrawMode.QUADS, color = faceColor, verticesToUse = vertices)
+
+    if (outlineColor != null) {
+        drawBox(box, DrawMode.DEBUG_LINES, useOutlineVertices = true, outlineColor, outlineVertices)
+    }
+}
+
 /**
  * Function to draw a side box using the specified [box] and [side].
  *

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
@@ -272,9 +272,8 @@ class FontRenderer(
 
     }
 
-    override fun RenderEnvironment.commit(
-        buffers: FontRendererBuffers,
-    ) {
+    context(environment: RenderEnvironment)
+    override fun commit(buffers: FontRendererBuffers) {
         cache.renderedGlyphs.forEach { renderedGlyph ->
             val glyphDescriptor = renderedGlyph.glyph
             val renderBuffer = buffers.getTextBufferForGlyphPage(glyphDescriptor.page)
@@ -283,7 +282,7 @@ class FontRenderer(
             val atlasLocation = glyphDescriptor.renderInfo.atlasLocation!!
 
             renderBuffer.drawQuad(
-                this,
+                environment,
                 mutableVec3d1.set(renderedGlyph.x1.toDouble(), renderedGlyph.y1.toDouble(), renderedGlyph.z.toDouble()),
                 atlasLocation.uvCoordinatesOnTexture.min,
                 mutableVec3d2.set(renderedGlyph.x2.toDouble(), renderedGlyph.y2.toDouble(), renderedGlyph.z.toDouble()),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
@@ -272,11 +272,10 @@ class FontRenderer(
 
     }
 
-    override fun commit(
-        env: RenderEnvironment,
+    override fun RenderEnvironment.commit(
         buffers: FontRendererBuffers,
     ) {
-        this.cache.renderedGlyphs.forEach { renderedGlyph ->
+        cache.renderedGlyphs.forEach { renderedGlyph ->
             val glyphDescriptor = renderedGlyph.glyph
             val renderBuffer = buffers.getTextBufferForGlyphPage(glyphDescriptor.page)
 
@@ -284,7 +283,7 @@ class FontRenderer(
             val atlasLocation = glyphDescriptor.renderInfo.atlasLocation!!
 
             renderBuffer.drawQuad(
-                env,
+                this,
                 mutableVec3d1.set(renderedGlyph.x1.toDouble(), renderedGlyph.y1.toDouble(), renderedGlyph.z.toDouble()),
                 atlasLocation.uvCoordinatesOnTexture.min,
                 mutableVec3d2.set(renderedGlyph.x2.toDouble(), renderedGlyph.y2.toDouble(), renderedGlyph.z.toDouble()),
@@ -293,14 +292,14 @@ class FontRenderer(
             )
         }
 
-        if (this.cache.lines.isNotEmpty()) {
-            for (line in this.cache.lines) {
-                buffers.lineBufferBuilder.drawLine(env, line.p1, line.p2, line.color)
+        if (cache.lines.isNotEmpty()) {
+            for (line in cache.lines) {
+                buffers.lineBufferBuilder.drawLine(line.p1, line.p2, line.color)
             }
         }
 
-        this.cache.lines.clear()
-        this.cache.renderedGlyphs.clear()
+        cache.lines.clear()
+        cache.renderedGlyphs.clear()
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/GlyphPage.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/GlyphPage.kt
@@ -125,7 +125,6 @@ abstract class GlyphPage {
         @JvmStatic
         protected val DEFAULT_PADDING: Int = 1
 
-
         /**
          * Used for the Font Atlas generation
          */

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/TextProcessor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/processor/TextProcessor.kt
@@ -19,6 +19,7 @@ abstract class TextProcessor(obfuscationSeed: Long?) {
         /**
          * Contains the chars for the `§k` formatting
          */
+        @JvmField
         val RANDOM_CHARS = "1234567890abcdefghijklmnopqrstuvwxyz~!@#\$%^&*()-=_+{}[]".toCharArray()
 
         @JvmStatic
@@ -31,10 +32,14 @@ abstract class TextProcessor(obfuscationSeed: Long?) {
             Color4b(red, green, blue, 255)
         }
     }
+
+    @JvmRecord
     data class ProcessedTextCharacter(val char: Char, val font: Int, val obfuscated: Boolean, val color: Color4b)
+
+    @JvmRecord
     data class ProcessedText(
         val chars: List<ProcessedTextCharacter>,
         val underlines: List<IntRange>,
-        val strikeThroughs: List<IntRange>
+        val strikeThroughs: List<IntRange>,
     )
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WireframePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WireframePlayer.kt
@@ -19,7 +19,7 @@
 package net.ccbluex.liquidbounce.utils.render
 
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
@@ -50,19 +50,17 @@ data class WireframePlayer(private var pos: Vec3d, private var yaw: Float, priva
                 matrix.rotate(Quaternionf().rotationY(Math.toRadians(yRot).toFloat()))
                 matrix.scale(1.9f)
 
-                drawBoxes {
-                    drawBox(RENDER_LEFT_LEG, color, outlineColor)
-                    drawBox(RENDER_RIGHT_LEG, color, outlineColor)
-                    drawBox(RENDER_BODY, color, outlineColor)
-                    drawBox(RENDER_LEFT_ARM, color, outlineColor)
-                    drawBox(RENDER_RIGHT_ARM, color, outlineColor)
+                drawBox(RENDER_LEFT_LEG, color, outlineColor)
+                drawBox(RENDER_RIGHT_LEG, color, outlineColor)
+                drawBox(RENDER_BODY, color, outlineColor)
+                drawBox(RENDER_LEFT_ARM, color, outlineColor)
+                drawBox(RENDER_RIGHT_ARM, color, outlineColor)
 
-                    matrix.translate(0f, RENDER_HEAD.minY.toFloat(), 0f)
-                    matrix.rotate(Quaternionf().rotationX(Math.toRadians(pitch.toDouble()).toFloat()))
-                    matrix.translate(0f, -RENDER_HEAD.minY.toFloat(), 0f)
+                matrix.translate(0f, RENDER_HEAD.minY.toFloat(), 0f)
+                matrix.rotate(Quaternionf().rotationX(Math.toRadians(pitch.toDouble()).toFloat()))
+                matrix.translate(0f, -RENDER_HEAD.minY.toFloat(), 0f)
 
-                    drawBox(RENDER_HEAD, color, outlineColor)
-                }
+                drawBox(RENDER_HEAD, color, outlineColor)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderHandler.kt
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap
 import net.ccbluex.fastutil.fastIterator
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.render.*
-import net.ccbluex.liquidbounce.render.drawBoxes
+import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.utils.block.searchBlocksInCuboid
 import net.ccbluex.liquidbounce.utils.math.iterator
 import net.ccbluex.liquidbounce.utils.math.toVec3d
@@ -66,66 +66,64 @@ class PlacementRenderHandler(private val placementRenderer: PlacementRenderer, v
 
             renderEnvironmentForWorld(matrixStack) {
                 // Do not use destructuring declaration which returns boxed [Long] values
-                drawBoxes {
-                    fun drawEntryBox(blockPos: BlockPos, cullData: Long, box: Box, colorFactor: Float) {
-                        withPositionRelativeToCamera(blockPos.toVec3d()) {
-                            drawBox(
-                                box,
-                                color.fade(colorFactor),
-                                outlineColor.fade(colorFactor),
-                                (cullData shr 32).toInt(),
-                                (cullData and 0xFFFFFFFF).toInt()
-                            )
-                        }
+                fun drawEntryBox(blockPos: BlockPos, cullData: Long, box: Box, colorFactor: Float) {
+                    withPositionRelativeToCamera(blockPos.toVec3d()) {
+                        drawBox(
+                            box,
+                            color.fade(colorFactor),
+                            outlineColor.fade(colorFactor),
+                            (cullData shr 32).toInt(),
+                            (cullData and 0xFFFFFFFF).toInt()
+                        )
                     }
+                }
 
-                    inList.long2ObjectEntrySet().removeIf { entry ->
-                        // Do not use destructuring declaration which returns boxed [Long] values
-                        val pos = entry.longKey
-                        val value = entry.value
+                inList.long2ObjectEntrySet().removeIf { entry ->
+                    // Do not use destructuring declaration which returns boxed [Long] values
+                    val pos = entry.longKey
+                    val value = entry.value
 
-                        val sizeFactor = startSizeCurve.getFactor(value.startTime, time, inTime.toFloat())
-                        val expand = MathHelper.lerp(sizeFactor, startSize, 1f)
-                        val box = getBox(if (expand < 1f) 1f - expand else expand, value.box)
-                        val colorFactor = fadeInCurve.getFactor(value.startTime, time, inTime.toFloat())
+                    val sizeFactor = startSizeCurve.getFactor(value.startTime, time, inTime.toFloat())
+                    val expand = MathHelper.lerp(sizeFactor, startSize, 1f)
+                    val box = getBox(if (expand < 1f) 1f - expand else expand, value.box)
+                    val colorFactor = fadeInCurve.getFactor(value.startTime, time, inTime.toFloat())
 
-                        drawEntryBox(blockPosCache.set(pos), value.cullData, box, colorFactor)
+                    drawEntryBox(blockPosCache.set(pos), value.cullData, box, colorFactor)
 
-                        if (time - value.startTime >= outTime) {
-                            if (keep) {
-                                currentList.put(pos, value.toCurrent())
-                            } else {
-                                outList.put(pos, value.copy(startTime = time))
-                            }
-                            true
+                    if (time - value.startTime >= outTime) {
+                        if (keep) {
+                            currentList.put(pos, value.toCurrent())
                         } else {
-                            false
+                            outList.put(pos, value.copy(startTime = time))
                         }
+                        true
+                    } else {
+                        false
                     }
+                }
 
-                    currentList.fastIterator().forEach { entry ->
-                        val pos = entry.longKey
-                        val value = entry.value
-                        drawEntryBox(blockPosCache.set(pos), value.cullData, value.box, 1f)
-                    }
+                currentList.fastIterator().forEach { entry ->
+                    val pos = entry.longKey
+                    val value = entry.value
+                    drawEntryBox(blockPosCache.set(pos), value.cullData, value.box, 1f)
+                }
 
-                    outList.long2ObjectEntrySet().removeIf { entry ->
-                        val pos = entry.longKey
-                        val value = entry.value
+                outList.long2ObjectEntrySet().removeIf { entry ->
+                    val pos = entry.longKey
+                    val value = entry.value
 
-                        val sizeFactor = endSizeCurve.getFactor(value.startTime, time, outTime.toFloat())
-                        val expand = 1f - MathHelper.lerp(sizeFactor, 1f, endSize)
-                        val box = getBox(expand, value.box)
-                        val colorFactor = 1f - fadeOutCurve.getFactor(value.startTime, time, outTime.toFloat())
+                    val sizeFactor = endSizeCurve.getFactor(value.startTime, time, outTime.toFloat())
+                    val expand = 1f - MathHelper.lerp(sizeFactor, 1f, endSize)
+                    val box = getBox(expand, value.box)
+                    val colorFactor = 1f - fadeOutCurve.getFactor(value.startTime, time, outTime.toFloat())
 
-                        drawEntryBox(blockPosCache.set(pos), value.cullData, box, colorFactor)
+                    drawEntryBox(blockPosCache.set(pos), value.cullData, box, colorFactor)
 
-                        if (time - value.startTime >= outTime) {
-                            updateNeighbors(blockPosCache.set(pos))
-                            true
-                        } else {
-                            false
-                        }
+                    if (time - value.startTime >= outTime) {
+                        updateNeighbors(blockPosCache.set(pos))
+                        true
+                    } else {
+                        false
                     }
                 }
             }


### PR DESCRIPTION
continue of https://github.com/CCBlueX/LiquidBounce/pull/1142

This will cause some predictable performance loss, as Mojang did not implement two-pass rendering in version 1.21.4, but this will be fixed in later versions of Minecraft.