### PR TITLE
fix(PotionSpoof): no attributes applied

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModulePotionSpoof.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModulePotionSpoof.kt
@@ -76,11 +76,16 @@ object ModulePotionSpoof : ClientModule("PotionSpoof", Category.PLAYER) {
 
     @Suppress("unused")
     private val tickHandler = handler<PlayerTickEvent> {
-        for (configurable in statusEffectValues) {
-            if (configurable.enabled) {
-                player.addStatusEffect(configurable.instance)
-            } else if (player.getStatusEffect(configurable.registryEntry)?.duration == 0) {
-                player.removeStatusEffect(configurable.registryEntry)
+        for (effect in statusEffectValues) {
+            if (effect.enabled) {
+                player.addStatusEffect(effect.instance)
+                effect.instance.effectType.value().onApplied(
+                    player.attributes,
+                    effect.instance.amplifier
+                )
+            } else if (player.getStatusEffect(effect.registryEntry)?.duration == 0) {
+                player.removeStatusEffect(effect.registryEntry)
+                effect.instance.effectType.value().onRemoved(player.attributes)
             }
         }
     }


### PR DESCRIPTION
The PotionSpoof was not applying attributes such as speed. This fixes https://github.com/CCBlueX/LiquidBounce/issues/6504