### PR TITLE
fix(cosmetics): possible NPE

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/entity/feature/MixinDeadmau5EarsLayer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/entity/feature/MixinDeadmau5EarsLayer.java
@@ -34,7 +34,10 @@ public class MixinDeadmau5EarsLayer {
 
     @ModifyExpressionValue(method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/entity/state/AvatarRenderState;showExtraEars:Z", remap = false))
     private boolean onRender(boolean original, @Local(argsOnly = true) AvatarRenderState playerEntityRenderState) {
-        return original || CosmeticService.INSTANCE.hasCosmetic(((EntityRenderStateAddition) playerEntityRenderState).liquid_bounce$getEntity().getUUID(), CosmeticCategory.DEADMAU5_EARS);
+        if (original) return true;
+
+        var entity = ((EntityRenderStateAddition) playerEntityRenderState).liquid_bounce$getEntity();
+        return entity != null && CosmeticService.INSTANCE.hasCosmetic(entity.getUUID(), CosmeticCategory.DEADMAU5_EARS);
     }
 
 }


### PR DESCRIPTION
closes #7462 

I'm curious that why this will be null? Hasn't the state instance updated after init...

1.21.11 issue.