### PR TITLE
feat(AntiBot): Sentinel 

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/CustomAntiBotMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/antibot/modes/CustomAntiBotMode.kt
@@ -36,6 +36,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.CRITICAL_MO
 import net.ccbluex.liquidbounce.utils.kotlin.enumMapOf
 import net.ccbluex.liquidbounce.utils.math.sq
 import net.minecraft.entity.EquipmentSlot
+import net.minecraft.entity.attribute.EntityAttributes
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.*
 import net.minecraft.item.equipment.ArmorMaterials
@@ -340,6 +341,9 @@ object CustomAntiBotMode : Choice("Custom"), ModuleAntiBot.IAntiBotMode {
         }),
         ATTRIBUTES("Attributes", { suspected ->
             !attributesSet.contains(suspected.id)
+        }),
+        ILLEGAL_SCALE("IllegalScale", { suspected ->
+            suspected.attributes.getValue(EntityAttributes.SCALE) != 1.0
         })
     }
 }


### PR DESCRIPTION
Bots on Sentinel Anticheat are currently miniature sized and no longer have invisibility effect on it
<img width="2560" height="1407" alt="Screenshot From 2025-11-27 13-24-00" src="https://github.com/user-attachments/assets/b04f0f89-247b-48fa-b8a3-aabb3fa06cfd" />

