### PR TITLE
fix(compatibility/LunarClient): mismatched okhttp version

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/BaseApi.kt
@@ -38,7 +38,7 @@ fun formatAvatarUrl(uuid: UUID?, username: String): String {
  *
  * @param baseUrl The base URL of the API
  */
-abstract class BaseApi(protected val baseUrl: String, val defaultHeaders: Headers = Headers.EMPTY) {
+abstract class BaseApi(protected val baseUrl: String, val defaultHeaders: Headers = HttpClient.EMPTY_HEADERS) {
 
     /**
      * Makes a request and parses the response to the specified type

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
@@ -73,6 +73,13 @@ object HttpClient {
         " (${LiquidBounce.clientCommit}, ${LiquidBounce.clientBranch}, " +
         "${if (LiquidBounce.IN_DEVELOPMENT) "dev" else "release"}, ${System.getProperty("os.name")})"
 
+    /**
+     * Unfortunately, Lunar Client uses OkHttp 4.12.0 which does not have Headers.EMPTY
+     */
+    @Deprecated("Use Headers.EMPTY instead when Lunar Client updates OkHttp to 5.10 or newer.")
+    @JvmField
+    val EMPTY_HEADERS = Headers.Builder().build()
+
     object MediaTypes {
         @JvmField
         val JSON = "application/json; charset=utf-8".toMediaType()


### PR DESCRIPTION
Added our own [EMPTY_HEADERS] field because [Headers.EMPTY] does not exist on Lunar's OkHttp version (4.12.0).