### PR TITLE
fix(eagle): sneak condition

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
@@ -36,7 +36,8 @@ import java.util.function.Predicate
  *
  * Legit trick to build faster.
  */
-object ModuleEagle : ClientModule("Eagle", Category.PLAYER,
+object ModuleEagle : ClientModule(
+    "Eagle", Category.PLAYER,
     aliases = listOf("FastBridge", "BridgeAssistant", "LegitScaffold")
 ) {
 
@@ -47,13 +48,54 @@ object ModuleEagle : ClientModule("Eagle", Category.PLAYER,
 
     private var currentEdgeDistance: Float = edgeDistance.random()
     private var wasSneaking = false
+    private var sneakCaptured = false
+
+    private fun shouldActivateEagle(event: MovementInputEvent, conditionsMet: Boolean): Boolean {
+        if (player.abilities.flying || !conditionsMet) {
+            return false
+        }
+
+        return player.isCloseToEdge(event.directionalInput, currentEdgeDistance.toDouble())
+    }
+
+    private fun updateSneakCapture(originalSneak: Boolean, active: Boolean) {
+        if (!Conditional.controlsSneak) {
+            sneakCaptured = false
+            return
+        }
+
+        when {
+            !sneakCaptured && active && originalSneak -> sneakCaptured = true
+            sneakCaptured && !originalSneak -> sneakCaptured = false
+        }
+    }
+
+    private fun shouldOverrideSneak(conditionsMet: Boolean, active: Boolean): Boolean {
+        return conditionsMet && Conditional.controlsSneak && (active || sneakCaptured)
+    }
+
+    private fun updateSneakState(isSneaking: Boolean) {
+        if (isSneaking) {
+            wasSneaking = true
+            return
+        }
+
+        if (wasSneaking) {
+            currentEdgeDistance = edgeDistance.random()
+            wasSneaking = false
+        }
+    }
 
     private object Conditional : ToggleableConfigurable(this, "Conditional", true) {
-        private val conditions by multiEnumChoice("Conditions",
+        private val conditions by multiEnumChoice(
+            "Conditions",
             Condition.ON_GROUND
         )
 
         val pitch by floatRange("Pitch", -90f..90f, -90f..90f)
+
+        val controlsSneak
+            get() = enabled && Condition.SNEAK in conditions
 
         fun shouldSneak(event: MovementInputEvent) =
             !enabled || player.pitch in pitch && conditions.all { it.test(event) }
@@ -86,6 +128,7 @@ object ModuleEagle : ClientModule("Eagle", Category.PLAYER,
 
     override fun onDisabled() {
         wasSneaking = false
+        sneakCaptured = false
         super.onDisabled()
     }
 
@@ -93,17 +136,21 @@ object ModuleEagle : ClientModule("Eagle", Category.PLAYER,
     private val handleMovementInput = handler<MovementInputEvent>(priority = SAFETY_FEATURE) { event ->
         debugParameter("EdgeDistance") { currentEdgeDistance }
 
-        val shouldBeActive = !player.abilities.flying && Conditional.shouldSneak(event) &&
-            player.isCloseToEdge(event.directionalInput, currentEdgeDistance.toDouble())
+        val originalSneak = mc.options.sneakKey.isPressed
+        val conditionsMet = Conditional.shouldSneak(event)
+        val isActive = shouldActivateEagle(event, conditionsMet)
 
-        event.sneak = event.sneak || shouldBeActive
+        updateSneakCapture(originalSneak, isActive)
 
-        if (event.sneak) {
-            wasSneaking = true
-        } else if (wasSneaking) {
-            currentEdgeDistance = edgeDistance.random()
-            wasSneaking = false
+        val controlsSneak = shouldOverrideSneak(conditionsMet, isActive)
+
+        event.sneak = if (controlsSneak) {
+            isActive
+        } else {
+            originalSneak || isActive
         }
+
+        updateSneakState(event.sneak)
     }
 
 }


### PR DESCRIPTION
When having the condition sneak enabled and pressing the sneak button, eagle will not unsneak meaning that we never eagle.
This was caused by #6975 , but before that sneaking with eagle enabled was not possible at all when the condition sneak was enabled but eagle correctly started sneaking when it needed.

With this PR eagle will when the sneak condition is enabled sneak normaly when the player presses the sneak key till we approach an edge, then eagle takes control over the sneaking behavior till the player no longer presses the sneak key or if other conditions are no longer met. If other conditions are no longer met but the player still presses the sneak key the player will correctly put in the sneak state again