### PR TITLE
fix: default position of armor items HUD element

### DIFF
--- a/src-theme/public/components/armoritems.json
+++ b/src-theme/public/components/armoritems.json
@@ -4,7 +4,7 @@
   "singleton": true,
   "alignment": {
     "horizontalAlignment": "CenterTranslated",
-    "horizontalOffset": 225,
+    "horizontalOffset": 240,
     "verticalAlignment": "Bottom",
     "verticalOffset": 15
   }


### PR DESCRIPTION
Currently, armor items are slightly too close to the hotbar.

<img width="529" height="223" alt="image" src="https://github.com/user-attachments/assets/03f36eaf-57b8-4971-841a-f39b7457c856" />


Updated:

<img width="508" height="173" alt="image" src="https://github.com/user-attachments/assets/7d61b83f-4086-48cc-bb90-8da7c9a2e108" />
