### PR TITLE
fix(EnvironmentRemapper): broken environment detection from yarn class names

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/mappings/EnvironmentRemapper.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/mappings/EnvironmentRemapper.kt
@@ -47,7 +47,7 @@ object EnvironmentRemapper {
         val mappings = mappings ?: return null
 
         val minecraftClassEntry = mappings.classEntries?.find { entry ->
-            entry?.get("named") == "net/minecraft/client/MinecraftClient"
+            entry?.get("named") == "net/minecraft/client/Minecraft"
         }
 
         if (minecraftClassEntry == null) {


### PR DESCRIPTION
I was wondering why my scripts weren't working at all, even when using M*jmap for the names :broken_heart: