### PR TITLE
chore(CapeApi): receive NativeImage instead of registered texture

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/core/HttpClient.kt
@@ -28,9 +28,8 @@ import net.ccbluex.liquidbounce.mcef.listeners.OkHttpProgressInterceptor
 import net.ccbluex.liquidbounce.utils.client.error.ErrorHandler
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.kotlin.Minecraft
-import net.ccbluex.liquidbounce.utils.render.asTexture
 import net.ccbluex.liquidbounce.utils.render.toNativeImage
-import net.minecraft.client.texture.NativeImageBackedTexture
+import net.minecraft.client.texture.NativeImage
 import net.minecraft.util.Util
 import net.minecraft.util.crash.CrashException
 import okhttp3.*
@@ -206,22 +205,14 @@ enum class HttpMethod {
  * If [T] is one of following types, it should be closed after using:
  * [InputStream] / [BufferedSource] / [Reader]
  */
-suspend inline fun <reified T> Response.parse(): T {
+inline fun <reified T> Response.parse(): T {
     return when (T::class.java) {
         String::class.java -> body.string() as T
         Unit::class.java -> close() as T
         InputStream::class.java -> body.byteStream() as T
         BufferedSource::class.java -> body.source() as T
         Reader::class.java -> body.charStream() as T
-        NativeImageBackedTexture::class.java -> {
-            val nativeImage = body.byteStream().toNativeImage()
-
-            withContext(Dispatchers.Minecraft) {
-                nativeImage.asTexture {
-                    "NetworkImage ${request.url}"
-                }
-            } as T
-        }
+        NativeImage::class.java -> body.byteStream().toNativeImage() as T
         else -> body.charStream().readJson<T>()
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CapeApi.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/services/cosmetics/CapeApi.kt
@@ -20,12 +20,12 @@ package net.ccbluex.liquidbounce.api.services.cosmetics
 
 import net.ccbluex.liquidbounce.api.core.ApiConfig.Companion.config
 import net.ccbluex.liquidbounce.api.core.BaseApi
-import net.minecraft.client.texture.NativeImageBackedTexture
+import net.minecraft.client.texture.NativeImage
 
 object CapeApi : BaseApi(config.apiEndpointV1) {
     /**
-     * Request a cape by name and return the cape texture as [NativeImageBackedTexture].
+     * Request a cape by name and return the cape texture as [NativeImage].
      */
     suspend fun getCape(name: String) =
-        get<NativeImageBackedTexture>("/cape/name/$name")
+        get<NativeImage>("/cape/name/$name")
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CapeCosmeticsManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/CapeCosmeticsManager.kt
@@ -19,7 +19,6 @@
 package net.ccbluex.liquidbounce.features.cosmetic
 
 import com.mojang.authlib.GameProfile
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.api.core.withScope
@@ -30,6 +29,7 @@ import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.events.DisconnectEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.utils.client.mc
+import net.ccbluex.liquidbounce.utils.render.registerTexture
 import net.minecraft.util.Identifier
 
 /**
@@ -45,7 +45,7 @@ object CapeCosmeticsManager : EventListener {
      * We also don't need to worry about memory leaks
      * because the cache is cleared when the player disconnects from the world.
      */
-    private val cachedCapes = mutableMapOf<String, Identifier>()
+    private val cachedCapes = hashMapOf<String, Identifier>()
 
     /**
      * Interface for returning a cape texture
@@ -72,15 +72,16 @@ object CapeCosmeticsManager : EventListener {
                     val name = getCapeName(cosmetic) ?: return@fetchCosmetic
 
                     // Check if the cape is cached
-                    if (cachedCapes.containsKey(name)) {
+                    val cachedCapeId = cachedCapes[name]
+                    if (cachedCapeId != null) {
                         LiquidBounce.logger.info("Successfully loaded cached cape for ${player.name}")
-                        response.response(cachedCapes[name]!!)
+                        response.response(cachedCapeId)
                         return@fetchCosmetic
                     }
 
                     // Request cape texture
                     val nativeImageBackedTexture = runCatching {
-                        runBlocking(Dispatchers.IO) {
+                        runBlocking {
                             CapeApi.getCape(name)
                         }
                     }.getOrNull() ?: return@fetchCosmetic
@@ -89,14 +90,16 @@ object CapeCosmeticsManager : EventListener {
 
                     val id = LiquidBounce.identifier("cape-$name")
 
-                    // Register cape texture
-                    mc.textureManager.registerTexture(id, nativeImageBackedTexture)
+                    mc.execute {
+                        // Register cape texture
+                        nativeImageBackedTexture.registerTexture(id)
 
-                    // Cache cape texture
-                    cachedCapes[name] = id
+                        // Cache cape texture
+                        cachedCapes[name] = id
 
-                    // Return cape texture
-                    response.response(id)
+                        // Return cape texture
+                        response.response(id)
+                    }
                 }
             }
         }


### PR DESCRIPTION
We register the texture on main thread.