### PR TITLE
feat: ProtectionZones

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -90,6 +90,7 @@ import net.ccbluex.liquidbounce.features.module.modules.world.autofarm.ModuleAut
 import net.ccbluex.liquidbounce.features.module.modules.world.fucker.ModuleFucker
 import net.ccbluex.liquidbounce.features.module.modules.world.nuker.ModuleNuker
 import net.ccbluex.liquidbounce.features.module.modules.world.packetmine.ModulePacketMine
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleProtectionZones
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ModuleScaffold
 import net.ccbluex.liquidbounce.features.module.modules.world.traps.ModuleAutoTrap
 import net.ccbluex.liquidbounce.script.ScriptApiRequired
@@ -404,6 +405,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleItemChams,
             ModuleCrystalView,
             ModuleSkinChanger,
+            ModuleProtectionZones,
 
             // World
             ModuleAirPlace,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -133,15 +133,15 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         centers: Sequence<BlockPos>, limit: Int, playerPos: Vec3d
     ): List<BlockPos> {
         if (limit <= 0) return emptyList()
-        val compareBySquaredDist = Comparator<BlockPos> { a, b ->
+
+        return Ordering.from<BlockPos> { a, b ->
             fun squaredDist(p: BlockPos): Double {
                 val dx = (p.x + 0.5) - playerPos.x
                 val dz = (p.z + 0.5) - playerPos.z
                 return dx * dx + dz * dz
             }
             squaredDist(a).compareTo(squaredDist(b))
-        }
-        return Ordering.from(compareBySquaredDist).leastOf(centers.iterator(), limit)
+        }.leastOf(centers.iterator(), limit)
     }
 
     private fun computeZones(centers: List<BlockPos>, world: World): Array<Box> {
@@ -209,15 +209,18 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         )
 
         val indicatorPos = BlockPos(snappedX, snappedY, snappedZ)
-        if (zones.any { it.contains(indicatorPos.toCenterPos()) }) return
+        val indicatorCenter = indicatorPos.toCenterPos()
+        if (zones.any { it.contains(indicatorCenter) }) return
         val indicatorBox = Box(indicatorPos).offset(camOffset)
 
         drawBox(
-            indicatorBox, Renderer.IndicatorColors.indicatorFill,
-            Renderer.IndicatorColors.indicatorOutline
+            indicatorBox,
+            faceColor = Renderer.IndicatorColors.indicatorFill,
+            outlineColor = Renderer.IndicatorColors.indicatorOutline,
         )
     }
 
