### PR TITLE
feat(CombineMobs/Nametags/Targets): mob count, improvements and missing passive targets

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
@@ -31,7 +31,7 @@ import net.minecraft.entity.mob.MobEntity
  * Combine Mobs
  *
  * This module will disable rendering of entities of the same type that are crammed together
- * TODO: and show a single entity instead with a count of how many entities are crammed together.
+ * and show a single entity instead with a count of how many entities are crammed together.
  *
  * This is useful for example in 2b2t where there are a lot of entities in spawn.
  * The idea behind this module originates from the video
@@ -39,16 +39,14 @@ import net.minecraft.entity.mob.MobEntity
  */
 object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
 
-    /**
-     * Key: type Value: position->count
-     */
-    private val trackedEntitySinceRender = hashMapOf<EntityType<*>, Long2IntOpenHashMap>()
+    private data class CombineKey(val type: EntityType<*>, val babyGroup: Boolean)
 
-    /**
-     * As soon we disable the module, we want to clear the tracked entities
-     */
+    private val renderTracked: HashMap<CombineKey, Long2IntOpenHashMap> = hashMapOf()
+    private val nametagTracked: HashMap<CombineKey, Long2IntOpenHashMap> = hashMapOf()
+
     override fun onDisabled() {
-        trackedEntitySinceRender.clear()
+        renderTracked.clear()
+        nametagTracked.clear()
     }
 
     /**
@@ -56,23 +54,40 @@ object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
      */
     @Suppress("unused")
     val renderGameHandler = handler<GameRenderEvent> {
-        trackedEntitySinceRender.clear()
+        renderTracked.clear()
+        nametagTracked.clear()
     }
 
-    fun trackEntity(entity: Entity): Boolean {
-        if (entity !is MobEntity) {
-            return false
-        }
-
-        val entityType = entity.type
-
-        val pos = entity.blockPos.asLong()
-
-        val trackedEntities = trackedEntitySinceRender.getOrPut(entityType, ::Long2IntOpenHashMap)
-        val count = trackedEntities.getOrDefault(pos, 0)
-        trackedEntities.put(pos, count + 1)
-
-        return count > 0
+    private fun keyFor(mob: MobEntity): CombineKey {
+        val babyGroup = mob.isBaby
+        return CombineKey(mob.type, babyGroup)
     }
 
+    @JvmOverloads
+    fun trackEntity(entity: Entity, forNametag: Boolean = false): Boolean {
+        val mob = entity as? MobEntity ?: return false
+        val target = if (forNametag) nametagTracked else renderTracked
+
+        val key = keyFor(mob)
+        val pos = mob.blockPos.asLong()
+
+        val posMap = target.getOrPut(key, ::Long2IntOpenHashMap)
+        val count = posMap.getOrDefault(pos, 0) + 1
+
+        posMap.put(pos, count)
+
+        return count > 1
+    }
+
+    fun getCombinedCount(entity: Entity): Int {
+        val mob = entity as? MobEntity ?: return 1
+
+        val key = keyFor(mob)
+        val pos = mob.blockPos.asLong()
+
+        val count = renderTracked[key]?.getOrDefault(pos, 0) ?: 0
+        if (count > 0) return count
+
+        return nametagTracked[key]?.getOrDefault(pos, 1) ?: 1
+    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
@@ -39,10 +39,11 @@ import net.minecraft.entity.mob.MobEntity
  */
 object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
 
+    @JvmRecord
     private data class CombineKey(val type: EntityType<*>, val babyGroup: Boolean)
 
-    private val renderTracked: HashMap<CombineKey, Long2IntOpenHashMap> = hashMapOf()
-    private val nametagTracked: HashMap<CombineKey, Long2IntOpenHashMap> = hashMapOf()
+    private val renderTracked = HashMap<CombineKey, Long2IntOpenHashMap>()
+    private val nametagTracked = HashMap<CombineKey, Long2IntOpenHashMap>()
 
     override fun onDisabled() {
         renderTracked.clear()
@@ -72,11 +73,9 @@ object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
         val pos = mob.blockPos.asLong()
 
         val posMap = target.getOrPut(key, ::Long2IntOpenHashMap)
-        val count = posMap.getOrDefault(pos, 0) + 1
+        val count = posMap.addTo(pos, 1)
 
-        posMap.put(pos, count)
-
-        return count > 1
+        return count > 0
     }
 
     fun getCombinedCount(entity: Entity): Int {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render.nametags
 
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleCombineMobs
 import net.ccbluex.liquidbounce.utils.client.asText
 import net.ccbluex.liquidbounce.utils.client.bold
 import net.ccbluex.liquidbounce.utils.client.player
@@ -62,6 +63,14 @@ class NametagTextFormatter(private val entity: Entity) {
         }
 
         outputText.append(nameText)
+
+        if (ModuleCombineMobs.running) {
+            val count = ModuleCombineMobs.getCombinedCount(entity)
+            if (count > 1) {
+                val countText = ("x $count").asText().formatted(Formatting.AQUA).bold(true)
+                outputText.append(" ").append(countText)
+            }
+        }
 
         if (NametagShowOptions.HEALTH.isShowing()) {
             outputText.append(" ").append(this.healthText)
@@ -127,7 +136,6 @@ class NametagTextFormatter(private val entity: Entity) {
                 if (entity.hasHealthScoreboard()) 0f else entity.absorptionAmount).toInt()
 
             val healthColor = when {
-                // Perhaps you should modify the values here
                 actualHealth >= 14 -> Formatting.GREEN
                 actualHealth >= 8 -> Formatting.YELLOW
                 else -> Formatting.RED

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
@@ -30,6 +30,7 @@ import net.ccbluex.liquidbounce.utils.entity.hasHealthScoreboard
 import net.ccbluex.liquidbounce.utils.entity.ping
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.mob.MobEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.text.TextColor
@@ -51,10 +52,13 @@ class NametagTextFormatter(private val entity: Entity) {
         val name = entity.displayName!!
         val nameColor = this.nameColor
 
+        val isBaby = (entity as? MobEntity)?.isBaby == true
+        val baseNameString = (if (isBaby) "Baby " else "") + name.string
+
         val nameText: Text = if (nameColor != null) {
-            name.string.asText().withColor(nameColor)
+            baseNameString.asText().withColor(nameColor)
         } else {
-            name
+            baseNameString.asText()
         }
 
         outputText.append(nameText)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
@@ -42,6 +42,8 @@ import net.minecraft.entity.mob.Angerable
 import net.minecraft.entity.mob.HostileEntity
 import net.minecraft.entity.mob.Monster
 import net.minecraft.entity.mob.WaterCreatureEntity
+import net.minecraft.entity.passive.AllayEntity
+import net.minecraft.entity.passive.BatEntity
 import net.minecraft.entity.passive.PassiveEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket
@@ -138,9 +140,10 @@ private fun EnumSet<Targets>.isInteresting(suspect: Entity): Boolean {
             else -> Targets.PLAYERS in this
         }
         is WaterCreatureEntity -> Targets.WATER_CREATURE in this
-        is PassiveEntity -> Targets.PASSIVE in this
+        is PassiveEntity, is BatEntity, is AllayEntity -> Targets.PASSIVE in this
         is HostileEntity, is Monster -> Targets.HOSTILE in this
         is Angerable -> Targets.ANGERABLE in this
+
         else -> false
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleCombineMobs
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.combat.shouldBeShown
@@ -61,8 +62,15 @@ object RenderedEntities : Collection<LivingEntity> by entities, EventListener {
         }
 
         entities.clear()
+
+        val shouldCheckCombineMobs = ModuleCombineMobs.running
+
         for (entity in world.entities) {
             if (entity is LivingEntity && entity.shouldBeShown()) {
+                if (shouldCheckCombineMobs && ModuleCombineMobs.trackEntity(entity, true)) {
+                    continue
+                }
+
                 entities += entity
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.utils.entity
 
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
@@ -30,7 +31,7 @@ import net.ccbluex.liquidbounce.utils.combat.shouldBeShown
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FIRST_PRIORITY
 import net.minecraft.entity.LivingEntity
 
-private val entities = ArrayList<LivingEntity>()
+private val entities = ReferenceArrayList<LivingEntity>()
 
 /**
  * A readonly [Collection] containing all [LivingEntity] instances that meet the [shouldBeShown] condition.


### PR DESCRIPTION
Improvements for CombineMobs, Nametags, Targets

- **CombineMobs:** Render baby mobs and normal mobs separately.
- **Nametags:** Added mob count from CombineMobs and a "Baby" prefix for baby mobs.
- **Targets:** Added Allay and Bat to the list of passive targets.

<img height="400" alt="Screenshot" src="https://github.com/user-attachments/assets/ea7d9e15-1f29-420c-b213-203e67d94c4b" />
