### PR TITLE
fix(gradle): configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
-org.gradle.configuration-cache=true
+#org.gradle.configuration-cache=true
 # ZGC from JDK 21
 org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseZGC -XX:+ZGenerational
 


### PR DESCRIPTION
This option is straight up broken. DO NOT ENABLE.