### PR TITLE
Fix Smooth Camera breaks Free Look

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
@@ -148,16 +148,25 @@ public abstract class MixinCamera {
 
     @ModifyReturnValue(method = "getPos", at = @At("RETURN"))
     private Vec3d modifyGetPos(Vec3d original) {
+        if (ModuleFreeLook.INSTANCE.getRunning()) {
+            return original;
+        }
         return ModuleSmoothCamera.shouldApplyChanges() ? ModuleSmoothCamera.INSTANCE.getSmoothPos() : original;
     }
 
     @ModifyReturnValue(method = "getYaw", at = @At("RETURN"))
     private float modifyGetYaw(float original) {
+        if (ModuleFreeLook.INSTANCE.getRunning()) {
+            return original;
+        }
         return ModuleSmoothCamera.shouldApplyChanges() ? ModuleSmoothCamera.INSTANCE.getSmoothYaw() : original;
     }
 
     @ModifyReturnValue(method = "getPitch", at = @At("RETURN"))
     private float modifyGetPitch(float original) {
+        if (ModuleFreeLook.INSTANCE.getRunning()) {
+            return original;
+        }
         return ModuleSmoothCamera.shouldApplyChanges() ? ModuleSmoothCamera.INSTANCE.getSmoothPitch() : original;
     }
 }


### PR DESCRIPTION
When FreeLook is active, force the camera to use the original position and ignore SmoothCamera

Fix #6840
Test on Linux