### PR TITLE
chore(theme): skip warning of input param by fragment shader

### DIFF
--- a/src-theme/public/backgrounds/background.frag
+++ b/src-theme/public/backgrounds/background.frag
@@ -10,6 +10,9 @@ layout(std140) uniform ThemeBackgroundData {
 // Output color
 out vec4 fragColor;
 
+// Input position
+in vec2 texCoord;
+
 // Simple hash function
 float hash(float n) {
     return fract(sin(n) * 43758.5453);


### PR DESCRIPTION
The theme background fragment shader always uses Minecraft built-in vertex shader 'core/screenquad'.