### PR TITLE
fix(BlockPlacer):not work with some times 

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacerRotationModes.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/block/placer/BlockPlacerRotationModes.kt
@@ -93,9 +93,6 @@ class NormalRotationMode(configurable: ChoiceConfigurable<BlockPlacerRotationMod
 
         return true
     }
-
-    override fun getVerificationRotation(targetedRotation: Rotation): Rotation = RotationManager.serverRotation
-
 }
 
 /**


### PR DESCRIPTION
When postMove=false, doPlacement runs at the start of the tick, but serverRotation hasn’t updated yet because the movement packet hasn’t been sent, so the check fails using the old rotation.