### PR TITLE
fix(Scaffold/Down): allow not visible faces

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldNormalTechnique.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/ScaffoldNormalTechnique.kt
@@ -38,6 +38,7 @@ import net.ccbluex.liquidbounce.utils.math.geometry.Line
 import net.ccbluex.liquidbounce.utils.math.toBlockPos
 import net.minecraft.entity.EntityPose
 import net.minecraft.item.ItemStack
+import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3i
@@ -92,7 +93,10 @@ object ScaffoldNormalTechnique : ScaffoldTechnique("Normal") {
                 offsets,
                 priorityComparator,
             ),
-            FaceHandlingOptions(facePositionFactory),
+            FaceHandlingOptions(
+                facePositionFactory,
+                considerFacingAwayFaces = ScaffoldDownFeature.shouldGoDown
+            ),
             stackToPlaceWith = bestStack,
             PlayerLocationOnPlacement(position = predictedPos, pose = predictedPose),
         )
@@ -121,6 +125,22 @@ object ScaffoldNormalTechnique : ScaffoldTechnique("Normal") {
         }
 
         return super.getRotations(target)
+    }
+
+    override fun getCrosshairTarget(target: BlockPlacementTarget?, rotation: Rotation): BlockHitResult? {
+        val crosshairTarget = super.getCrosshairTarget(target ?: return null, rotation)
+
+        // Prefer a visible hit result
+        if (crosshairTarget != null && target.doesCrosshairTargetFullFillRequirements(crosshairTarget)) {
+            return crosshairTarget
+        }
+
+        // Allow a non-visible hit result
+        if (ScaffoldDownFeature.shouldGoDown) {
+            return target.blockHitResult
+        }
+
+        return null
     }
 
     private fun getFacePositionFactoryForConfig(predictedPos: Vec3d, predictedPose: EntityPose, optimalLine: Line?):


### PR DESCRIPTION
This allows the Down-Feature of Scaffold to finally work as expected. Be aware that this will not work on anti-cheats with ray-casting.

fixes https://github.com/CCBlueX/LiquidBounce/issues/3357


https://github.com/user-attachments/assets/302d0f93-0373-4d5c-810f-03a18b7709c2

