### PR TITLE
feat(render): batch draw

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/debugrecorder/modes/MinaraiCombatRecorder.kt
@@ -187,6 +187,7 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
         val matrixStack = event.matrixStack
 
         renderEnvironmentForWorld(matrixStack) {
+            startBatch()
             targetTracker.targets().forEach { entity ->
                 val pos = entity.interpolateCurrentPosition(event.partialTicks)
                 val eyePos = pos.add(0.0, entity.standingEyeHeight.toDouble(), 0.0)
@@ -215,6 +216,7 @@ object MinaraiCombatRecorder : ModuleDebugRecorder.DebugRecorderMode<TrainingDat
                     )
                 }
             }
+            commitBatch()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -105,6 +105,7 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
         ): Boolean {
             var dirty = false
 
+            startBatch()
             for (blockPos in blocks) {
                 val blockState = blockPos.getState() ?: continue
 
@@ -129,12 +130,13 @@ object ModuleBlockESP : ClientModule("BlockESP", Category.RENDER) {
                     drawBox(
                         boundingBox,
                         faceColor = color,
-                        outlineColor = color.with(a = 150).takeIf { drawOutline }
+                        outlineColor = if (drawOutline) color.with(a = 150) else null,
                     )
                 }
 
                 dirty = true
             }
+            commitBatch()
 
             return dirty
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -60,7 +60,7 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         private val box = Box(-0.125, 0.125, -0.125, 0.125, 0.375, 0.125)
 
         @Suppress("unused")
-        val renderHandler = handler<WorldRenderEvent> { event ->
+        private val renderHandler = handler<WorldRenderEvent> { event ->
             val matrixStack = event.matrixStack
 
             val base = getColor()
@@ -68,8 +68,10 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
             val outlineColor = base.with(a = 100)
 
             val filtered = world.entities.filter(::shouldRender)
+            if (filtered.isEmpty()) return@handler
 
             renderEnvironmentForWorld(matrixStack) {
+                startBatch()
                 for (entity in filtered) {
                     val pos = entity.interpolateCurrentPosition(event.partialTicks)
 
@@ -77,6 +79,7 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
                         drawBox(box, baseColor, outlineColor)
                     }
                 }
+                commitBatch()
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleProtectionZones.kt
@@ -240,11 +240,13 @@ object ModuleProtectionZones : ClientModule("ProtectionZones", Category.RENDER) 
         val highlightIndex = findHighlightIndex(zones, playerPos = player.pos)
 
         renderEnvironmentForWorld(e.matrixStack) {
+            startBatch()
             val camOffset = mc.entityRenderDispatcher.camera.pos.negate()
             drawZones(zones, centers, highlightIndex, camOffset)
             if (holdingProt) {
                 drawIndicator(centers, zones, camOffset)
             }
+            commitBatch()
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -110,16 +110,19 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
             val matrixStack = event.matrixStack
 
             val queuedBoxes = collectBoxesToDraw(event)
+            if (queuedBoxes.isEmpty()) return@handler
 
             renderEnvironmentForWorld(matrixStack) {
+                startBatch()
                 for ((pos, box, color) in queuedBoxes) {
                     val baseColor = color.with(a = 50)
-                    val outlineColor = color.with(a = 100)
+                    val outlineColor = if (outline) color.with(a = 100) else null
 
                     withPositionRelativeToCamera(pos) {
-                        drawBox(box, baseColor, outlineColor.takeIf { outline })
+                        drawBox(box, baseColor, outlineColor)
                     }
                 }
+                commitBatch()
             }
         }
 
@@ -185,6 +188,7 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
             renderEnvironmentForWorld(event.matrixStack) {
                 // non-model blocks are already processed by WorldRenderer where we injected code which renders
                 // their outline
+                startBatch()
                 for ((pos, type) in StorageScanner.iterate()) {
                     if (!type.enabled) continue
 
@@ -204,12 +208,13 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
                         outlineShape.boundingBox
                     }
 
-                    withPosition(relativeToCamera(Vec3d.of(pos))) {
+                    withPositionRelativeToCamera(pos) {
                         drawBox(boundingBox, type.color)
                     }
 
                     event.markDirty()
                 }
+                commitBatch()
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
@@ -44,6 +44,7 @@ object EspBoxMode : EspMode("Box") {
         }
 
         renderEnvironmentForWorld(matrixStack) {
+            startBatch()
             entitiesWithBoxes.forEach { (entity, box) ->
                 val pos = entity.interpolateCurrentPosition(event.partialTicks)
                 val color = getColor(entity)
@@ -59,6 +60,7 @@ object EspBoxMode : EspMode("Box") {
                     )
                 }
             }
+            commitBatch()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/murdermystery/ModuleMurderMystery.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
 import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
@@ -91,12 +92,15 @@ object ModuleMurderMystery : ClientModule("MurderMystery", Category.RENDER) {
             playBow = false
         }
 
-        world.entities.filterIsInstance<ArmorStandEntity>().forEach {
-            if (it.getEquippedStack(EquipmentSlot.MAINHAND).item is BowItem && it.isInvisible) {
-                renderDroppedBowBox(event, it)
+        renderEnvironmentForWorld(event.matrixStack) {
+            startBatch()
+            world.entities.filterIsInstance<ArmorStandEntity>().forEach {
+                if (it.getEquippedStack(EquipmentSlot.MAINHAND).item is BowItem && it.isInvisible) {
+                    renderDroppedBowBox(event.partialTicks, it)
+                }
             }
+            commitBatch()
         }
-
     }
 
     val packetHandler = handler<PacketEvent> { packetEvent ->
@@ -173,19 +177,15 @@ object ModuleMurderMystery : ClientModule("MurderMystery", Category.RENDER) {
         }
     }
 
-    private fun renderDroppedBowBox(event: WorldRenderEvent, armorStandEntity: ArmorStandEntity) {
-        val matrixStack = event.matrixStack
+    private fun WorldRenderEnvironment.renderDroppedBowBox(partialTicks: Float, armorStandEntity: ArmorStandEntity) {
+        val box = Box(-0.6, 0.0, -0.6, 0.6, 2.5, 0.6)
+        val pos = armorStandEntity.interpolateCurrentPosition(partialTicks)
 
-        renderEnvironmentForWorld(matrixStack) {
-            val box = Box(-0.6, 0.0, -0.6, 0.6, 2.5, 0.6)
-            val pos = armorStandEntity.interpolateCurrentPosition(event.partialTicks)
-
-            withPositionRelativeToCamera(pos) {
-                drawBox(
-                    box,
-                    Color4b(127, 255, 212, 100), Color4b(0, 255, 255)
-                )
-            }
+        withPositionRelativeToCamera(pos) {
+            drawBox(
+                box,
+                Color4b(127, 255, 212, 100), Color4b(0, 255, 255)
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render.nametags
 
-import com.mojang.blaze3d.systems.RenderSystem
 import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.render.RenderEnvironment
 import net.ccbluex.liquidbounce.render.drawColoredQuad
@@ -165,9 +164,6 @@ object NametagEnchantmentRenderer {
         if (isPositionOccluded(worldX, worldY)) {
             return
         }
-
-        RenderSystem.enableBlend()
-        RenderSystem.defaultBlendFunc()
 
         val columnData = itemsWithEnchantments.mapNotNull { item ->
             val cells = processItemEnchantments(item)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -285,8 +285,6 @@ object NametagEnchantmentRenderer {
                 scale = FIXED_SCALE
             )
         }
-
-        ModuleNametags.fontRenderer.commit(this)
     }
 
     private fun RenderEnvironment.drawCellBackground(
@@ -335,7 +333,7 @@ object NametagEnchantmentRenderer {
         val rightBottom = Vec3(rect.x2, rect.y2, 0F)
         drawColoredQuad(
             leftTop, rightBottom,
-            Color4b.BLACK.with(a = 120).toARGB(),
+            Color4b.BLACK.with(a = 100).toARGB(),
         )
 
         drawColoredQuadOutlines(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagEnchantmentRenderer.kt
@@ -24,7 +24,6 @@ import net.ccbluex.liquidbounce.render.drawColoredQuad
 import net.ccbluex.liquidbounce.render.drawColoredQuadOutlines
 import net.ccbluex.liquidbounce.render.engine.font.processor.MinecraftTextProcessor
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
-import net.ccbluex.liquidbounce.render.engine.font.processor.ProcessedText
 import net.ccbluex.liquidbounce.render.engine.type.Rect
 import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.item.getEnchantment
@@ -320,7 +319,7 @@ object NametagEnchantmentRenderer {
             y + maxColumnHeight + FRAME_MARGIN
         )
 
-        drawGroupBorder(this, groupRect)
+        drawGroupBorder(groupRect)
 
         var columnX = x - halfTotalWidth
         columnData.forEach { column ->
@@ -330,16 +329,16 @@ object NametagEnchantmentRenderer {
         }
     }
 
-    private fun drawGroupBorder(env: RenderEnvironment, rect: Rect) {
+    private fun RenderEnvironment.drawGroupBorder(rect: Rect) {
         // Drawing a semi-transparent background instead of just lines for better visibility
         val leftTop = Vec3(rect.x1, rect.y1, 0F)
         val rightBottom = Vec3(rect.x2, rect.y2, 0F)
-        env.drawColoredQuad(
+        drawColoredQuad(
             leftTop, rightBottom,
             Color4b.BLACK.with(a = 120).toARGB(),
         )
 
-        env.drawColoredQuadOutlines(
+        drawColoredQuadOutlines(
             leftTop, rightBottom,
             Color4b.RED.toARGB(),
         )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagRenderer.kt
@@ -52,6 +52,8 @@ internal fun GUIRenderEnvironment.drawNametag(nametag: Nametag, pos: Vec3) {
     matrixStack.translate(pos.x, pos.y, pos.z)
     matrixStack.scale(scale, scale, 1f)
 
+    startBatch()
+
     GlStateManager._enableBlend()
 
     val x =
@@ -88,6 +90,8 @@ internal fun GUIRenderEnvironment.drawNametag(nametag: Nametag, pos: Vec3) {
             worldY,
         )
     }
+
+    commitBatch()
 
     ModuleNametags.fontRenderer.commit(this@drawNametag)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientTessellator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientTessellator.kt
@@ -30,7 +30,7 @@ object ClientTessellator {
     private const val BUFFER_SIZE = 0xC0000
 
     private val bufferAllocators = enumMapOf<DrawMode, EnumMap<VertexInputType, BufferAllocator>> { _ ->
-        enumMapOf<VertexInputType, BufferAllocator>()
+        enumMapOf()
     }
 
     @JvmStatic

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientTessellator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientTessellator.kt
@@ -1,0 +1,48 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.render
+
+import net.ccbluex.liquidbounce.utils.kotlin.enumMapOf
+import net.minecraft.client.render.BufferBuilder
+import net.minecraft.client.render.VertexFormat.DrawMode
+import net.minecraft.client.util.BufferAllocator
+import java.util.EnumMap
+
+object ClientTessellator {
+
+    private const val BUFFER_SIZE = 0xC0000
+
+    private val bufferAllocators = enumMapOf<DrawMode, EnumMap<VertexInputType, BufferAllocator>> { _ ->
+        enumMapOf<VertexInputType, BufferAllocator>()
+    }
+
+    @JvmStatic
+    fun allocator(drawMode: DrawMode, vertexInputType: VertexInputType): BufferAllocator =
+        bufferAllocators[drawMode]!!.getOrPut(vertexInputType) { BufferAllocator(BUFFER_SIZE) }
+
+    @JvmStatic
+    fun begin(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder =
+        BufferBuilder(
+            allocator(drawMode, vertexInputType),
+            drawMode,
+            vertexInputType.vertexFormat
+        )
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -22,6 +22,9 @@ package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.platform.GlStateManager
 import com.mojang.blaze3d.systems.RenderSystem
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap
+import net.ccbluex.fastutil.fastIterator
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.gui.MixinDrawContextAccessor
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
@@ -30,11 +33,13 @@ import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.client.fastCos
 import net.ccbluex.liquidbounce.utils.client.fastSin
 import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.collection.Pool
+import net.ccbluex.liquidbounce.utils.kotlin.enumMapOf
 import net.ccbluex.liquidbounce.utils.kotlin.unmodifiable
-import net.minecraft.client.gl.ShaderProgramKeys
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.render.*
 import net.minecraft.client.render.VertexFormat.DrawMode
+import net.minecraft.client.util.BufferAllocator
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Direction
@@ -45,8 +50,13 @@ import org.joml.Matrix3x2fStack
 import org.joml.Matrix4f
 import org.joml.Vector3fc
 import org.lwjgl.opengl.GL11C
+import java.util.ArrayDeque
+import java.util.EnumMap
+import kotlin.collections.component1
+import kotlin.collections.component2
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+import kotlin.use
 
 /**
  * This variable should be used when rendering long lines, meaning longer than ~2 in 3d.
@@ -73,27 +83,66 @@ val EMPTY_BOX = Box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
  *
  * @property matrixStack The matrix stack for rendering.
  */
-sealed interface RenderEnvironment {
-    val matrixStack: MatrixStack
+sealed class RenderEnvironment(val matrixStack: MatrixStack) {
+    private var batchBuffer: EnumMap<VertexInputType, BufferBuilder>? = null
 
-    fun relativeToCamera(pos: Vec3d): Vec3d
+    val isBatchMode: Boolean get() = batchBuffer != null
+
+    fun getOrCreateBuffer(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder {
+        return batchBuffer?.getOrPut(vertexInputType) {
+            BufferBuilder(
+                bufferAllocator,
+                drawMode,
+                vertexInputType.vertexFormat
+            )
+        } ?: BufferBuilder(
+            bufferAllocator,
+            drawMode,
+            vertexInputType.vertexFormat
+        )
+    }
+
+    fun startBatch() {
+        if (isBatchMode) commitBatch()
+        batchBuffer = bufferPool.take()
+    }
+
+    fun commitBatch() {
+        val batchBuffer = requireNotNull(batchBuffer) {
+            "Current environment is not in batch mode!"
+        }
+
+        this.batchBuffer = null
+        batchBuffer.forEach { (vertexInputType, bufferBuilder) ->
+            bufferBuilder.endNullable()?.draw(vertexInputType)
+        }
+        bufferPool.offer(batchBuffer)
+    }
+
+    open fun relativeToCamera(pos: Vec3d): Vec3d = pos
+
+    companion object {
+        @JvmStatic
+        private val bufferAllocator = BufferAllocator(0xC00000)
+
+        @JvmStatic
+        private val bufferPool = Pool<EnumMap<VertexInputType, BufferBuilder>>(
+            ArrayDeque(),
+            ::enumMapOf,
+            EnumMap<*, *>::clear
+        )
+    }
 }
 
 class GUIRenderEnvironment(
     val context: DrawContext,
     matrixStack: MatrixStack?,
-) : RenderEnvironment {
-    override val matrixStack: MatrixStack = matrixStack ?: context.matrices
-
-    override fun relativeToCamera(pos: Vec3d): Vec3d {
-        return pos
-    }
-}
+) : RenderEnvironment(matrixStack ?: context.matrices)
 
 class WorldRenderEnvironment(
-    override val matrixStack: MatrixStack,
+    matrixStack: MatrixStack,
     val camera: Camera,
-) : RenderEnvironment {
+) : RenderEnvironment(matrixStack) {
     override fun relativeToCamera(pos: Vec3d): Vec3d {
         return pos.subtract(camera.pos)
     }
@@ -102,8 +151,6 @@ class WorldRenderEnvironment(
         return Vec3d(pos.x.toDouble() - camera.pos.x, pos.y.toDouble() - camera.pos.y, pos.z.toDouble() - camera.pos.z)
     }
 }
-
-fun newDrawContext(): DrawContext = DrawContext(mc, mc.bufferBuilders.entityVertexConsumers)
 
 /**
  * Helper function to render an environment with the specified [matrixStack] and [draw] block.
@@ -126,6 +173,7 @@ inline fun renderEnvironmentForWorld(matrixStack: MatrixStack, draw: WorldRender
 
     val environment = WorldRenderEnvironment(matrixStack, camera)
     draw(environment)
+    if (environment.isBatchMode) environment.commitBatch()
 
     RenderSystem.setShaderColor(1f, 1f, 1f, 1f)
     RenderSystem.disableBlend()
@@ -147,7 +195,9 @@ inline fun renderEnvironmentForGUI(
     RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f)
     RenderSystem.enableBlend()
 
-    draw(GUIRenderEnvironment(event.context, matrixStack))
+    val environment = GUIRenderEnvironment(event.context, matrixStack)
+    draw(environment)
+    if (environment.isBatchMode) environment.commitBatch()
 
     RenderSystem.disableBlend()
 }
@@ -268,18 +318,20 @@ inline fun RenderEnvironment.drawCustomMesh(
     vertexInputType: VertexInputType,
     drawer: VertexConsumer.(Matrix4f) -> Unit
 ) {
-    val tessellator = Tessellator.getInstance()
-    val buffer = tessellator.begin(drawMode, vertexInputType.vertexFormat)
-
     val matrix = matrixStack.peek().positionMatrix
+
+    val buffer = getOrCreateBuffer(drawMode, vertexInputType)
 
     drawer(buffer, matrix)
 
-    // Draw the custom mesh
-    buffer.endNullable()?.use { builtBuffer ->
-        RenderSystem.setShader(vertexInputType.shaderProgram)
-        BufferRenderer.drawWithGlobalProgram(builtBuffer)
+    if (!isBatchMode) {
+        buffer.endNullable()?.draw(vertexInputType)
     }
+}
+
+fun BuiltBuffer.draw(vertexInputType: VertexInputType) = use { builtBuffer ->
+    RenderSystem.setShader(vertexInputType.shaderProgram)
+    BufferRenderer.drawWithGlobalProgram(builtBuffer)
 }
 
 /**
@@ -751,6 +803,8 @@ fun RenderEnvironment.drawGradientSides(
         vertexColors
     )
 }
+
+fun newDrawContext(): DrawContext = DrawContext(mc, mc.bufferBuilders.entityVertexConsumers)
 
 /**
  * Float version of [DrawContext.fill]

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -22,9 +22,6 @@ package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.platform.GlStateManager
 import com.mojang.blaze3d.systems.RenderSystem
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap
-import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap
-import net.ccbluex.fastutil.fastIterator
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.gui.MixinDrawContextAccessor
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
@@ -84,22 +81,24 @@ val EMPTY_BOX = Box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
  * @property matrixStack The matrix stack for rendering.
  */
 sealed class RenderEnvironment(val matrixStack: MatrixStack) {
-    private var batchBuffer: EnumMap<VertexInputType, BufferBuilder>? = null
+    private var batchBuffer: EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>? = null
 
     val isBatchMode: Boolean get() = batchBuffer != null
 
     fun getOrCreateBuffer(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder {
-        return batchBuffer?.getOrPut(vertexInputType) {
+        val batchBuffer = batchBuffer ?: return BufferBuilder(
+            bufferAllocator,
+            drawMode,
+            vertexInputType.vertexFormat
+        )
+
+        return batchBuffer.getOrPut(vertexInputType, ::enumMapOf).getOrPut(drawMode) {
             BufferBuilder(
                 bufferAllocator,
                 drawMode,
                 vertexInputType.vertexFormat
             )
-        } ?: BufferBuilder(
-            bufferAllocator,
-            drawMode,
-            vertexInputType.vertexFormat
-        )
+        }
     }
 
     fun startBatch() {
@@ -113,8 +112,10 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
         }
 
         this.batchBuffer = null
-        batchBuffer.forEach { (vertexInputType, bufferBuilder) ->
-            bufferBuilder.endNullable()?.draw(vertexInputType)
+        batchBuffer.forEach { (vertexInputType, map) ->
+            map.values.forEach { bufferBuilder ->
+                bufferBuilder.endNullable()?.draw(vertexInputType)
+            }
         }
         bufferPool.offer(batchBuffer)
     }
@@ -126,7 +127,7 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
         private val bufferAllocator = BufferAllocator(0xC00000)
 
         @JvmStatic
-        private val bufferPool = Pool<EnumMap<VertexInputType, BufferBuilder>>(
+        private val bufferPool = Pool<EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>>(
             ArrayDeque(),
             ::enumMapOf,
             EnumMap<*, *>::clear

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -30,13 +30,11 @@ import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.utils.client.fastCos
 import net.ccbluex.liquidbounce.utils.client.fastSin
 import net.ccbluex.liquidbounce.utils.client.mc
-import net.ccbluex.liquidbounce.utils.collection.Pool
 import net.ccbluex.liquidbounce.utils.kotlin.enumMapOf
 import net.ccbluex.liquidbounce.utils.kotlin.unmodifiable
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.render.*
 import net.minecraft.client.render.VertexFormat.DrawMode
-import net.minecraft.client.util.BufferAllocator
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.math.Box
 import net.minecraft.util.math.Direction
@@ -47,7 +45,6 @@ import org.joml.Matrix3x2fStack
 import org.joml.Matrix4f
 import org.joml.Vector3fc
 import org.lwjgl.opengl.GL11C
-import java.util.ArrayDeque
 import java.util.EnumMap
 import kotlin.collections.component1
 import kotlin.collections.component2
@@ -81,50 +78,47 @@ val EMPTY_BOX = Box(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
  * @property matrixStack The matrix stack for rendering.
  */
 sealed class RenderEnvironment(val matrixStack: MatrixStack) {
-    private var batchBuffer: EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>? = null
-
-    val isBatchMode: Boolean get() = batchBuffer != null
+    var isBatchMode: Boolean = false
+        private set
 
     fun getOrCreateBuffer(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder {
-        val batchBuffer = batchBuffer ?: return Tessellator.getInstance()
-            .begin(drawMode, vertexInputType.vertexFormat)
-
-        return batchBuffer.getOrPut(vertexInputType, ::enumMapOf).getOrPut(drawMode) {
-            ClientTessellator.begin(drawMode, vertexInputType)
+        return if (isBatchMode) {
+            batchBuffer[vertexInputType]!!.getOrPut(drawMode) {
+                ClientTessellator.begin(drawMode, vertexInputType)
+            }
+        } else {
+            Tessellator.getInstance().begin(drawMode, vertexInputType.vertexFormat)
         }
     }
 
     fun startBatch() {
         if (isBatchMode) commitBatch()
-        batchBuffer = bufferPool.take()
+        isBatchMode = true
     }
 
     fun commitBatch() {
-        val batchBuffer = requireNotNull(batchBuffer) {
+        require(isBatchMode) {
             "Current environment is not in batch mode!"
         }
 
-        this.batchBuffer = null
         batchBuffer.forEach { (vertexInputType, map) ->
-            map.entries.forEach { (drawMode, bufferBuilder) ->
+            map.forEach { (drawMode, bufferBuilder) ->
                 bufferBuilder.endNullable()?.let {
                     it.draw(vertexInputType)
                     ClientTessellator.allocator(drawMode, vertexInputType).clear()
                 }
             }
+            map.clear()
         }
-        bufferPool.offer(batchBuffer)
     }
 
     open fun relativeToCamera(pos: Vec3d): Vec3d = pos
 
     companion object {
         @JvmStatic
-        private val bufferPool = Pool<EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>>(
-            ArrayDeque(),
-            ::enumMapOf,
-            EnumMap<*, *>::clear
-        )
+        private val batchBuffer = enumMapOf<VertexInputType, EnumMap<DrawMode, BufferBuilder>> { _ ->
+            enumMapOf()
+        }
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -86,15 +86,11 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
     val isBatchMode: Boolean get() = batchBuffer != null
 
     fun getOrCreateBuffer(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder {
-        val batchBuffer = batchBuffer ?: return BufferBuilder(
-            bufferAllocator,
-            drawMode,
-            vertexInputType.vertexFormat
-        )
+        val batchBuffer = batchBuffer ?: return Tessellator.getInstance().begin(drawMode, vertexInputType.vertexFormat)
 
         return batchBuffer.getOrPut(vertexInputType, ::enumMapOf).getOrPut(drawMode) {
             BufferBuilder(
-                bufferAllocator,
+                bufferAllocators[vertexInputType]!![drawMode]!!,
                 drawMode,
                 vertexInputType.vertexFormat
             )
@@ -113,8 +109,11 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
 
         this.batchBuffer = null
         batchBuffer.forEach { (vertexInputType, map) ->
-            map.values.forEach { bufferBuilder ->
-                bufferBuilder.endNullable()?.draw(vertexInputType)
+            map.entries.forEach { (drawMode, bufferBuilder) ->
+                bufferBuilder.endNullable()?.let {
+                    it.draw(vertexInputType)
+                    bufferAllocators[vertexInputType]!![drawMode]!!.clear()
+                }
             }
         }
         bufferPool.offer(batchBuffer)
@@ -124,7 +123,11 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
 
     companion object {
         @JvmStatic
-        private val bufferAllocator = BufferAllocator(0xC00000)
+        private val bufferAllocators = enumMapOf<VertexInputType, EnumMap<DrawMode, BufferAllocator>> { _ ->
+            enumMapOf<DrawMode, BufferAllocator> { _ ->
+                BufferAllocator(0xC0000)
+            }
+        }
 
         @JvmStatic
         private val bufferPool = Pool<EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>>(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -86,14 +86,11 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
     val isBatchMode: Boolean get() = batchBuffer != null
 
     fun getOrCreateBuffer(drawMode: DrawMode, vertexInputType: VertexInputType): BufferBuilder {
-        val batchBuffer = batchBuffer ?: return Tessellator.getInstance().begin(drawMode, vertexInputType.vertexFormat)
+        val batchBuffer = batchBuffer ?: return Tessellator.getInstance()
+            .begin(drawMode, vertexInputType.vertexFormat)
 
         return batchBuffer.getOrPut(vertexInputType, ::enumMapOf).getOrPut(drawMode) {
-            BufferBuilder(
-                bufferAllocators[vertexInputType]!![drawMode]!!,
-                drawMode,
-                vertexInputType.vertexFormat
-            )
+            ClientTessellator.begin(drawMode, vertexInputType)
         }
     }
 
@@ -112,7 +109,7 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
             map.entries.forEach { (drawMode, bufferBuilder) ->
                 bufferBuilder.endNullable()?.let {
                     it.draw(vertexInputType)
-                    bufferAllocators[vertexInputType]!![drawMode]!!.clear()
+                    ClientTessellator.allocator(drawMode, vertexInputType).clear()
                 }
             }
         }
@@ -122,13 +119,6 @@ sealed class RenderEnvironment(val matrixStack: MatrixStack) {
     open fun relativeToCamera(pos: Vec3d): Vec3d = pos
 
     companion object {
-        @JvmStatic
-        private val bufferAllocators = enumMapOf<VertexInputType, EnumMap<DrawMode, BufferAllocator>> { _ ->
-            enumMapOf<DrawMode, BufferAllocator> { _ ->
-                BufferAllocator(0xC0000)
-            }
-        }
-
         @JvmStatic
         private val bufferPool = Pool<EnumMap<VertexInputType, EnumMap<DrawMode, BufferBuilder>>>(
             ArrayDeque(),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
@@ -23,29 +23,11 @@ import net.minecraft.client.gl.ShaderProgramKey
 import net.minecraft.client.gl.ShaderProgramKeys
 import net.minecraft.client.render.*
 
-sealed interface VertexInputType {
-    val vertexFormat: VertexFormat
-    val shaderProgram: ShaderProgramKey
-
-    object Pos : VertexInputType {
-        override val vertexFormat: VertexFormat
-            get() = VertexFormats.POSITION
-        override val shaderProgram: ShaderProgramKey
-            get() = ShaderProgramKeys.POSITION
-    }
-
-    object PosColor : VertexInputType {
-        override val vertexFormat: VertexFormat
-            get() = VertexFormats.POSITION_COLOR
-        override val shaderProgram: ShaderProgramKey
-            get() = ShaderProgramKeys.POSITION_COLOR
-    }
-
-    object PosTexColor : VertexInputType {
-        override val vertexFormat: VertexFormat
-            get() = VertexFormats.POSITION_TEXTURE_COLOR
-        override val shaderProgram: ShaderProgramKey
-            get() = ShaderProgramKeys.POSITION_TEX_COLOR
-    }
-
+enum class VertexInputType(
+    val vertexFormat: VertexFormat,
+    val shaderProgram: ShaderProgramKey,
+) {
+    Pos(VertexFormats.POSITION, ShaderProgramKeys.POSITION),
+    PosColor(VertexFormats.POSITION_COLOR, ShaderProgramKeys.POSITION_COLOR),
+    PosTexColor(VertexFormats.POSITION_TEXTURE_COLOR, ShaderProgramKeys.POSITION_TEX_COLOR),
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/font/FontRenderer.kt
@@ -288,6 +288,7 @@ class FontRenderer(
             RenderSystem.bindTexture(glyphPage.texture.glId)
             RenderSystem.setShaderTexture(0, glyphPage.texture.glId)
 
+            environment.startBatch()
             for (renderedGlyph in renderedGlyphs) {
                 val glyphDescriptor = renderedGlyph.glyph
 
@@ -302,22 +303,27 @@ class FontRenderer(
                     color.toARGB(),
                 )
             }
+            environment.commitBatch()
             cache.renderedGlyphListPool.offer(renderedGlyphs)
         }
         Pool.Vec3f.offer(vec3f1)
         Pool.Vec3f.offer(vec3f2)
         cache.commitGlyphs.clear()
 
-        for (line in cache.lines) {
-            environment.drawCustomMesh(
-                VertexFormat.DrawMode.DEBUG_LINES,
-                VertexInputType.PosColor,
-            ) { matrix ->
-                vertex(matrix, line.p1.x, line.p1.y, line.p1.z).color(line.color.toARGB())
-                vertex(matrix, line.p2.x, line.p2.y, line.p2.z).color(line.color.toARGB())
+        if (cache.lines.isNotEmpty()) {
+            environment.startBatch()
+            for (line in cache.lines) {
+                environment.drawCustomMesh(
+                    VertexFormat.DrawMode.DEBUG_LINES,
+                    VertexInputType.PosColor,
+                ) { matrix ->
+                    vertex(matrix, line.p1.x, line.p1.y, line.p1.z).color(line.color.toARGB())
+                    vertex(matrix, line.p2.x, line.p2.y, line.p2.z).color(line.color.toARGB())
+                }
+                Pool.Vec3f.offer(line.p1)
+                Pool.Vec3f.offer(line.p2)
             }
-            Pool.Vec3f.offer(line.p1)
-            Pool.Vec3f.offer(line.p2)
+            environment.commitBatch()
         }
 
         cache.lines.clear()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WireframePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WireframePlayer.kt
@@ -44,6 +44,7 @@ data class WireframePlayer(private var pos: Vec3d, private var yaw: Float, priva
 
     fun render(event: WorldRenderEvent, color: Color4b, outlineColor: Color4b) {
         renderEnvironmentForWorld(event.matrixStack) {
+            startBatch()
             withPositionRelativeToCamera(pos) {
                 val matrix = matrixStack.peek().positionMatrix
                 val yRot = -MathHelper.wrapDegrees(yaw.toDouble())
@@ -62,6 +63,7 @@ data class WireframePlayer(private var pos: Vec3d, private var yaw: Float, priva
 
                 drawBox(RENDER_HEAD, color, outlineColor)
             }
+            commitBatch()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderHandler.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/placement/PlacementRenderHandler.kt
@@ -65,7 +65,7 @@ class PlacementRenderHandler(private val placementRenderer: PlacementRenderer, v
             val outlineColor = getOutlineColor(id)
 
             renderEnvironmentForWorld(matrixStack) {
-                // Do not use destructuring declaration which returns boxed [Long] values
+                startBatch()
                 fun drawEntryBox(blockPos: BlockPos, cullData: Long, box: Box, colorFactor: Float) {
                     withPositionRelativeToCamera(blockPos.toVec3d()) {
                         drawBox(
@@ -103,12 +103,14 @@ class PlacementRenderHandler(private val placementRenderer: PlacementRenderer, v
                 }
 
                 currentList.fastIterator().forEach { entry ->
+                    // Do not use destructuring declaration which returns boxed [Long] values
                     val pos = entry.longKey
                     val value = entry.value
                     drawEntryBox(blockPosCache.set(pos), value.cullData, value.box, 1f)
                 }
 
                 outList.long2ObjectEntrySet().removeIf { entry ->
+                    // Do not use destructuring declaration which returns boxed [Long] values
                     val pos = entry.longKey
                     val value = entry.value
 
@@ -126,6 +128,8 @@ class PlacementRenderHandler(private val placementRenderer: PlacementRenderer, v
                         false
                     }
                 }
+
+                commitBatch()
             }
         }
     }


### PR DESCRIPTION
## Overview
This new feature allows us to easily make multiple `drawCustomMesh` invocations draw in once, which makes the performance be better than previous version (using legacy buffer classes).

Sadly I will rewrite this in 1.21.5, but it's good enough for 1.21.4.

## API changes:

### Breaking:

- `sealed interface VertexInputType` -> `enum class VertexInputType` (same for Kotlin usages)
- `RenderEnvironment` becomes `class` again

### New:

- `ClientTessellator`: experimental. Customized `BufferAllocator`s for different usages.
- `fun BuiltBuffer.draw(vertexInputType: VertexInputType)`: unstable. Should not be used anywhere because it will be removed or changed in 1.21.5.
- `RenderEnvironment`: batch draw related API.
