### PR TITLE
fix(fucker/nuker): use of getOutlineShape instead getCollisionShape

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/fucker/ModuleFucker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/fucker/ModuleFucker.kt
@@ -255,7 +255,7 @@ object ModuleFucker : ClientModule("Fucker", Category.WORLD, aliases = listOf("B
                 else -> true
             }
         }.toCollection(WeightedSortedList(upperBound = range.sq().toDouble()) { (pos, state) ->
-            state.getCollisionShape(world, pos, ShapeContext.of(player))
+            state.getOutlineShape(world, pos, ShapeContext.of(player))
                 .offset(pos)
                 .getClosestSquaredDistanceTo(player.eyePos)
         }).mapToArray { it.first }.unmodifiable()
@@ -459,7 +459,7 @@ object ModuleFucker : ClientModule("Fucker", Category.WORLD, aliases = listOf("B
 
     private val comparator = Comparator.comparingDouble(ToDoubleFunction(::miningDuration))
         .thenComparingDouble(ToDoubleFunction { (pos, state) ->
-            state.getCollisionShape(world, pos, ShapeContext.of(player))
+            state.getOutlineShape(world, pos, ShapeContext.of(player))
                 .offset(pos)
                 .getClosestSquaredDistanceTo(player.eyePos)
         })

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/area/NukerArea.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/nuker/area/NukerArea.kt
@@ -46,7 +46,7 @@ sealed class NukerArea(name: String) : Choice(name) {
             return false
         }
 
-        val shape = state.getCollisionShape(world, pos, ShapeContext.of(player))
+        val shape = state.getOutlineShape(world, pos, ShapeContext.of(player))
 
         if (shape.isEmpty) {
             return false


### PR DESCRIPTION
Using getOutlineShape instead of getCollisionShape allows Fucker & Nuker to interact with blocks that dont have a collisionbox like grass.