### PR TITLE
feat: EnderChestBreaker

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraftClient.java
@@ -31,6 +31,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
 import net.ccbluex.liquidbounce.features.module.modules.exploit.ModuleMultiActions;
 import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleMiddleClickAction;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleAutoBreak;
+import net.ccbluex.liquidbounce.features.module.modules.player.ModuleEnderChestBreaker;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleNoBlockInteract;
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features.FeatureSilentScreen;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleXRay;
@@ -139,6 +140,9 @@ public abstract class MixinMinecraftClient {
     @Shadow
     @org.jetbrains.annotations.Nullable
     public ClientWorld world;
+
+    @Shadow
+    protected abstract void doItemUse();
 
     /**
      * Entry point of our hacked client
@@ -416,6 +420,15 @@ public abstract class MixinMinecraftClient {
             if (ModuleAutoBreak.INSTANCE.getEnabled()) {
                 this.handleBlockBreaking(this.options.attackKey.isPressed());
             }
+
+            if (ModuleEnderChestBreaker.INSTANCE.getEnabled()) {
+                if (ModuleEnderChestBreaker.canUseOffhand()) {
+                    this.doItemUse();
+                }
+                else {
+                    this.handleBlockBreaking(this.options.attackKey.isPressed());
+                }
+            }
         }
     }
 
@@ -454,7 +467,7 @@ public abstract class MixinMinecraftClient {
         final BlockHitResult blockHitResult = (BlockHitResult) this.crosshairTarget;
         if (blockHitResult == null) return; // it should never be null
 
-        if (ModuleNoBlockInteract.INSTANCE.getRunning() &&
+        if ((ModuleNoBlockInteract.INSTANCE.getRunning() || ModuleEnderChestBreaker.INSTANCE.getRunning()) &&
                 ModuleNoBlockInteract.INSTANCE.shouldSneak(blockHitResult)) {
 
             ModuleNoBlockInteract.INSTANCE.startSneaking();

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -331,6 +331,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleAntiAFK,
             ModuleAntiExploit,
             ModuleAutoBreak,
+            ModuleEnderChestBreaker,
             ModuleAutoFish,
             ModuleAutoRespawn,
             ModuleAutoWindCharge,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEnderChestBreaker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEnderChestBreaker.kt
@@ -1,0 +1,98 @@
+package net.ccbluex.liquidbounce.features.module.modules.player
+
+import net.ccbluex.liquidbounce.event.events.KeybindIsPressedEvent
+import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.features.module.Category
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.modules.player.offhand.ModuleOffhand
+import net.ccbluex.liquidbounce.features.module.modules.world.ModuleAirPlace
+import net.ccbluex.liquidbounce.utils.block.getBlock
+import net.ccbluex.liquidbounce.utils.block.getState
+import net.ccbluex.liquidbounce.utils.client.chat
+import net.ccbluex.liquidbounce.utils.client.markAsError
+import net.ccbluex.liquidbounce.utils.inventory.*
+import net.ccbluex.liquidbounce.utils.item.isConsumable
+import net.minecraft.block.Blocks
+import net.minecraft.client.option.KeyBinding
+import net.minecraft.item.Items
+import net.minecraft.util.hit.BlockHitResult
+
+/**
+ * EnderChestBreaker
+ * Automatically breaks ender chests from your inventory.
+ */
+object ModuleEnderChestBreaker : ClientModule("EnderChestBreaker", Category.PLAYER) {
+    val allowAirPlace by boolean("AllowAirPlace", false)
+    private val inventoryConstraints = tree(
+        PlayerInventoryConstraints().apply {
+            requirements += InventoryRequirements.NO_MOVEMENT
+        }
+    )
+
+    @Suppress("unused")
+    private val tickHandler = tickHandler {
+        if (ModuleOffhand.isOperating()) {
+            chat(markAsError(message("offhandConflict")))
+            enabled = false
+        }
+    }
+
+    @JvmStatic
+    fun canUseOffhand(): Boolean {
+        if (!player.offHandStack.isOf(Items.ENDER_CHEST) || player.mainHandStack.isConsumable) return false
+
+        val hit = mc.crosshairTarget as? BlockHitResult ?: return false
+        val targetBlock = hit.blockPos.getBlock() ?: return false
+
+        if (targetBlock == Blocks.ENDER_CHEST) return false
+
+        val adjacent = world.getBlockState(hit.blockPos.offset(hit.side))
+        if (adjacent.block == Blocks.ENDER_CHEST) return false
+
+        val targetState = world.getBlockState(hit.blockPos)
+        if (!targetState.fluidState.isEmpty) return false
+
+        if (targetState.isAir) return allowAirPlace && ModuleAirPlace.running
+
+        return Blocks.ENDER_CHEST.defaultState.canPlaceAt(world, hit.blockPos)
+    }
+
+
+    @Suppress("unused")
+    private val inventoryScheduleHandler = handler<ScheduleInventoryActionEvent> { event ->
+        if (player.offHandStack.isOf(Items.ENDER_CHEST)) return@handler
+
+        val fromSlot = (Slots.Hotbar + Slots.Inventory).findSlot(Items.ENDER_CHEST) ?: return@handler
+
+        val actions = buildList(3) {
+            this += InventoryAction.Click.performPickup(slot = fromSlot)
+            this += InventoryAction.Click.performPickup(slot = OffHandSlot)
+            if (!OffHandSlot.itemStack.isEmpty) this += InventoryAction.Click.performPickup(slot = fromSlot)
+        }
+
+        event.schedule(inventoryConstraints, actions)
+    }
+
+    @Suppress("unused")
+    private val keybindIsPressedHandler = handler<KeybindIsPressedEvent> { event ->
+        if (event.keyBinding != mc.options.attackKey || mc.attackCooldown > 0) return@handler
+
+        val hit = mc.crosshairTarget as? BlockHitResult ?: return@handler
+        val state = hit.blockPos.getState() ?: return@handler
+        val isTargetEChest = state.block == Blocks.ENDER_CHEST
+
+        if (canUseOffhand()) {
+            KeyBinding.onKeyPressed(mc.options.useKey.boundKey)
+            return@handler
+        }
+
+        if (!isTargetEChest) return@handler
+
+        if (!interaction.isBreakingBlock) {
+            KeyBinding.onKeyPressed(mc.options.attackKey.boundKey)
+        }
+        event.isPressed = true
+    }
+}

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -529,6 +529,8 @@
   "liquidbounce.module.elytraFly.description": "Makes controlling an elytra easier.",
   "liquidbounce.module.elytraFly.messages.altitudeTooLow": "Warning: Altitude too low for optimal performance. Recommended height: %sY",
   "liquidbounce.module.elytraTarget.description": "Following the target on elytra.",
+  "liquidbounce.module.enderChestBreaker.description": "Automatically breaks ender chests from your inventory.",
+  "liquidbounce.module.enderChestBreaker.messages.offhandConflict": "Offhand module must be disabled to use EnderChestBreaker.",
   "liquidbounce.module.targets.description": "Allows you to manage which entities are considered to be your targets.",
   "liquidbounce.module.extendedFirework.description": "Extends the velocity of firework rocket boost.",
   "liquidbounce.module.esp.description": "Highlights all targets allowing you to see them through walls.",


### PR DESCRIPTION
New Module: EnderChestBreaker

Automatically breaks ender chests from your inventory.
Useful when you need a lot of obsidian (e.g., portal farms) and have no other way to get it.