### PR TITLE
Fix BlockESP Outline mode not rendering outline (Closes #6928)

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinWorldRenderer.java
@@ -91,14 +91,18 @@ public abstract class MixinWorldRenderer {
         }
     }
 
-   @Inject(method = "render", at = @At("HEAD"))
+    @Inject(method = "render", at = @At("HEAD"))
     private void onRender(ObjectAllocator allocator, RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
         try {
             OutlineShader outlineShader = OutlineShader.INSTANCE;
             outlineShader.update();
             outlineShader.getHandle().get().beginWrite(false);
 
-            var event = new DrawOutlinesEvent(new MatrixStack(), camera, tickCounter.getTickDelta(false), DrawOutlinesEvent.OutlineType.INBUILT_OUTLINE);
+            var matrixStack = new MatrixStack();
+            // Apply camera transformation to fix outline positioning
+            matrixStack.peek().getPositionMatrix().mul(positionMatrix);
+
+            var event = new DrawOutlinesEvent(matrixStack, camera, tickCounter.getTickDelta(false), DrawOutlinesEvent.OutlineType.INBUILT_OUTLINE);
             EventManager.INSTANCE.callEvent(event);
 
             if (event.getDirtyFlag()) {


### PR DESCRIPTION
This PR fixes BlockESP "Outline" mode not rendering outlines.
Tested on Linux
Closes #6928.
<img width="1920" height="1080" alt="LB" src="https://github.com/user-attachments/assets/1bf69132-9b59-486b-b53e-6dfc66bd79e9" />
