### PR TITLE
improve(CI): Build is faster now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: '21'
-          cache: 'gradle'
       - name: Grant permissions to src-theme
         run: sudo chmod -R 777 src-theme
       - name: Setup Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setting up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'graalvm'
+          distribution: 'temurin'
           java-version: '21'
       - name: Grant permissions to src-theme
         run: sudo chmod -R 777 src-theme
@@ -143,13 +143,14 @@ jobs:
       - name: Setting up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'graalvm'
+          distribution: 'temurin'
           java-version: '21'
-          cache: 'gradle'
       - name: Grant permissions to src-theme
         run: sudo chmod -R 777 src-theme
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/nextgen' }}
       - name: Build
         env:
           CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
         run: sudo chmod -R 777 src-theme
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/nextgen' }}
       - name: Build
         env:
           CI: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,8 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
-#org.gradle.configuration-cache=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 # ZGC from JDK 21
 org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseZGC -XX:+ZGenerational
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
+#org.gradle.configuration-cache=true
 # ZGC from JDK 21
 org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseZGC -XX:+ZGenerational
 


### PR DESCRIPTION
it is hard to measure exact build time improvements, but I would estimate that is is >30s compared to no cache

https://github.com/kroune/LiquidBounce/actions/runs/20696465844/job/59418635868 - 6m 34s build with a small change in code, **no cache** used

https://github.com/kroune/LiquidBounce/actions/runs/20696270197/job/59418865451 - pipeline runs on master (nextgen) and **saves caches** which takes ~46s

https://github.com/kroune/LiquidBounce/actions/runs/20696465844/job/59419093121 - 3m 6s build with a small change, **cache used** from master (nextgen)



cache used from master (nextgen) on a pr, cache isn't stored
<img width="1156" height="1333" alt="image" src="https://github.com/user-attachments/assets/10d8e2d5-35a6-4c3d-9e92-d6daa4ae22d7" />

cache stored on master (nextgen) (it doesn't use cache because it didn't have any at the time, but after first run there is always cache to use)

<img width="1152" height="1261" alt="image" src="https://github.com/user-attachments/assets/7d40b4c9-1a77-41dd-b461-474fed132049" />
