### PR TITLE
fix: CombineMob desync with RenderedEntities

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleCombineMobs.kt
@@ -19,10 +19,12 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import net.ccbluex.liquidbounce.event.events.GameRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.utils.entity.RenderedEntities
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityType
 import net.minecraft.entity.mob.MobEntity
@@ -42,10 +44,17 @@ object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
     @JvmRecord
     private data class CombineKey(val type: EntityType<*>, val babyGroup: Boolean)
 
-    private val renderTracked = HashMap<CombineKey, Long2IntOpenHashMap>()
-    private val nametagTracked = HashMap<CombineKey, Long2IntOpenHashMap>()
+    private val renderTracked = Object2ObjectOpenHashMap<CombineKey, Long2IntOpenHashMap>()
+    private val nametagTracked = Object2ObjectOpenHashMap<CombineKey, Long2IntOpenHashMap>()
+
+    override fun onEnabled() {
+        RenderedEntities.subscribe(this)
+        RenderedEntities.onUpdated(nametagTracked::clear)
+        super.onEnabled()
+    }
 
     override fun onDisabled() {
+        RenderedEntities.unsubscribe(this)
         renderTracked.clear()
         nametagTracked.clear()
     }
@@ -54,9 +63,8 @@ object ModuleCombineMobs : ClientModule("CombineMobs", Category.RENDER) {
      * On each frame, we start with a clean slate
      */
     @Suppress("unused")
-    val renderGameHandler = handler<GameRenderEvent> {
+    private val renderGameHandler = handler<GameRenderEvent> {
         renderTracked.clear()
-        nametagTracked.clear()
     }
 
     private fun keyFor(mob: MobEntity): CombineKey {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/ModuleNametags.kt
@@ -62,7 +62,7 @@ object ModuleNametags : ClientModule("Nametags", Category.RENDER) {
 
     override fun onEnabled() {
         RenderedEntities.subscribe(this)
-        RenderedEntities.onUpdate(::collectAndSortNametagsToRender)
+        RenderedEntities.onUpdated(::collectAndSortNametagsToRender)
     }
 
     @Suppress("unused")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/RenderedEntities.kt
@@ -46,7 +46,7 @@ object RenderedEntities : Collection<LivingEntity> by entities, EventListener {
     private val onUpdate = ReferenceArrayList<Pair<EventListener, Runnable>>()
 
     context(listener: EventListener)
-    fun onUpdate(callback: Runnable) {
+    fun onUpdated(callback: Runnable) {
         onUpdate += listener to callback
     }
 


### PR DESCRIPTION
It should clean nametagTracked on RenderedEntities updated (or before each update) instead of on frame along with renderTracked