### PR TITLE
feat: icon fallback for item lists

### DIFF
--- a/src-theme/src/integration/rest.ts
+++ b/src-theme/src/integration/rest.ts
@@ -31,6 +31,10 @@ import {isLoggingIn} from "../routes/menu/altmanager/altmanager_store";
 
 const API_BASE = `${REST_BASE}/api/v1`;
 
+export async function textureUrl(texture: string) {
+    return `${API_BASE}/client/resource/itemTexture?id=${texture}`
+}
+
 export async function getMetadata(): Promise<Metadata> {
     const response = await fetch(`metadata.json`);
     const data: Metadata = await response.json();

--- a/src-theme/src/routes/clickgui/setting/list/ListItem.svelte
+++ b/src-theme/src/routes/clickgui/setting/list/ListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import {createEventDispatcher} from "svelte";
+    import {textureUrl} from "../../../../integration/rest";
 
     const dispatch = createEventDispatcher<{
         toggle: { value: string, enabled: boolean }
@@ -9,13 +10,23 @@
     export let name: string;
     export let icon: string | undefined;
     export let enabled: boolean;
+
+    let showingFallbackImage = false;
+
+    async function showFallbackIcon(event: Event) {
+        const img = event.currentTarget as HTMLImageElement;
+
+        showingFallbackImage = true;
+        img.src = await textureUrl("minecraft:grass_block");
+    }
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="item" class:has-icon={icon !== undefined} on:click={() => dispatch("toggle", {enabled: !enabled, value:value})}>
+<div class="item" class:has-icon={icon !== undefined}
+     on:click={() => dispatch("toggle", {enabled: !enabled, value:value})}>
     {#if icon}
-        <img class="icon" src="{icon}" alt={value}/>
+        <img class="icon" class:fallback={showingFallbackImage} src="{icon}" alt={value} on:error={showFallbackIcon}/>
     {/if}
     <div class="name">{name}</div>
     <div class="tick">
@@ -46,7 +57,12 @@
   .icon {
     height: 25px;
     width: 25px;
+
+    &.fallback {
+      filter: grayscale(1);
+    }
   }
+
   .name {
     font-size: 12px;
     color: $clickgui-text-color;


### PR DESCRIPTION
Item lists now show a grayscale grass block as a fallback image when the actual icon does not exist.

<img width="285" height="304" alt="image" src="https://github.com/user-attachments/assets/83512f36-f96d-41f2-9b0f-ad40f2ebd167" />
