### PR TITLE
fix: command usage incomplete

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/Command.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/Command.kt
@@ -198,12 +198,12 @@ class Command(
                 joiner.add(name)
             }
 
-            output.add(this.name + " " + joiner.toString())
+            output.add(getFullName() + " " + joiner.toString())
         }
 
         for (subcommand in subcommands) {
             for (subcommandUsage in subcommand.usage()) {
-                output.add(this.name + " " + subcommandUsage)
+                output.add(subcommandUsage)
             }
         }
 


### PR DESCRIPTION
Command usage used to only show the current subcommand.

Before:
<img width="715" height="228" alt="Screenshot From 2025-12-28 19-31-46" src="https://github.com/user-attachments/assets/d76dc1a4-1d66-4189-88aa-69b9d0bb4743" />

After:
<img width="715" height="228" alt="Screenshot From 2025-12-28 19-31-08" src="https://github.com/user-attachments/assets/fe4d9494-d842-4194-9ce8-e8efc1816616" />