### PR TITLE
fix: labymod crashing (due to private field)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/PlayerFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/game/PlayerFunctions.kt
@@ -140,7 +140,7 @@ data class PlayerInventoryData(
             armor = player.inventory.armor.map(ItemStack::copy),
             main = player.inventory.main.map(ItemStack::copy),
             crafting = player.playerScreenHandler.craftingInput.heldStacks.map(ItemStack::copy),
-            enderChest = player.enderChestInventory.heldStacks.map(ItemStack::copy),
+            enderChest = player.enderChestInventory.getHeldStacks().map(ItemStack::copy),
         )
     }
 


### PR DESCRIPTION
(using the LabyFabric addon) note: this doesn't fix everything, there's some stuff that's still broken:

- EnvironmentRemapper expects intermediary names, but labymod doesn't remap the client itself to intermediary, causing scripts to not work and packet logger(?) to use the real class name.
- the enhanced chat mod thing makes your screen black
- pressing TAB blacks your screen
- sword blocking doesn't work
- and probably more

but it was enough for me to do funny stuff on roxbot
