### PR TITLE
fix(protocol): `ClientboundSetEntityMotionPacket#movement` is no longer scaled

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityHypixel.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityHypixel.kt
@@ -45,8 +45,8 @@ internal object VelocityHypixel : VelocityMode("Hypixel") {
                     return@handler
                 }
             }
-            packet.movement.x = (player.deltaMovement.x * 8000)
-            packet.movement.z = (player.deltaMovement.z * 8000)
+            packet.movement.x = player.deltaMovement.x
+            packet.movement.z = player.deltaMovement.z
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
@@ -93,9 +93,9 @@ object VelocityIntave : VelocityMode("Intave") {
             val packet = event.packet
 
             if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
-                val velocityX = packet.movement.x / 8000.0
-                val velocityY = packet.movement.y / 8000.0
-                val velocityZ = packet.movement.z / 8000.0
+                val velocityX = packet.movement.x
+                val velocityY = packet.movement.y
+                val velocityZ = packet.movement.z
 
                 // Check if the player is taking fall damage
                 // We set this on every packet, because if the player gets hit afterward,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityJumpReset.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityJumpReset.kt
@@ -75,9 +75,9 @@ internal object VelocityJumpReset : VelocityMode("JumpReset") {
         val packet = event.packet
 
         if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
-            val velocityX = packet.movement.x / 8000.0
-            val velocityY = packet.movement.y / 8000.0
-            val velocityZ = packet.movement.z / 8000.0
+            val velocityX = packet.movement.x
+            val velocityY = packet.movement.y
+            val velocityZ = packet.movement.z
 
             // Check if the player is taking fall damage
             // We set this on every packet, because if the player gets hit afterward,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityModify.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityModify.kt
@@ -65,19 +65,19 @@ internal object VelocityModify : VelocityMode("Modify") {
 
             // Modify packet according to the specified values
             if (horizontal != 0f) {
-                packet.movement.x = (packet.movement.x * horizontal)
-                packet.movement.z = (packet.movement.z * horizontal)
+                packet.movement.x = packet.movement.x * horizontal
+                packet.movement.z = packet.movement.z * horizontal
             } else {
                 // set the horizontal velocity to the player velocity to prevent horizontal slowdown
-                packet.movement.x = ((currentVelocity.x * motionHorizontal) * 8000)
-                packet.movement.z = ((currentVelocity.z * motionHorizontal) * 8000)
+                packet.movement.x = currentVelocity.x * motionHorizontal
+                packet.movement.z = currentVelocity.z * motionHorizontal
             }
 
             if (vertical != 0f) {
-                packet.movement.y = (packet.movement.y * vertical)
+                packet.movement.y = packet.movement.y * vertical
             } else {
                 // set the vertical velocity to the player velocity to prevent vertical slowdown
-                packet.movement.y = ((currentVelocity.y * motionVertical) * 8000)
+                packet.movement.y = currentVelocity.y * motionVertical
             }
 
             NoFallBlink.waitUntilGround = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
@@ -155,9 +155,9 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("C
             val packet = it.packet
 
             if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
-                val velocityX = packet.movement.x / 8000.0
-                val velocityY = packet.movement.y / 8000.0
-                val velocityZ = packet.movement.z / 8000.0
+                val velocityX = packet.movement.x
+                val velocityY = packet.movement.y
+                val velocityZ = packet.movement.z
 
                 ticksTimeout = velocityTimeout
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/SpeedCustom.kt
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.utils.entity.moving
 import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.withStrafe
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
+import net.ccbluex.liquidbounce.utils.network.isMovementYFallDamage
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 
 /**
@@ -156,7 +157,6 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("C
 
             if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
                 val velocityX = packet.movement.x
-                val velocityY = packet.movement.y
                 val velocityZ = packet.movement.z
 
                 ticksTimeout = velocityTimeout
@@ -165,7 +165,7 @@ class SpeedCustom(override val parent: ChoiceConfigurable<*>) : SpeedBHopBase("C
                     waitTicks(1)
 
                     // Fall damage velocity
-                    val speed = if (velocityX == 0.0 && velocityZ == 0.0 && velocityY == -0.078375) {
+                    val speed = if (velocityX == 0.0 && velocityZ == 0.0 && packet.isMovementYFallDamage()) {
                         player.horizontalSpeed.coerceAtLeast(0.2857671997172534)
                     } else {
                         player.horizontalSpeed

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
@@ -31,6 +31,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speed.modes.Spe
 import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.withStrafe
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.CRITICAL_MODIFICATION
+import net.ccbluex.liquidbounce.utils.network.isMovementYFallDamage
 import net.minecraft.world.effect.MobEffects
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
@@ -112,13 +113,12 @@ class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBa
 
         if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
             val velocityX = packet.movement.x
-            val velocityY = packet.movement.y
             val velocityZ = packet.movement.z
 
             waitTicks(1)
 
             // Fall damage velocity
-            val speed = if (velocityX == 0.0 && velocityZ == 0.0 && velocityY == -0.078375) {
+            val speed = if (velocityX == 0.0 && velocityZ == 0.0 && packet.isMovementYFallDamage()) {
                 player.horizontalSpeed.coerceAtLeast(
                     BASH *
                         (player.getEffect(MobEffects.SPEED)?.amplifier ?: 0)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/modes/watchdog/SpeedHypixelBHop.kt
@@ -111,9 +111,9 @@ class SpeedHypixelBHop(override val parent: ChoiceConfigurable<*>) : SpeedBHopBa
         val packet = event.packet
 
         if (packet is ClientboundSetEntityMotionPacket && packet.id == player.id) {
-            val velocityX = packet.movement.x / 8000.0
-            val velocityY = packet.movement.y / 8000.0
-            val velocityZ = packet.movement.z / 8000.0
+            val velocityX = packet.movement.x
+            val velocityY = packet.movement.y
+            val velocityZ = packet.movement.z
 
             waitTicks(1)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/network/PacketExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/network/PacketExtensions.kt
@@ -1,0 +1,26 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.utils.network
+
+import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
+
+fun ClientboundSetEntityMotionPacket.isMovementYFallDamage(): Boolean {
+    return this.movement.y.toRawBits() == -4633060179779189496
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/network/PacketExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/network/PacketExtensions.kt
@@ -22,5 +22,5 @@ package net.ccbluex.liquidbounce.utils.network
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 
 fun ClientboundSetEntityMotionPacket.isMovementYFallDamage(): Boolean {
-    return this.movement.y.toRawBits() == -4633060179779189496
+    return this.movement.y.toRawBits() == -4633060179779189496L // -0.0783739241897089
 }


### PR DESCRIPTION
noticed this because 0% 100% velocity seems to just freeze your game and move you eons away (and then get teleported back by the server due to going >10 blocks in a single move packet)