### PR TITLE
feat(ItemESP): show tracers

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
@@ -34,6 +34,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.DoRender;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleAntiBlind;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleAspect;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleItemChams;
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleItemESP;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleNoBob;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleNoFov;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleNoHurtCam;
@@ -133,7 +134,10 @@ public abstract class MixinGameRenderer {
 
     @Inject(method = "bobView", at = @At("HEAD"), cancellable = true)
     private void injectBobView(PoseStack matrixStack, float tickProgress, CallbackInfo callbackInfo) {
-        if (ModuleNoBob.INSTANCE.getRunning() || ModuleTracers.INSTANCE.getRunning()) {
+        if (ModuleNoBob.INSTANCE.getRunning() ||
+            ModuleTracers.INSTANCE.getRunning() ||
+            (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.INSTANCE.getShowTracers())) {
+
             callbackInfo.cancel();
             return;
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -26,21 +26,20 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.GenericRainbowColorMode
-import net.ccbluex.liquidbounce.render.GenericStaticColorMode
-import net.ccbluex.liquidbounce.render.drawBox
+import net.ccbluex.liquidbounce.render.*
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
-import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
-import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
+import net.ccbluex.liquidbounce.render.engine.type.Vec3f
+import net.ccbluex.liquidbounce.utils.client.toRadians
 import net.ccbluex.liquidbounce.utils.collection.Filter
 import net.ccbluex.liquidbounce.utils.collection.itemSortedSetOf
 import net.ccbluex.liquidbounce.utils.entity.cameraDistanceSq
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.math.sq
+import net.ccbluex.liquidbounce.utils.math.toVec3f
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.item.ItemEntity
-import net.minecraft.world.entity.projectile.arrow.Arrow
 import net.minecraft.world.entity.projectile.arrow.AbstractArrow.Pickup
+import net.minecraft.world.entity.projectile.arrow.Arrow
 import net.minecraft.world.entity.projectile.arrow.SpectralArrow
 import net.minecraft.world.entity.projectile.arrow.ThrownTrident
 import net.minecraft.world.phys.AABB
@@ -60,6 +59,8 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
     private val items by items("Items", itemSortedSetOf())
     private val maximumDistance by float("MaximumDistance", 128F, 1F..512F)
 
+    val showTracers by boolean("ShowTracers", false)
+    
     private object ShowArrows : ToggleableConfigurable(this, "ShowArrows", true) {
         val regularArrows by boolean("RegularArrows", true)
         val spectralArrows by boolean("SpectralArrows", true)
@@ -86,6 +87,45 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         )
     }
 
+    // showTracers
+    @Suppress("unused")
+    private val tracerRenderHandler = handler<WorldRenderEvent> { event ->
+        // Check if the tracer option is enabled
+        if (!showTracers) return@handler
+
+        val matrixStack = event.matrixStack
+        val camera = mc.gameRenderer.mainCamera
+
+        renderEnvironmentForWorld(matrixStack) {
+            // We calculate the gaze vector (where the camera is looking)
+            val eyeVector = Vec3f(0.0, 0.0, 1.0)
+                .rotatePitch(-camera.xRot().toRadians())
+                .rotateYaw(-camera.yRot().toRadians())
+
+            longLines {
+                startBatch()
+                // Using entitiesForRendering() to get a list of entities around
+                val entities = world.entitiesForRendering()
+                for (entity in entities) {
+                    // Using the existing filtering logic (distance, type, etc.)
+                    if (!shouldRender(entity)) continue
+
+                    val color = getColor()
+
+                    // Interpolating the position (motion smoothing)
+                    val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3f()
+
+                    drawLines(
+                        argb = color.toARGB(),
+                        eyeVector, pos,
+                        pos, pos.add(0f, entity.bbHeight, 0f)
+                    )
+                }
+                commitBatch()
+            }
+        }
+    }
+    
     private object BoxMode : Choice("Box") {
 
         override val parent: ChoiceConfigurable<Choice>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.render.GenericRainbowColorMode
 import net.ccbluex.liquidbounce.render.GenericStaticColorMode
 import net.ccbluex.liquidbounce.render.drawBox
-import net.ccbluex.liquidbounce.render.drawLines
+import net.ccbluex.liquidbounce.render.drawLine
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.ccbluex.liquidbounce.render.longLines
@@ -65,8 +65,8 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
     private val items by items("Items", itemSortedSetOf())
     private val maximumDistance by float("MaximumDistance", 128F, 1F..512F)
 
-    val showTracers by boolean("ShowTracers", false)
-    
+    val showTracers by boolean("Tracers", false)
+
     private object ShowArrows : ToggleableConfigurable(this, "ShowArrows", true) {
         val regularArrows by boolean("RegularArrows", true)
         val spectralArrows by boolean("SpectralArrows", true)
@@ -99,10 +99,7 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
         // Check if the tracer option is enabled
         if (!showTracers) return@handler
 
-        val matrixStack = event.matrixStack
-        val camera = mc.gameRenderer.mainCamera
-
-        renderEnvironmentForWorld(matrixStack) {
+        renderEnvironmentForWorld(event.matrixStack) {
             // We calculate the gaze vector (where the camera is looking)
             val eyeVector = Vec3f(0.0, 0.0, 1.0)
                 .rotatePitch(-camera.xRot().toRadians())
@@ -121,17 +118,17 @@ object ModuleItemESP : ClientModule("ItemESP", Category.RENDER) {
                     // Interpolating the position (motion smoothing)
                     val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3f()
 
-                    drawLines(
+                    drawLine(
                         argb = color.toARGB(),
-                        eyeVector, pos,
-                        pos, pos.add(0f, entity.bbHeight, 0f)
+                        p1 = eyeVector,
+                        p2 = pos,
                     )
                 }
                 commitBatch()
             }
         }
     }
-    
+
     private object BoxMode : Choice("Box") {
 
         override val parent: ChoiceConfigurable<Choice>

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -26,9 +26,15 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.render.*
+import net.ccbluex.liquidbounce.render.GenericRainbowColorMode
+import net.ccbluex.liquidbounce.render.GenericStaticColorMode
+import net.ccbluex.liquidbounce.render.drawBox
+import net.ccbluex.liquidbounce.render.drawLines
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
+import net.ccbluex.liquidbounce.render.longLines
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.client.toRadians
 import net.ccbluex.liquidbounce.utils.collection.Filter
 import net.ccbluex.liquidbounce.utils.collection.itemSortedSetOf


### PR DESCRIPTION
Adds an optional "Show Tracers" feature to the ItemESP module, rendering lines to dropped items.

The initial version was generated with the help of AI tools and then manually tested. Since it works and doesnt affect existing behavior when disabled, i decided to share it.

Video of demonstration: https://youtu.be/neigwIBmcqg