+    @Suppress("unused")
     private val renderHandler = handler<WorldRenderEvent> { e ->
         if (BlockTracker.isEmpty()) return@handler
         val holdingProt = isHoldingProtBlock()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -17,14 +17,12 @@
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.google.common.collect.Ordering
+import com.google.common.collect.Sets
 import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
-import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
@@ -35,6 +33,8 @@ import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
 import net.ccbluex.liquidbounce.utils.block.ChunkScanner
+import net.ccbluex.liquidbounce.utils.item.getBlock
+import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks
 import net.minecraft.util.math.BlockPos
@@ -49,11 +49,8 @@ import kotlin.math.roundToInt
  * ProtectionZones module
  *
  * Allows you to see areas protected by protection blocks and suggests optimal placement spots.
- *
- *
  */
 object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) {
-
 
     private val DEFAULT_ZONE_FILL = Color4b(0, 255, 0, 51)
     private val DEFAULT_ZONE_OUTLINE = Color4b(0, 255, 0, 255)
@@ -62,9 +59,13 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
     private val DEFAULT_INDICATOR_FILL = Color4b(255, 240, 0, 51)
     private const val HIGHLIGHT_RADIUS: Float = 5.0f
 
-    private val protBlocks by blocks("ProtectionBlocks", mutableSetOf(Blocks.EMERALD_BLOCK)).onChange {
+    private val protBlocks by blocks(
+        "ProtectionBlocks",
+        Sets.newConcurrentHashSet<Block>().apply { add(Blocks.EMERALD_BLOCK) },
+    ).onChange {
         if (running) {
-            onDisabled(); onEnabled()
+            onDisabled()
+            onEnabled()
         }
         it
     }
@@ -78,7 +79,6 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
     private object Renderer : Configurable("Renderer") {
         val renderLimit by int("RenderLimit", 16, 3..50, "zones")
         val holdBlockToRender by boolean("HoldBlockToRender", false)
-
 
         object ProtectionColors : Configurable("ProtectionColors") {
             val zoneFill by color("ZoneFill", DEFAULT_ZONE_FILL)
@@ -104,27 +104,24 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         treeAll(Radius, Indicator, Renderer)
     }
 
-    private object Tracker : AbstractBlockLocationTracker.BlockPos2State<Unit>() {
-        override fun getStateFor(pos: BlockPos, state: BlockState): Unit? =
-            if (state.block in protBlocks) Unit else null
+    private object BlockTracker : AbstractBlockLocationTracker.State2BlockPos<Block>() {
+        override fun getStateFor(pos: BlockPos, state: BlockState): Block? =
+            state.block?.takeIf { it in protBlocks }
     }
 
     override fun onEnabled() {
-        ChunkScanner.subscribe(Tracker)
+        ChunkScanner.subscribe(BlockTracker)
     }
 
     override fun onDisabled() {
-        ChunkScanner.unsubscribe(Tracker)
+        ChunkScanner.unsubscribe(BlockTracker)
     }
 
     private fun isHoldingProtBlock(): Boolean {
         val player = mc.player ?: return false
-        val main = player.mainHandStack.item
-        val off = player.offHandStack.item
-        return protBlocks.any { blockItem ->
-            val item = blockItem.asItem()
-            item == main || item == off
-        }
+        val main = player.mainHandStack.getBlock()
+        val off = player.offHandStack.getBlock()
+        return main in protBlocks || off in protBlocks
     }
 
     private fun snapToGrid(value: Int, origin: Int, step: Int): Int {
@@ -221,9 +218,8 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         )
     }
 
-
     private val renderHandler = handler<WorldRenderEvent> { e ->
-        if (Tracker.isEmpty()) return@handler
+        if (BlockTracker.isEmpty()) return@handler
         val holdingProt = isHoldingProtBlock()
         if (Renderer.holdBlockToRender && !holdingProt) return@handler
 
@@ -231,7 +227,7 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         val player = mc.player ?: return@handler
 
         val centers = nearestCenters(
-            centers = Tracker.allPositions(),
+            centers = BlockTracker.allPositions(),
             limit = Renderer.renderLimit,
             playerPos = player.pos,
         )
@@ -246,13 +242,6 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
             if (holdingProt) {
                 drawIndicator(centers, zones, camOffset)
             }
-        }
-    }
-
-
-    private val worldChangeHandler = handler<WorldChangeEvent> {
-        if (running) {
-            onDisabled(); onEnabled()
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -1,0 +1,268 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+
+package net.ccbluex.liquidbounce.features.module.modules.render
+
+import com.google.common.collect.Ordering
+import com.mojang.blaze3d.systems.RenderSystem
+import net.ccbluex.liquidbounce.config.types.nesting.Configurable
+import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
+import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
+import net.ccbluex.liquidbounce.render.drawBox
+import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
+import net.ccbluex.liquidbounce.utils.block.ChunkScanner
+import net.minecraft.block.BlockState
+import net.minecraft.block.Blocks
+import net.minecraft.util.math.BlockPos
+import net.minecraft.util.math.Box
+import net.minecraft.util.math.Vec3d
+import net.minecraft.world.World
+
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * ProtectionZones module
+ *
+ * Allows you to see areas protected by protection blocks and suggests optimal placement spots.
+ *
+ *
+ */
+object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) {
+
+
+    private val DEFAULT_ZONE_FILL = Color4b(0, 255, 0, 51)
+    private val DEFAULT_ZONE_OUTLINE = Color4b(0, 255, 0, 255)
+    private val DEFAULT_CENTER_OUTLINE = Color4b(0, 255, 207, 255)
+    private val DEFAULT_INDICATOR_OUTLINE = Color4b(255, 240, 0, 255)
+    private val DEFAULT_INDICATOR_FILL = Color4b(255, 240, 0, 51)
+    private const val HIGHLIGHT_RADIUS: Float = 5.0f
+
+    private val protBlocks by blocks("ProtectionBlocks", mutableSetOf(Blocks.EMERALD_BLOCK)).onChange {
+        if (running) {
+            onDisabled(); onEnabled()
+        }
+        it
+    }
+
+    private object Radius : Configurable("ProtectionRadius") {
+        val x by int("RadiusX", 20, 1..256, "blocks")
+        val z by int("RadiusZ", 20, 1..256, "blocks")
+        val y by int("RadiusY", 383, 1..383, "blocks")
+    }
+
+    private object Renderer : Configurable("Renderer") {
+        val renderLimit by int("RenderLimit", 16, 3..50, "zones")
+        val holdBlockToRender by boolean("HoldBlockToRender", false)
+
+
+        object ProtectionColors : Configurable("ProtectionColors") {
+            val zoneFill by color("ZoneFill", DEFAULT_ZONE_FILL)
+            val zoneOutline by color("ZoneOutline", DEFAULT_ZONE_OUTLINE)
+            val centerZoneOutline by color("CenterZoneOutline", DEFAULT_CENTER_OUTLINE)
+        }
+
+        object IndicatorColors : Configurable("IndicatorColors") {
+            val indicatorOutline by color("IndicatorOutline", DEFAULT_INDICATOR_OUTLINE)
+            val indicatorFill by color("IndicatorFill", DEFAULT_INDICATOR_FILL)
+        }
+
+        init {
+            treeAll(ProtectionColors, IndicatorColors)
+        }
+    }
+
+    private object Indicator : Configurable("PlacementIndicator") {
+        val snapY by boolean("SnapToY", false)
+    }
+
+    init {
+        treeAll(Radius, Indicator, Renderer)
+    }
+
+    private object Tracker : AbstractBlockLocationTracker.BlockPos2State<Unit>() {
+        override fun getStateFor(pos: BlockPos, state: BlockState): Unit? =
+            if (state.block in protBlocks) Unit else null
+    }
+
+    override fun onEnabled() {
+        ChunkScanner.subscribe(Tracker)
+    }
+
+    override fun onDisabled() {
+        ChunkScanner.unsubscribe(Tracker)
+    }
+
+    private fun isHoldingProtBlock(): Boolean {
+        val player = mc.player ?: return false
+        val main = player.mainHandStack.item
+        val off = player.offHandStack.item
+        return protBlocks.any { blockItem ->
+            val item = blockItem.asItem()
+            item == main || item == off
+        }
+    }
+
+    private fun snapToGrid(value: Int, origin: Int, step: Int): Int {
+        val stepsFromOrigin = ((value - origin).toDouble() / step).roundToInt()
+        return origin + stepsFromOrigin * step
+    }
+
+    private fun nearestCenters(
+        centers: Sequence<BlockPos>, limit: Int, playerPos: Vec3d
+    ): List<BlockPos> {
+        if (limit <= 0) return emptyList()
+        val compareBySquaredDist = Comparator<BlockPos> { a, b ->
+            fun squaredDist(p: BlockPos): Double {
+                val dx = (p.x + 0.5) - playerPos.x
+                val dz = (p.z + 0.5) - playerPos.z
+                return dx * dx + dz * dz
+            }
+            squaredDist(a).compareTo(squaredDist(b))
+        }
+        return Ordering.from(compareBySquaredDist).leastOf(centers.iterator(), limit)
+    }
+
+    private fun computeZones(centers: List<BlockPos>, world: World): ArrayList<Box> {
+        return centers.mapTo(ArrayList(centers.size)) { c ->
+            val minY = max(c.y - Radius.y, world.bottomY)
+            val maxY = min(c.y + Radius.y, world.topYInclusive)
+            Box(
+                (c.x - Radius.x).toDouble(),
+                minY.toDouble(),
+                (c.z - Radius.z).toDouble(),
+                (c.x + Radius.x + 1).toDouble(),
+                (maxY + 1).toDouble(),
+                (c.z + Radius.z + 1).toDouble()
+            )
+        }
+    }
+
+    private fun findHighlightIndex(zones: List<Box>, playerPos: Vec3d): Int? {
+        val r2 = (HIGHLIGHT_RADIUS * HIGHLIGHT_RADIUS).toDouble()
+        for ((i, b) in zones.withIndex()) {
+            if (b.contains(playerPos)) return null
+            if (b.squaredMagnitude(playerPos) <= r2) return i
+        }
+        return null
+    }
+
+    private fun WorldRenderEnvironment.drawZones(
+        zones: List<Box>, centers: List<BlockPos>, highlightIndex: Int?, camOffset: Vec3d
+    ) {
+        val colors = Renderer.ProtectionColors
+        val viewZones = ArrayList<Box>(zones.size)
+        val centerBoxes = ArrayList<Box>(centers.size)
+        for (i in zones.indices) {
+            viewZones += zones[i].offset(camOffset)
+            centerBoxes += Box(centers[i]).offset(camOffset)
+        }
+
+        for (b in viewZones) drawBox(b, Color4b.TRANSPARENT, colors.zoneOutline)
+        for (c in centerBoxes) drawBox(c, Color4b.TRANSPARENT, colors.centerZoneOutline)
+
+        if (highlightIndex != null && highlightIndex in viewZones.indices) {
+            val highlighted = viewZones[highlightIndex]
+            RenderSystem.enableDepthTest()
+            RenderSystem.depthMask(false)
+            RenderSystem.enablePolygonOffset()
+            RenderSystem.polygonOffset(1f, 1f)
+
+            drawBox(highlighted, colors.zoneFill, Color4b.TRANSPARENT)
+
+            RenderSystem.disablePolygonOffset()
+            RenderSystem.depthMask(true)
+            RenderSystem.disableDepthTest()
+        }
+    }
+
+    private fun WorldRenderEnvironment.drawIndicator(
+        centers: List<BlockPos>, zones: List<Box>, camOffset: Vec3d
+    ) {
+        if (centers.isEmpty()) return
+        val player = mc.player ?: return
+        val world = mc.world ?: return
+
+        val playerBlockPos = player.blockPos
+        val refCenter = centers.first()
+
+        val stepX = 2 * Radius.x + 1
+        val stepZ = 2 * Radius.z + 1
+
+        val snappedX = snapToGrid(value = playerBlockPos.x, origin = refCenter.x, step = stepX)
+        val snappedZ = snapToGrid(value = playerBlockPos.z, origin = refCenter.z, step = stepZ)
+        val snappedY = (if (Indicator.snapY) refCenter.y else playerBlockPos.y).coerceIn(
+            world.bottomY,
+            world.topYInclusive
+        )
+
+        val indicatorPos = BlockPos(snappedX, snappedY, snappedZ)
+        if (zones.any { it.contains(indicatorPos.toCenterPos()) }) return
+        val indicatorBox = Box(indicatorPos).offset(camOffset)
+
+        drawBox(
+            indicatorBox, Renderer.IndicatorColors.indicatorFill,
+            Renderer.IndicatorColors.indicatorOutline
+        )
+    }
+
+
+    private val renderHandler = handler<WorldRenderEvent> { e ->
+        if (Tracker.isEmpty()) return@handler
+        val holdingProt = isHoldingProtBlock()
+        if (Renderer.holdBlockToRender && !holdingProt) return@handler
+
+        val world = mc.world ?: return@handler
+        val player = mc.player ?: return@handler
+
+        val centers = nearestCenters(
+            centers = Tracker.allPositions(),
+            limit = Renderer.renderLimit,
+            playerPos = player.pos,
+        )
+        if (centers.isEmpty()) return@handler
+
+        val zones = computeZones(centers, world)
+        val highlightIndex = findHighlightIndex(zones, playerPos = player.pos)
+
+        renderEnvironmentForWorld(e.matrixStack) {
+            val camOffset = mc.entityRenderDispatcher.camera.pos.negate()
+            drawZones(zones, centers, highlightIndex, camOffset)
+            if (holdingProt) {
+                drawIndicator(centers, zones, camOffset)
+            }
+        }
+    }
+
+
+    private val worldChangeHandler = handler<WorldChangeEvent> {
+        if (running) {
+            onDisabled(); onEnabled()
+        }
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -22,7 +22,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import com.google.common.collect.Ordering
-import com.mojang.blaze3d.systems.RenderSystem
+import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
@@ -41,7 +41,6 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Vec3d
 import net.minecraft.world.World
-
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -148,8 +147,8 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         return Ordering.from(compareBySquaredDist).leastOf(centers.iterator(), limit)
     }
 
-    private fun computeZones(centers: List<BlockPos>, world: World): ArrayList<Box> {
-        return centers.mapTo(ArrayList(centers.size)) { c ->
+    private fun computeZones(centers: List<BlockPos>, world: World): Array<Box> {
+        return centers.mapToArray { c ->
             val minY = max(c.y - Radius.y, world.bottomY)
             val maxY = min(c.y + Radius.y, world.topYInclusive)
             Box(
@@ -163,7 +162,7 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         }
     }
 
-    private fun findHighlightIndex(zones: List<Box>, playerPos: Vec3d): Int? {
+    private fun findHighlightIndex(zones: Array<Box>, playerPos: Vec3d): Int? {
         val r2 = (HIGHLIGHT_RADIUS * HIGHLIGHT_RADIUS).toDouble()
         for ((i, b) in zones.withIndex()) {
             if (b.contains(playerPos)) return null
@@ -173,7 +172,7 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
     }
 
     private fun WorldRenderEnvironment.drawZones(
-        zones: List<Box>, centers: List<BlockPos>, highlightIndex: Int?, camOffset: Vec3d
+        zones: Array<Box>, centers: List<BlockPos>, highlightIndex: Int?, camOffset: Vec3d
     ) {
         val colors = Renderer.ProtectionColors
         val viewZones = ArrayList<Box>(zones.size)
@@ -188,21 +187,12 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
 
         if (highlightIndex != null && highlightIndex in viewZones.indices) {
             val highlighted = viewZones[highlightIndex]
-            RenderSystem.enableDepthTest()
-            RenderSystem.depthMask(false)
-            RenderSystem.enablePolygonOffset()
-            RenderSystem.polygonOffset(1f, 1f)
-
             drawBox(highlighted, colors.zoneFill, Color4b.TRANSPARENT)
-
-            RenderSystem.disablePolygonOffset()
-            RenderSystem.depthMask(true)
-            RenderSystem.disableDepthTest()
         }
     }
 
     private fun WorldRenderEnvironment.drawIndicator(
-        centers: List<BlockPos>, zones: List<Box>, camOffset: Vec3d
+        centers: List<BlockPos>, zones: Array<Box>, camOffset: Vec3d
     ) {
         if (centers.isEmpty()) return
         val player = mc.player ?: return

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -179,12 +179,12 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
             centerBoxes += Box(centers[i]).offset(camOffset)
         }
 
-        for (b in viewZones) drawBox(b, Color4b.TRANSPARENT, colors.zoneOutline)
-        for (c in centerBoxes) drawBox(c, Color4b.TRANSPARENT, colors.centerZoneOutline)
+        for (b in viewZones) drawBox(b, outlineColor = colors.zoneOutline)
+        for (c in centerBoxes) drawBox(c, outlineColor = colors.centerZoneOutline)
 
         if (highlightIndex != null && highlightIndex in viewZones.indices) {
             val highlighted = viewZones[highlightIndex]
-            drawBox(highlighted, colors.zoneFill, Color4b.TRANSPARENT)
+            drawBox(highlighted, faceColor = colors.zoneFill)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -475,16 +475,16 @@ private fun RenderEnvironment.drawBox(
  */
 fun RenderEnvironment.drawBox(
     box: Box,
-    faceColor: Color4b = Color4b.TRANSPARENT,
-    outlineColor: Color4b = Color4b.TRANSPARENT,
+    faceColor: Color4b? = Color4b.TRANSPARENT,
+    outlineColor: Color4b? = Color4b.TRANSPARENT,
     vertices: Int = -1,
     outlineVertices: Int = -1
 ) {
-    if (!faceColor.isTransparent) {
+    if (faceColor != null && !faceColor.isTransparent) {
         drawBox(box, DrawMode.QUADS, color = faceColor, verticesToUse = vertices)
     }
 
-    if (!outlineColor.isTransparent) {
+    if (outlineColor != null && !outlineColor.isTransparent) {
         drawBox(box, DrawMode.DEBUG_LINES, useOutlineVertices = true, outlineColor, outlineVertices)
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -475,14 +475,16 @@ private fun RenderEnvironment.drawBox(
  */
 fun RenderEnvironment.drawBox(
     box: Box,
-    faceColor: Color4b,
-    outlineColor: Color4b? = null,
+    faceColor: Color4b = Color4b.TRANSPARENT,
+    outlineColor: Color4b = Color4b.TRANSPARENT,
     vertices: Int = -1,
     outlineVertices: Int = -1
 ) {
-    drawBox(box, DrawMode.QUADS, color = faceColor, verticesToUse = vertices)
+    if (!faceColor.isTransparent) {
+        drawBox(box, DrawMode.QUADS, color = faceColor, verticesToUse = vertices)
+    }
 
-    if (outlineColor != null) {
+    if (!outlineColor.isTransparent) {
         drawBox(box, DrawMode.DEBUG_LINES, useOutlineVertices = true, outlineColor, outlineVertices)
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/type/Color4b.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/type/Color4b.kt
@@ -101,6 +101,9 @@ data class Color4b @JvmOverloads constructor(val r: Int, val g: Int, val b: Int,
         a = if (hasAlpha) (hex shr 24) and 0xFF else 255
     )
 
+    val isTransparent: Boolean
+        get() = a == 0
+
     fun with(
         r: Int = this.r,
         g: Int = this.g,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
@@ -165,6 +165,9 @@ fun RegistryKey<Enchantment>.toRegistryEntry(): RegistryEntry<Enchantment> {
     return registry.getOptional(this).orElseThrow { IllegalArgumentException("Unknown enchantment key $this") }
 }
 
+/**
+ * Get [Block] of inner item if it is [BlockItem], or null if not
+ */
 fun ItemStack.getBlock(): Block? {
     val item = this.item
     if (item !is BlockItem) {

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -820,5 +820,7 @@
   "liquidbounce.module.notebot.messages.songInfoTotalNotes": "Total notes: %s",
   "liquidbounce.module.guiCloser.description": "Closes GUIs if their title matches specified patterns.",
   "liquidbounce.module.yggdrasilSignatureFix.description": "Disables Authlib Yggdrasil signature check, may fix missing skins on some servers.",
-  "liquidbounce.module.reportHelper.description": "Automatically starts a report and confirms it for you."
+  "liquidbounce.module.reportHelper.description": "Automatically starts a report and confirms it for you.",
+  "liquidbounce.module.protectionZones.description": "Allows you to see areas protected by protection blocks and suggests optimal placement spots."
+
 }


### PR DESCRIPTION
| Placement Indicator | Protected Areas |
|--------------------|----------------|
| ![demo1](https://github.com/user-attachments/assets/063a29d0-1013-47eb-b06b-b5ca96ff9337) | ![demo2](https://github.com/user-attachments/assets/bd81e020-5df8-400c-b31d-fb24d538a9dd) |

Added `ProtectionZones` module that allows you to:
- See areas protected by protection blocks
- Suggest optimal placement spots for new protection blocks
- Avoid wasting protection blocks and ensure full coverage

Useful on servers with protection plugins like [ProtectionStones](https://github.com/espidev/ProtectionStones), which let players protect areas by placing a special block (e.g., Emerald Blocks).
