### PR TITLE
refactor(render): remove `withColor` call and `Pos` VertexInputType

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -31,12 +31,10 @@ import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
-import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.combat.findEnemy
 import net.ccbluex.liquidbounce.utils.entity.PlayerSimulationCache
 import net.ccbluex.liquidbounce.utils.math.sq
@@ -230,11 +228,12 @@ internal object ModuleTickBase : ClientModule("TickBase", Category.COMBAT) {
         }
 
         renderEnvironmentForWorld(event.matrixStack) {
-            withColor(lineColor) {
-                drawLineStrip(positions = tickBuffer.mapToArray { tick ->
+            drawLineStrip(
+                argb = lineColor.toARGB(),
+                positions = tickBuffer.mapToArray { tick ->
                     relativeToCamera(tick.position).toVec3()
-                })
-            }
+                }
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
@@ -40,7 +40,6 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.TpAuraChoi
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.block.AStarPathBuilder
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
@@ -128,11 +127,12 @@ object AStarMode : TpAuraChoice("AStar"), AStarPathBuilder {
         val (_, path) = pathCache ?: return@handler
 
         renderEnvironmentForWorld(matrixStack) {
-            withColor(Color4b.WHITE) {
-                drawLineStrip(positions = path.mapToArray {
+            drawLineStrip(
+                argb = Color4b.WHITE.toARGB(),
+                positions = path.mapToArray {
                     relativeToCamera(it.toVec3d(0.5, 0.5, 0.5)).toVec3()
-                })
-            }
+                }
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/ImmediateMode.kt
@@ -33,7 +33,6 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.TpAuraChoi
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.client.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
@@ -67,12 +66,11 @@ object ImmediateMode : TpAuraChoice("Immediate") {
 
         renderEnvironmentForWorld(matrixStack) {
             desyncPlayerPosition?.let { playerPosition ->
-                withColor(Color4b.WHITE) {
-                    drawLineStrip(
-                        relativeToCamera(player.pos.add(0.0, 1.0, 0.0)).toVec3(),
-                        relativeToCamera(playerPosition.add(0.0, 1.0, 0.0)).toVec3()
-                    )
-                }
+                drawLineStrip(
+                    Color4b.WHITE.toARGB(),
+                    relativeToCamera(player.pos.add(0.0, 1.0, 0.0)).toVec3(),
+                    relativeToCamera(playerPosition.add(0.0, 1.0, 0.0)).toVec3()
+                )
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -29,7 +29,6 @@ import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleEasyPearl
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.client.PacketQueueManager.Action
 import net.ccbluex.liquidbounce.utils.client.notification
@@ -128,9 +127,10 @@ object ModuleFreeze : ClientModule("Freeze", Category.MOVEMENT, disableOnQuit = 
             .getSnapshotsBetween(0 until this.missedOutTick)
 
         renderEnvironmentForWorld(event.matrixStack) {
-            withColor(Color4b(0x00, 0x80, 0xFF, 0xFF)) {
-                drawLineStrip(positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() })
-            }
+            drawLineStrip(
+                argb = Color4b(0x00, 0x80, 0xFF, 0xFF).toARGB(),
+                positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() },
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -371,9 +371,11 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
 
     class DebuggedQuad(val p1: Vec3d, val p2: Vec3d, override val color: Color4b) : DebuggedGeometry {
         override fun render(env: WorldRenderEnvironment) {
-            env.withColor(color) {
-                this.drawQuad(relativeToCamera(p1).toVec3(), relativeToCamera(p2).toVec3())
-            }
+            env.drawQuad(
+                pos1 = relativeToCamera(p1).toVec3(),
+                pos2 = relativeToCamera(p2).toVec3(),
+                color = color.toARGB(),
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -88,9 +88,10 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
                 .getSnapshotsBetween(0 until this.ticksToPredict)
 
             renderEnvironmentForWorld(event.matrixStack) {
-                withColor(Color4b.BLUE) {
-                    drawLineStrip(positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() })
-                }
+                drawLineStrip(
+                    Color4b.BLUE.toARGB(),
+                    positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3() },
+                )
             }
         }
 
@@ -363,27 +364,31 @@ object ModuleDebug : ClientModule("Debug", Category.RENDER) {
         }
 
         override fun render(env: WorldRenderEnvironment) {
-            env.withColor(color) {
-                this.drawLineStrip(relativeToCamera(from).toVec3(), relativeToCamera(to).toVec3())
-            }
+            env.drawLineStrip(
+                color.toARGB(),
+                env.relativeToCamera(from).toVec3(),
+                env.relativeToCamera(to).toVec3()
+            )
         }
     }
 
     class DebuggedQuad(val p1: Vec3d, val p2: Vec3d, override val color: Color4b) : DebuggedGeometry {
         override fun render(env: WorldRenderEnvironment) {
             env.drawQuad(
-                pos1 = relativeToCamera(p1).toVec3(),
-                pos2 = relativeToCamera(p2).toVec3(),
-                color = color.toARGB(),
+                pos1 = env.relativeToCamera(p1).toVec3(),
+                pos2 = env.relativeToCamera(p2).toVec3(),
+                argb = color.toARGB(),
             )
         }
     }
 
     class DebuggedLineSegment(val from: Vec3d, val to: Vec3d, override val color: Color4b) : DebuggedGeometry {
         override fun render(env: WorldRenderEnvironment) {
-            env.withColor(color) {
-                this.drawLineStrip(relativeToCamera(from).toVec3(), relativeToCamera(to).toVec3())
-            }
+            env.drawLineStrip(
+                color.toARGB(),
+                env.relativeToCamera(from).toVec3(),
+                env.relativeToCamera(to).toVec3(),
+            )
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleRotations.kt
@@ -30,7 +30,6 @@ import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.entity.lastRotation
@@ -122,9 +121,10 @@ object ModuleRotations : ClientModule("Rotations", Category.RENDER) {
 
             if (drawVectorLine) {
                 renderEnvironmentForWorld(matrixStack) {
-                    withColor(vectorLine) {
-                        drawLineStrip(eyeVector, eyeVector + Vec3(interpolatedRotationVec * 100.0))
-                    }
+                    drawLineStrip(
+                        vectorLine.toARGB(),
+                        eyeVector, eyeVector + Vec3(interpolatedRotationVec * 100.0)
+                    )
                 }
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -257,9 +257,7 @@ object ModuleStorageESP : ClientModule("StorageESP", Category.RENDER, aliases = 
                     if (!type.enabled || !type.tracers || type.color.a <= 0) continue
                     val pos = relativeToCamera(blockPos.toCenterPos()).toVec3()
 
-                    withColor(type.color) {
-                        drawLines(eyeVector, pos, pos)
-                    }
+                    drawLines(type.color.toARGB(), eyeVector, pos, pos)
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTracers.kt
@@ -111,9 +111,10 @@ object ModuleTracers : ClientModule("Tracers", Category.RENDER) {
 
                     val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3()
 
-                    withColor(color) {
-                        drawLines(eyeVector, pos, pos, pos + Vec3(0f, entity.height, 0f))
-                    }
+                    drawLines(
+                        argb = color.toARGB(),
+                        eyeVector, pos, pos, pos + Vec3(0f, entity.height, 0f)
+                    )
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmVisualizer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmVisualizer.kt
@@ -41,13 +41,12 @@ object AutoFarmVisualizer : ToggleableConfigurable(ModuleAutoFarm, "Visualize", 
         @Suppress("unused")
         private val renderHandler = handler<WorldRenderEvent> { event ->
             renderEnvironmentForWorld(event.matrixStack) {
-                withColor(color) {
-                    AutoFarmAutoWalk.walkTarget?.let { target ->
-                        drawLines(
-                            relativeToCamera(player.interpolateCurrentPosition(event.partialTicks)).toVec3(),
-                            relativeToCamera(target).toVec3()
-                        )
-                    }
+                AutoFarmAutoWalk.walkTarget?.let { target ->
+                    drawLines(
+                        color.toARGB(),
+                        relativeToCamera(player.interpolateCurrentPosition(event.partialTicks)).toVec3(),
+                        relativeToCamera(target).toVec3()
+                    )
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapComponent.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapComponent.kt
@@ -165,6 +165,7 @@ object MinimapComponent : NativeComponent("Minimap", false, Alignment(
 
             drawShadowForBB(boundingBox, from, to)
             drawLines(
+                argb = Color4b.WHITE.toARGB(),
                 // Cursor
                 Vec3(boundingBox.xMin, centerBB.y, 0.0F),
                 Vec3(boundingBox.xMax, centerBB.y, 0.0F),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -272,21 +272,6 @@ inline fun WorldRenderEnvironment.longLines(draw: RenderEnvironment.() -> Unit) 
 }
 
 /**
- * Extension function to apply a color transformation to the current rendering environment.
- *
- * @param color4b The color transformation.
- * @param draw The block of code to be executed in the transformed environment.
- */
-inline fun RenderEnvironment.withColor(color4b: Color4b, draw: RenderEnvironment.() -> Unit) {
-    RenderSystem.setShaderColor(color4b.r / 255f, color4b.g / 255f, color4b.b / 255f, color4b.a / 255f)
-    try {
-        draw()
-    } finally {
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f)
-    }
-}
-
-/**
  * Extension function to disable cull
  * Good for rendering faces that should be visible from both sides
  *
@@ -327,11 +312,11 @@ fun BuiltBuffer.draw(vertexInputType: VertexInputType) = use { builtBuffer ->
  *
  * @param lines The vectors representing the lines.
  */
-fun RenderEnvironment.drawLines(vararg lines: Vec3) {
+fun RenderEnvironment.drawLines(argb: Int, vararg lines: Vec3) {
     drawLines(
         lines.unmodifiable(),
         mode = DrawMode.DEBUG_LINES,
-        argb = TODO()
+        argb = argb,
     )
 }
 
@@ -340,11 +325,11 @@ fun RenderEnvironment.drawLines(vararg lines: Vec3) {
  *
  * @param positions The vectors representing the line strip.
  */
-fun RenderEnvironment.drawLineStrip(vararg positions: Vec3) {
+fun RenderEnvironment.drawLineStrip(argb: Int, vararg positions: Vec3) {
     drawLines(
         positions.unmodifiable(),
         mode = DrawMode.DEBUG_LINE_STRIP,
-        argb = TODO()
+        argb = argb,
     )
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -327,9 +327,12 @@ fun BuiltBuffer.draw(vertexInputType: VertexInputType) = use { builtBuffer ->
  *
  * @param lines The vectors representing the lines.
  */
-
 fun RenderEnvironment.drawLines(vararg lines: Vec3) {
-    drawLines(lines.unmodifiable(), mode = DrawMode.DEBUG_LINES)
+    drawLines(
+        lines.unmodifiable(),
+        mode = DrawMode.DEBUG_LINES,
+        argb = TODO()
+    )
 }
 
 /**
@@ -338,7 +341,11 @@ fun RenderEnvironment.drawLines(vararg lines: Vec3) {
  * @param positions The vectors representing the line strip.
  */
 fun RenderEnvironment.drawLineStrip(vararg positions: Vec3) {
-    drawLines(positions.unmodifiable(), mode = DrawMode.DEBUG_LINE_STRIP)
+    drawLines(
+        positions.unmodifiable(),
+        mode = DrawMode.DEBUG_LINE_STRIP,
+        argb = TODO()
+    )
 }
 
 /**
@@ -347,7 +354,11 @@ fun RenderEnvironment.drawLineStrip(vararg positions: Vec3) {
  * @param lines The vectors representing the lines.
  * @param mode The draw mode for the lines.
  */
-private fun RenderEnvironment.drawLines(lines: List<Vec3>, mode: DrawMode = DrawMode.DEBUG_LINES) {
+private fun RenderEnvironment.drawLines(
+    lines: List<Vec3>,
+    mode: DrawMode,
+    argb: Int,
+) {
     // If the array of lines is empty, we don't need to draw anything
     if (lines.isEmpty()) {
         return
@@ -355,10 +366,10 @@ private fun RenderEnvironment.drawLines(lines: List<Vec3>, mode: DrawMode = Draw
 
     drawCustomMesh(
         mode,
-        VertexInputType.Pos,
+        VertexInputType.PosColor,
     ) { matrix ->
         lines.forEach { (x, y, z) ->
-            vertex(matrix, x, y, z)
+            vertex(matrix, x, y, z).color(argb)
         }
     }
 }
@@ -413,15 +424,15 @@ fun RenderEnvironment.drawTextureQuad(
     }
 }
 
-fun RenderEnvironment.drawQuad(pos1: Vec3, pos2: Vec3) {
+fun RenderEnvironment.drawQuad(pos1: Vec3, pos2: Vec3, argb: Int) {
     drawCustomMesh(
         DrawMode.QUADS,
-        VertexInputType.Pos,
+        VertexInputType.PosColor,
     ) { matrix ->
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos2.z)
-        vertex(matrix, pos2.x, pos1.y, pos2.z)
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos2.z).color(argb)
+        vertex(matrix, pos2.x, pos1.y, pos2.z).color(argb)
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
     }
 }
 
@@ -437,22 +448,22 @@ fun RenderEnvironment.drawColoredQuad(pos1: Vec3, pos2: Vec3, argb: Int) {
     }
 }
 
-fun RenderEnvironment.drawQuadOutlines(pos1: Vec3, pos2: Vec3) {
+fun RenderEnvironment.drawQuadOutlines(pos1: Vec3, pos2: Vec3, argb: Int) {
     drawCustomMesh(
         DrawMode.DEBUG_LINES,
-        VertexInputType.Pos,
+        VertexInputType.PosColor,
     ) { matrix ->
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
 
-        vertex(matrix, pos1.x, pos2.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos1.z)
+        vertex(matrix, pos1.x, pos2.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos1.z).color(argb)
 
-        vertex(matrix, pos2.x, pos1.y, pos1.z)
-        vertex(matrix, pos2.x, pos2.y, pos1.z)
+        vertex(matrix, pos2.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos2.y, pos1.z).color(argb)
 
-        vertex(matrix, pos1.x, pos1.y, pos1.z)
-        vertex(matrix, pos2.x, pos1.y, pos1.z)
+        vertex(matrix, pos1.x, pos1.y, pos1.z).color(argb)
+        vertex(matrix, pos2.x, pos1.y, pos1.z).color(argb)
     }
 }
 
@@ -475,14 +486,14 @@ fun RenderEnvironment.drawColoredQuadOutlines(pos1: Vec3, pos2: Vec3, argb: Int)
     }
 }
 
-fun RenderEnvironment.drawTriangle(p1: Vec3, p2: Vec3, p3: Vec3) {
+fun RenderEnvironment.drawTriangle(p1: Vec3, p2: Vec3, p3: Vec3, argb: Int) {
     drawCustomMesh(
         DrawMode.TRIANGLES,
-        VertexInputType.Pos,
+        VertexInputType.PosColor,
     ) { matrix ->
-        vertex(matrix, p1.x, p1.y, p1.z)
-        vertex(matrix, p2.x, p2.y, p2.z)
-        vertex(matrix, p3.x, p3.y, p3.z)
+        vertex(matrix, p1.x, p1.y, p1.z).color(argb)
+        vertex(matrix, p2.x, p2.y, p2.z).color(argb)
+        vertex(matrix, p3.x, p3.y, p3.z).color(argb)
     }
 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
@@ -27,6 +27,7 @@ enum class VertexInputType(
     val vertexFormat: VertexFormat,
     val shaderProgram: ShaderProgramKey,
 ) {
+    @Deprecated("use PosColor for colored rendering instead")
     Pos(VertexFormats.POSITION, ShaderProgramKeys.POSITION),
     PosColor(VertexFormats.POSITION_COLOR, ShaderProgramKeys.POSITION_COLOR),
     PosTexColor(VertexFormats.POSITION_TEXTURE_COLOR, ShaderProgramKeys.POSITION_TEX_COLOR),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexInputType.kt
@@ -27,8 +27,6 @@ enum class VertexInputType(
     val vertexFormat: VertexFormat,
     val shaderProgram: ShaderProgramKey,
 ) {
-    @Deprecated("use PosColor for colored rendering instead")
-    Pos(VertexFormats.POSITION, ShaderProgramKeys.POSITION),
     PosColor(VertexFormats.POSITION_COLOR, ShaderProgramKeys.POSITION_COLOR),
     PosTexColor(VertexFormats.POSITION_TEXTURE_COLOR, ShaderProgramKeys.POSITION_TEX_COLOR),
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/PacketQueueManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/client/PacketQueueManager.kt
@@ -28,7 +28,6 @@ import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.FINAL_DECISION
 import net.ccbluex.liquidbounce.utils.render.WireframePlayer
@@ -167,9 +166,10 @@ object PacketQueueManager : EventListener {
 
         renderEnvironmentForWorld(matrixStack) {
             // Use LiquidBounce accent color
-            withColor(Color4b.LIQUID_BOUNCE) {
-                drawLineStrip(positions = positions.mapToArray { vec3d -> Vec3(relativeToCamera(vec3d)) })
-            }
+            drawLineStrip(
+                argb = Color4b.LIQUID_BOUNCE.toARGB(),
+                positions = positions.mapToArray { vec3d -> Vec3(relativeToCamera(vec3d)) },
+            )
         }
 
         val perspectiveEvent = EventManager.callEvent(PerspectiveEvent(mc.options.perspective))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/TargetRenderer.kt
@@ -399,18 +399,14 @@ class OverlayTargetRenderer(module: ClientModule) : TargetRenderer<GUIRenderEnvi
                     Vec3d(0.0, entity.height.toDouble(), 0.0)
 
             val screenPos = calculateScreenPos(pos) ?: return
-
-            with(env) {
-                withColor(color) {
-                    drawCustomMesh(
-                        VertexFormat.DrawMode.TRIANGLE_STRIP,
-                        VertexInputType.Pos,
-                    ) {
-                        vertex(it, screenPos.x - 5 * size, screenPos.y - 10 * size, 1f)
-                        vertex(it, screenPos.x, screenPos.y, 1f)
-                        vertex(it, screenPos.x + 5 * size, screenPos.y - 10 * size, 1f)
-                    }
-                }
+            val argb = color.toARGB()
+            env.drawCustomMesh(
+                VertexFormat.DrawMode.TRIANGLE_STRIP,
+                VertexInputType.PosColor,
+            ) {
+                vertex(it, screenPos.x - 5 * size, screenPos.y - 10 * size, 1f).color(argb)
+                vertex(it, screenPos.x, screenPos.y, 1f).color(argb)
+                vertex(it, screenPos.x + 5 * size, screenPos.y - 10 * size, 1f).color(argb)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
@@ -28,7 +28,6 @@ import net.ccbluex.liquidbounce.render.drawBoxSide
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withColor
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.block.getState
@@ -275,9 +274,9 @@ class TrajectoryInfoRenderer(
         matrixStack: MatrixStack,
     ) {
         renderEnvironmentForWorld(matrixStack) {
-            withColor(color) {
-                drawLineStrip(positions = positions.mapToArray { relativeToCamera(it + renderOffset).toVec3() })
-            }
+            drawLineStrip(
+                color.toARGB(),
+                positions = positions.mapToArray { relativeToCamera(it + renderOffset).toVec3() })
         }
     }
 


### PR DESCRIPTION
API changes:
- Removed `RenderEnvironment.withColor` because it's incompatible with 1.21.5 and current batch rendering.
- Now `drawLines` and `drawLineStrip` accepts an ARGB color value for rendering. They don't need to work with `withColor` block now, and support batch rendering.
- Removed `VertexInputType.Pos` because it's unused. If you use it, please migrate to `PosColor`.