### PR TITLE
fix(AccountManager/Session): de-/serialize token

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ dependencies {
     modRuntimeOnly("com.viaversion:viafabricplus:${project.property("viafabricplus_version")}")
 
     // Minecraft Authlib
-    includeDependency("com.github.CCBlueX:mc-authlib:${project.property("mc_authlib_version")}")
+    includeDependency("net.ccbluex:mc-authlib:${project.property("mc_authlib_version")}")
 
     // JCEF Support
     val mcef = "com.github.CCBlueX:mcef:${project.property("mcef_version")}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ fabric_kotlin_version=1.13.5+kotlin.2.2.10
 # mcef
 mcef_version=3.1.3-1.21.5
 # mc-authlib
-mc_authlib_version=1.4.1
+mc_authlib_version=1.5.0
 # Polyglot
 polyglot_version=25.0.0
 # djl

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/adapter/MinecraftAccountAdapter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/adapter/MinecraftAccountAdapter.kt
@@ -20,16 +20,21 @@
 package net.ccbluex.liquidbounce.config.gson.adapter
 
 import com.google.gson.*
+import net.ccbluex.liquidbounce.LiquidBounce.logger
+import net.ccbluex.liquidbounce.authlib.account.CrackedAccount
 import net.ccbluex.liquidbounce.authlib.account.MinecraftAccount
-import net.ccbluex.liquidbounce.authlib.manage.AccountSerializer
 import java.lang.reflect.Type
 
 object MinecraftAccountAdapter : JsonSerializer<MinecraftAccount>, JsonDeserializer<MinecraftAccount> {
 
     override fun serialize(src: MinecraftAccount, typeOfSrc: Type, context: JsonSerializationContext) =
-        AccountSerializer.toJson(src)
+        src.toJson()
 
-    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext?) =
-        AccountSerializer.fromJson(json.asJsonObject)
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext?) = try {
+        MinecraftAccount.fromJson(json.asJsonObject)
+    } catch (e: Exception) {
+        logger.error("Failed to deserialize MinecraftAccount from JSON.", e)
+        CrackedAccount("Error${json.hashCode()}")
+    }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/AccountFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/AccountFunctions.kt
@@ -51,7 +51,7 @@ fun getAccounts(requestObject: RequestObject): FullHttpResponse {
             addProperty("uuid", profile.uuid.toString())
             addProperty("avatar", formatAvatarUrl(profile.uuid, profile.username))
             add("bans", interopGson.toJsonTree(account.bans))
-            addProperty("type", account.type)
+            addProperty("type", account.type.commonName)
             addProperty("favorite", account.favorite)
         })
     }
@@ -222,7 +222,8 @@ fun deleteAccount(requestObject: RequestObject): FullHttpResponse {
         addProperty("username", profile.username)
         addProperty("uuid", profile.uuid.toString())
         addProperty("avatar", formatAvatarUrl(profile.uuid, profile.username))
-        addProperty("type", account.type)
+
+        addProperty("type", account.type.commonName)
     })
 }
 


### PR DESCRIPTION
This fixes 'Session' accounts to be still working after restarting the game. Also updates the authlib and when an account cannot be deserialized, it will be replaced with a placeholder error account.