### PR TITLE
fix(Theme): unregister event hooks on closing theme and destroying component

### DIFF
--- a/src-theme/src/integration/ws.ts
+++ b/src-theme/src/integration/ws.ts
@@ -1,5 +1,6 @@
 import {WS_BASE} from "./host";
 import type {EventMap} from "./events";
+import {onDestroy} from "svelte";
 
 console.log("Connecting to server at: ", WS_BASE);
 
@@ -45,6 +46,16 @@ export function listenAlways<NAME extends keyof EventMap>(eventName: NAME, callb
     alwaysListeners.get(eventName)!!.push(callback);
 }
 
+/**
+ * Registers a event listener that will be called on every event of the given name.
+ *
+ * The listener will be automatically removed when the component is destroyed.
+ *
+ * Should only be used inside a Svelte component.
+ *
+ * @param eventName
+ * @param callback
+ */
 export function listen<NAME extends keyof EventMap>(eventName: NAME, callback: (event: EventMap[NAME]) => void) {
     if (!listeners.has(eventName)) {
         listeners.set(eventName, []);
@@ -52,7 +63,7 @@ export function listen<NAME extends keyof EventMap>(eventName: NAME, callback: (
 
     listeners.get(eventName)!!.push(callback);
 
-    return () => deleteListener(eventName, callback);
+    onDestroy(() => deleteListener(eventName, callback));
 }
 
 export function cleanupListeners() {

--- a/src-theme/src/routes/menu/altmanager/altmanager_store.ts
+++ b/src-theme/src/routes/menu/altmanager/altmanager_store.ts
@@ -1,6 +1,6 @@
 import {writable} from "svelte/store";
-import {listen} from "../../../integration/ws";
+import {listenAlways} from "../../../integration/ws";
 
 export const isLoggingIn = writable(false);
 
-listen("accountManagerLogin", () => isLoggingIn.set(false));
+listenAlways("accountManagerLogin", () => isLoggingIn.set(false));

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/Theme.kt
@@ -24,6 +24,7 @@ import net.ccbluex.liquidbounce.api.core.BaseApi
 import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
+import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer
 import net.ccbluex.liquidbounce.integration.interop.middleware.AuthMiddleware
 import net.ccbluex.liquidbounce.integration.theme.component.Component
@@ -80,10 +81,10 @@ class Theme private constructor(val origin: Origin, url: String) :
         }
     }
 
-    var components: MutableList<Component>
-        field: MutableList<Component>? = null
-        private set
-        get() = requireNotNull(field) { "components not loaded" }
+    private var _components: List<Component>? = null
+
+    val components: List<Component>
+        get() = requireNotNull(_components) { "components not loaded" }
 
     var settings: Configurable
         field: Configurable? = null
@@ -91,7 +92,7 @@ class Theme private constructor(val origin: Origin, url: String) :
         get() = requireNotNull(field) { "settings not loaded" }
 
     private suspend fun loadComponents() {
-        components = metadata.components.mapNotNullTo(mutableListOf()) { name ->
+        _components = metadata.components.mapNotNullTo(mutableListOf()) { name ->
             val componentFactory = runCatching {
                 get<JsonComponentFactory>("/components/${name.lowercase(Locale.US)}.json")
             }.onFailure {
@@ -220,6 +221,7 @@ class Theme private constructor(val origin: Origin, url: String) :
     override fun close() {
         themeBackgroundShader?.close()
         themeBackgroundTexture?.close()
+        _components?.forEach { EventManager.unregisterEventHandler(it) }
     }
 
     override fun toString() = "Theme(name=${metadata.name}, origin=${origin.choiceName}, url=$baseUrl)"


### PR DESCRIPTION
fixes 2 bugs:
- `Theme.close` doesn't unregister event hooks for components (Kotlin side)
- Svelte components don't unregister WS event listener on destroyed (TS side)