### PR TITLE
chore(workflow): use Java 25 for Dokka & TS gen

### DIFF
--- a/.github/workflows/generate-definitions.yml
+++ b/.github/workflows/generate-definitions.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'gradle'
 
       - name: Create Mods Directory

--- a/.github/workflows/generate-dokka-html.yml
+++ b/.github/workflows/generate-dokka-html.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           cache: 'gradle'
   
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
Preparation for next MC version, which requires Java 25.