### PR TITLE
fix(init/fallback): render thread deadlock

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -476,8 +476,11 @@ object LiquidBounce : EventListener {
                 initializeClient(
                     workerDispatcher = Dispatchers.Default,
                     renderThreadDispatcher = Dispatchers.Minecraft,
-                ).join()
-                ThemeManager.reloader.reload(resourceManager)
+                ).thenRun {
+                    ThemeManager.reloader.reload(resourceManager)
+                }.exceptionally {
+                    ErrorHandler.fatal(it, additionalMessage = "Client start/resource reloader(fallback)")
+                }
             }
         }.onFailure {
             ErrorHandler.fatal(it, additionalMessage = "Client start")


### PR DESCRIPTION
The old code uses `Future.join`. But the Future is produced by render thread (dispatcher) too, this causes deadlock on continuation resumption.