### PR TITLE
fix(Hud/Blur): item renderer not initiating

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/BlurEffectRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/engine/BlurEffectRenderer.kt
@@ -47,6 +47,14 @@ object BlurEffectRenderer : MinecraftShortcuts, EventListener {
 
     private var isDrawingHudFramebuffer = false
 
+    /**
+     * Whether the first draw has been completed yet.
+     *
+     * This fixes a bug where the blur effect would cause the
+     * item renderer to not render any textures.
+     */
+    private var hasCompletedFirstDraw = false
+
     private val overlayFramebuffer = SimpleFramebuffer(
         "BlurOverlay",
         mc.window.framebufferWidth,
@@ -76,7 +84,7 @@ object BlurEffectRenderer : MinecraftShortcuts, EventListener {
     }
 
     fun startOverlayDrawing(context: DrawContext, tickDelta: Float) {
-        if (ModuleHud.running && ModuleHud.isBlurEffectActive) {
+        if (ModuleHud.running && ModuleHud.isBlurEffectActive && hasCompletedFirstDraw) {
             this.isDrawingHudFramebuffer = true
             clearOverlay()
 
@@ -91,6 +99,7 @@ object BlurEffectRenderer : MinecraftShortcuts, EventListener {
         }
 
         callEvent(OverlayRenderEvent(context, tickDelta))
+        hasCompletedFirstDraw = true
     }
 
     private val GUI_BLUR_UNIFORM_BUFFER = gpuDevice.createUbo(


### PR DESCRIPTION
Blurring on the first render caused the item renderer to display either no items or more or fewer items than intended.

Before:
<img width="287" height="401" alt="image" src="https://github.com/user-attachments/assets/e37a820f-64a1-490c-bedd-a5816ac01884" />

After:
<img width="491" height="453" alt="image" src="https://github.com/user-attachments/assets/852c82e5-8311-4dbb-ba03-b6580e184824" />
