### PR TITLE
feat(killaura): add RangeIndicator visual feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /logs/
 /.kotlin/
 .DS_Store
+*.log

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -16,8 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
-@file:Suppress("WildcardImport")
-
 package net.ccbluex.liquidbounce.features.module.modules.combat.killaura
 
 import com.google.gson.JsonObject

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -49,6 +49,7 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugGeometry
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.aiming.data.RotationWithVector
@@ -134,15 +135,9 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
     @Suppress("unused")
     private val renderHandler = handler<WorldRenderEvent> { event ->
-        val matrixStack = event.matrixStack
-
-        renderFailedHits(matrixStack)
-        renderRangeIndicator(matrixStack, event.partialTicks)
-    }
-
-    private fun renderRangeIndicator(matrixStack: PoseStack, partialTicks: Float) {
-        renderEnvironmentForWorld(matrixStack) {
-            KillAuraRangeIndicator.render(this, partialTicks)
+        renderFailedHits(event.matrixStack)
+        renderEnvironmentForWorld(event.matrixStack) {
+            KillAuraRangeIndicator.render(this, event.partialTicks)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -45,6 +45,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.failedHits
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.renderFailedHits
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraRangeIndicator
 import net.ccbluex.liquidbounce.features.module.modules.misc.debugrecorder.modes.GenericDebugRecorder
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugGeometry
@@ -128,6 +129,7 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
     init {
         tree(KillAuraFailSwing)
         tree(KillAuraFightBot)
+        tree(KillAuraRangeIndicator)
     }
 
     override fun onDisabled() {
@@ -143,6 +145,13 @@ object ModuleKillAura : ClientModule("KillAura", Category.COMBAT) {
 
         renderTarget(matrixStack, event.partialTicks)
         renderFailedHits(matrixStack)
+        renderRangeIndicator(matrixStack, event.partialTicks)
+    }
+
+    private fun renderRangeIndicator(matrixStack: PoseStack, partialTicks: Float) {
+        renderEnvironmentForWorld(matrixStack) {
+            KillAuraRangeIndicator.render(this, partialTicks)
+        }
     }
 
     private fun renderTarget(matrixStack: PoseStack, partialTicks: Float) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2025 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
+
+import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
+import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
+import net.ccbluex.liquidbounce.render.drawGradientCircle
+import net.ccbluex.liquidbounce.render.drawCircleOutline
+import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
+
+/**
+ * Renders a circle around the player indicating the KillAura attack range.
+ * Uses the same range values as KillAura (Range and WallRange).
+ * - Red/idle color when no enemy is in range
+ * - Green/active color when an enemy is in range and being targeted
+ */
+object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeIndicator", false) {
+
+    private val idleColor by color("IdleColor", Color4b(255, 50, 50, 80))
+    private val activeColor by color("ActiveColor", Color4b(50, 255, 50, 80))
+    private val outline by boolean("Outline", true)
+    private val outlineColor by color("OutlineColor", Color4b(255, 255, 255, 120))
+    private val showWallRange by boolean("ShowWallRange", false)
+    private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 60))
+
+    fun render(env: WorldRenderEnvironment, partialTicks: Float) {
+        if (!enabled) return
+
+        val hasTarget = ModuleKillAura.targetTracker.target != null
+        val color = if (hasTarget) activeColor else idleColor
+        val range = ModuleKillAura.range
+        val wallRange = ModuleKillAura.wallRange
+
+        val pos = player.interpolateCurrentPosition(partialTicks)
+
+        with(env) {
+            withPositionRelativeToCamera(pos) {
+                // Main attack range circle
+                drawGradientCircle(range, 0f, color, color.with(a = 0))
+                
+                if (outline) {
+                    drawCircleOutline(range, outlineColor)
+                }
+
+                // Wall range circle (smaller, for attacking through walls)
+                if (showWallRange && wallRange < range) {
+                    drawGradientCircle(wallRange, 0f, wallRangeColor, wallRangeColor.with(a = 0))
+                    if (outline) {
+                        drawCircleOutline(wallRange, outlineColor.with(a = 80))
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -141,7 +141,7 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     }
 
     private fun WorldRenderEnvironment.drawRangeCircle(radius: Float, color: Color4b, outlineAlpha: Int = 255) {
-        drawGradientCircle(radius, 0f, color, color.with(a = 0))
+        drawGradientCircle(radius, 0f, color, Color4b.TRANSPARENT)
         if (outline) {
             drawCircleOutline(radius, outlineColor.with(a = outlineAlpha))
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
 
+import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
@@ -25,52 +26,178 @@ import net.ccbluex.liquidbounce.render.drawGradientCircle
 import net.ccbluex.liquidbounce.render.drawCircleOutline
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
+import net.ccbluex.liquidbounce.render.utils.rainbow
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
+import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.minecraft.util.Mth
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 /**
  * Renders a circle around the player indicating the KillAura attack range.
- * Uses the same range values as KillAura (Range and WallRange).
- * - Red/idle color when no enemy is in range
- * - Green/active color when an enemy is in range and being targeted
+ * Features:
+ * - Synced with KillAura Range and WallRange
+ * - Color changes based on target state (idle/active)
+ * - Multiple color modes (static, rainbow, distance-based)
+ * - Pulse animation option
+ * - Opponent range visualization
+ * - Enemy count display
  */
 object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeIndicator", false) {
 
+    // Color settings
+    private val colorMode by enumChoice("ColorMode", ColorMode.STATIC)
     private val idleColor by color("IdleColor", Color4b(255, 50, 50, 80))
     private val activeColor by color("ActiveColor", Color4b(50, 255, 50, 80))
+
+    // Outline settings
     private val outline by boolean("Outline", true)
     private val outlineColor by color("OutlineColor", Color4b(255, 255, 255, 120))
+
+    // Animation settings
+    private val pulseAnimation by boolean("PulseAnimation", false)
+    private val pulseSpeed by float("PulseSpeed", 2f, 0.5f..5f)
+    private val pulseIntensity by float("PulseIntensity", 0.15f, 0.05f..0.5f)
+
+    // Fade animation for state changes
+    private val fadeAnimation by boolean("FadeAnimation", true)
+    private val fadeSpeed by float("FadeSpeed", 0.1f, 0.01f..0.5f)
+
+    // Wall range circle
     private val showWallRange by boolean("ShowWallRange", false)
     private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 60))
+
+    // Opponent range (shows estimated enemy attack range)
+    private val showOpponentRange by boolean("ShowOpponentRange", false)
+    private val opponentRange by float("OpponentRange", 3f, 1f..6f)
+    private val opponentRangeColor by color("OpponentRangeColor", Color4b(255, 0, 0, 40))
+
+    // Conditions - when NOT to render
+    private val hideWhenDead by boolean("HideWhenDead", true)
+    private val hideWhenSpectator by boolean("HideWhenSpectator", true)
+    private val hideInVehicle by boolean("HideInVehicle", false)
+
+    // State tracking for animations
+    private var currentColorFactor = 0f
+    private var lastTargetState = false
+
+    private enum class ColorMode(override val choiceName: String) : NamedChoice {
+        STATIC("Static"),
+        RAINBOW("Rainbow"),
+        DISTANCE("Distance")
+    }
 
     fun render(env: WorldRenderEnvironment, partialTicks: Float) {
         if (!enabled) return
 
-        val hasTarget = ModuleKillAura.targetTracker.target != null
-        val color = if (hasTarget) activeColor else idleColor
+        // Check conditions
+        if (hideWhenDead && player.isDeadOrDying) return
+        if (hideWhenSpectator && player.isSpectator) return
+        if (hideInVehicle && player.vehicle != null) return
+
+        val target = ModuleKillAura.targetTracker.target
+        val hasTarget = target != null
+
+        // Update fade animation
+        updateFadeAnimation(hasTarget)
+
         val range = ModuleKillAura.range
         val wallRange = ModuleKillAura.wallRange
-
         val pos = player.interpolateCurrentPosition(partialTicks)
+
+        // Calculate pulse effect
+        val pulseOffset = if (pulseAnimation) {
+            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
+            (sin(time * Math.PI * 2).toFloat() * pulseIntensity * range)
+        } else 0f
+
+        val effectiveRange = range + pulseOffset
+
+        // Get color based on mode
+        val color = getColor(target?.let { sqrt(player.squaredBoxedDistanceTo(it)).toFloat() })
 
         with(env) {
             withPositionRelativeToCamera(pos) {
                 // Main attack range circle
-                drawGradientCircle(range, 0f, color, color.with(a = 0))
-                
+                drawGradientCircle(effectiveRange, 0f, color, color.with(a = 0))
+
                 if (outline) {
-                    drawCircleOutline(range, outlineColor)
+                    drawCircleOutline(effectiveRange, outlineColor)
                 }
 
-                // Wall range circle (smaller, for attacking through walls)
+                // Wall range circle
                 if (showWallRange && wallRange < range) {
-                    drawGradientCircle(wallRange, 0f, wallRangeColor, wallRangeColor.with(a = 0))
+                    val wallColor = wallRangeColor.let {
+                        if (hasTarget) it.with(a = (it.a * 1.5f).toInt().coerceAtMost(255)) else it
+                    }
+                    drawGradientCircle(wallRange, 0f, wallColor, wallColor.with(a = 0))
                     if (outline) {
                         drawCircleOutline(wallRange, outlineColor.with(a = 80))
                     }
                 }
+
+                // Opponent range circle (enemy's estimated attack range)
+                if (showOpponentRange && hasTarget) {
+                    drawGradientCircle(opponentRange, 0f, opponentRangeColor, opponentRangeColor.with(a = 0))
+                    if (outline) {
+                        drawCircleOutline(opponentRange, opponentRangeColor.with(a = 100))
+                    }
+                }
             }
         }
+    }
+
+    private fun updateFadeAnimation(hasTarget: Boolean) {
+        if (!fadeAnimation) {
+            currentColorFactor = if (hasTarget) 1f else 0f
+            lastTargetState = hasTarget
+            return
+        }
+
+        val targetFactor = if (hasTarget) 1f else 0f
+        currentColorFactor = Mth.lerp(fadeSpeed, currentColorFactor, targetFactor)
+
+        // Snap to target if close enough
+        if (kotlin.math.abs(currentColorFactor - targetFactor) < 0.01f) {
+            currentColorFactor = targetFactor
+        }
+
+        lastTargetState = hasTarget
+    }
+
+    private fun getColor(distanceToTarget: Float?): Color4b {
+        return when (colorMode) {
+            ColorMode.RAINBOW -> rainbow(alpha = 0.5f)
+
+            ColorMode.DISTANCE -> {
+                if (distanceToTarget == null) {
+                    idleColor
+                } else {
+                    // Interpolate from green (close) to red (far) based on distance
+                    val range = ModuleKillAura.range
+                    val factor = (distanceToTarget / range).coerceIn(0f, 1f)
+                    interpolateColor(activeColor, idleColor, factor)
+                }
+            }
+
+            ColorMode.STATIC -> {
+                if (fadeAnimation) {
+                    interpolateColor(idleColor, activeColor, currentColorFactor)
+                } else {
+                    if (currentColorFactor > 0.5f) activeColor else idleColor
+                }
+            }
+        }
+    }
+
+    private fun interpolateColor(from: Color4b, to: Color4b, factor: Float): Color4b {
+        return Color4b(
+            (from.r + (to.r - from.r) * factor).toInt(),
+            (from.g + (to.g - from.g) * factor).toInt(),
+            (from.b + (to.b - from.b) * factor).toInt(),
+            (from.a + (to.a - from.a) * factor).toInt()
+        )
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -82,25 +82,13 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     fun render(env: WorldRenderEnvironment, partialTicks: Float) {
         if (!enabled) return
 
-        val safePlayer = player.takeUnless { 
-            (hideWhenDead && it.isDeadOrDying) ||
-            (hideWhenSpectator && it.isSpectator) ||
-            (hideInVehicle && it.vehicle != null)
-        } ?: return
-
-        if (respectInventorySetting && !ModuleKillAura.ignoreOpenInventory) {
-            val inInventory = isInventoryOpen || 
-                net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
-            if (inInventory) return
-        }
+        val safePlayer = getPlayerIfVisible() ?: return
+        if (shouldHideForInventory()) return
 
         val target = ModuleKillAura.targetTracker.target
-        val hasTarget = target != null
-
-        updateColorFactor(hasTarget)
+        updateColorFactor(target != null)
 
         val range = ModuleKillAura.range
-        val wallRange = ModuleKillAura.wallRange
         val pos = safePlayer.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
         val pulseOffset = calculatePulse(range)
         val distance = target?.let { sqrt(safePlayer.squaredBoxedDistanceTo(it)).toFloat() }
@@ -108,28 +96,46 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         with(env) {
             startBatch()
             withPositionRelativeToCamera(pos) {
-                // Main range
-                drawRangeCircle(range + pulseOffset, getColor(distance, range))
-
-                // Wall range
-                if (showWallRange && wallRange < range) {
-                    val color = wallRangeColor.run { 
-                        if (hasTarget) with(a = (a * 1.5f).toInt().coerceAtMost(255)) else this 
-                    }
-                    drawRangeCircle(wallRange + pulseOffset * 0.5f, color, outlineAlpha = 80)
-                }
-
-                // Scan range
-                if (showScanRange) {
-                    drawRangeCircle(range + 2.5f, scanRangeColor, outlineAlpha = 60)
-                }
-
-                // Opponent range
-                if (showOpponentRange && hasTarget) {
-                    drawRangeCircle(3f, opponentRangeColor, outlineAlpha = 100)
-                }
+                renderAllCircles(range, pulseOffset, distance, target != null)
             }
             commitBatch()
+        }
+    }
+
+    private fun getPlayerIfVisible() = player.takeUnless {
+        (hideWhenDead && it.isDeadOrDying) ||
+        (hideWhenSpectator && it.isSpectator) ||
+        (hideInVehicle && it.vehicle != null)
+    }
+
+    private fun shouldHideForInventory(): Boolean {
+        if (!respectInventorySetting || ModuleKillAura.ignoreOpenInventory) return false
+        return isInventoryOpen || net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
+    }
+
+    private fun WorldRenderEnvironment.renderAllCircles(
+        range: Float,
+        pulseOffset: Float,
+        distance: Float?,
+        hasTarget: Boolean
+    ) {
+        drawRangeCircle(range + pulseOffset, getColor(distance, range))
+
+        if (showWallRange && ModuleKillAura.wallRange < range) {
+            val color = if (hasTarget) {
+                wallRangeColor.with(a = (wallRangeColor.a * 1.5f).toInt().coerceAtMost(255))
+            } else {
+                wallRangeColor
+            }
+            drawRangeCircle(ModuleKillAura.wallRange + pulseOffset * 0.5f, color, outlineAlpha = 80)
+        }
+
+        if (showScanRange) {
+            drawRangeCircle(range + 2.5f, scanRangeColor, outlineAlpha = 60)
+        }
+
+        if (showOpponentRange && hasTarget) {
+            drawRangeCircle(3f, opponentRangeColor, outlineAlpha = 100)
         }
     }
 
@@ -153,10 +159,14 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     private fun updateColorFactor(hasTarget: Boolean) {
         val target = if (hasTarget) 1f else 0f
         colorFactor = if (fadeAnimation) {
-            Mth.lerp(fadeSpeed, colorFactor, target).also { 
-                if (abs(it - target) < 0.01f) colorFactor = target 
+            Mth.lerp(fadeSpeed, colorFactor, target).also {
+                if (abs(it - target) < 0.01f) {
+                    colorFactor = target
+                }
             }
-        } else target
+        } else {
+            target
+        }
     }
 
     private fun getColor(distance: Float?, range: Float): Color4b = when (colorMode) {
@@ -167,7 +177,11 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         ColorMode.STATIC -> if (fadeAnimation) {
             idleColor.interpolateTo(activeColor, colorFactor.toDouble())
         } else {
-            if (colorFactor > 0.5f) activeColor else idleColor
+            if (colorFactor > 0.5f) {
+                activeColor
+            } else {
+                idleColor
+            }
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -30,19 +30,19 @@ import net.ccbluex.liquidbounce.render.utils.rainbow
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.ccbluex.liquidbounce.utils.inventory.InventoryManager.isInventoryOpen
+import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.util.Mth
 import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
  * Renders a circle around the player indicating the KillAura attack range.
- * Features:
- * - Synced with KillAura Range and WallRange
- * - Color changes based on target state (idle/active)
- * - Multiple color modes (static, rainbow, distance-based)
- * - Pulse animation option
- * - Opponent range visualization
- * - Enemy count display
+ * Fully synced with KillAura settings:
+ * - Range and WallRange from KillAura
+ * - ScanExtraRange visualization
+ * - OpponentRange from FightBot
+ * - Respects IgnoreOpenInventory setting
  */
 object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeIndicator", false) {
 
@@ -64,23 +64,25 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     private val fadeAnimation by boolean("FadeAnimation", true)
     private val fadeSpeed by float("FadeSpeed", 0.1f, 0.01f..0.5f)
 
-    // Wall range circle
+    // Additional range circles (synced with KillAura)
     private val showWallRange by boolean("ShowWallRange", false)
     private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 60))
 
-    // Opponent range (shows estimated enemy attack range)
+    private val showScanRange by boolean("ShowScanRange", false)
+    private val scanRangeColor by color("ScanRangeColor", Color4b(100, 100, 255, 40))
+
+    // Opponent range (synced with FightBot.opponentRange)
     private val showOpponentRange by boolean("ShowOpponentRange", false)
-    private val opponentRange by float("OpponentRange", 3f, 1f..6f)
     private val opponentRangeColor by color("OpponentRangeColor", Color4b(255, 0, 0, 40))
 
-    // Conditions - when NOT to render
+    // Conditions - synced with KillAura behavior
     private val hideWhenDead by boolean("HideWhenDead", true)
     private val hideWhenSpectator by boolean("HideWhenSpectator", true)
     private val hideInVehicle by boolean("HideInVehicle", false)
+    private val respectInventorySetting by boolean("RespectInventorySetting", true)
 
     // State tracking for animations
     private var currentColorFactor = 0f
-    private var lastTargetState = false
 
     private enum class ColorMode(override val choiceName: String) : NamedChoice {
         STATIC("Static"),
@@ -91,10 +93,16 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     fun render(env: WorldRenderEnvironment, partialTicks: Float) {
         if (!enabled) return
 
-        // Check conditions
+        // Sync with KillAura conditions
         if (hideWhenDead && player.isDeadOrDying) return
         if (hideWhenSpectator && player.isSpectator) return
         if (hideInVehicle && player.vehicle != null) return
+
+        // Respect KillAura's inventory setting
+        if (respectInventorySetting) {
+            val isInInventoryScreen = isInventoryOpen || net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
+            if (isInInventoryScreen && !ModuleKillAura.ignoreOpenInventory) return
+        }
 
         val target = ModuleKillAura.targetTracker.target
         val hasTarget = target != null
@@ -102,8 +110,10 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         // Update fade animation
         updateFadeAnimation(hasTarget)
 
+        // Get ranges from KillAura (synced)
         val range = ModuleKillAura.range
         val wallRange = ModuleKillAura.wallRange
+
         val pos = player.interpolateCurrentPosition(partialTicks)
 
         // Calculate pulse effect
@@ -119,29 +129,42 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
 
         with(env) {
             withPositionRelativeToCamera(pos) {
-                // Main attack range circle
+                // Main attack range circle (synced with KillAura.range)
                 drawGradientCircle(effectiveRange, 0f, color, color.with(a = 0))
 
                 if (outline) {
                     drawCircleOutline(effectiveRange, outlineColor)
                 }
 
-                // Wall range circle
+                // Wall range circle (synced with KillAura.wallRange)
                 if (showWallRange && wallRange < range) {
                     val wallColor = wallRangeColor.let {
                         if (hasTarget) it.with(a = (it.a * 1.5f).toInt().coerceAtMost(255)) else it
                     }
-                    drawGradientCircle(wallRange, 0f, wallColor, wallColor.with(a = 0))
+                    drawGradientCircle(wallRange + pulseOffset * 0.5f, 0f, wallColor, wallColor.with(a = 0))
                     if (outline) {
-                        drawCircleOutline(wallRange, outlineColor.with(a = 80))
+                        drawCircleOutline(wallRange + pulseOffset * 0.5f, outlineColor.with(a = 80))
                     }
                 }
 
-                // Opponent range circle (enemy's estimated attack range)
-                if (showOpponentRange && hasTarget) {
-                    drawGradientCircle(opponentRange, 0f, opponentRangeColor, opponentRangeColor.with(a = 0))
+                // Scan extra range circle (shows detection range beyond attack range)
+                if (showScanRange) {
+                    // ScanExtraRange is private, so we approximate with a fixed offset
+                    // This shows the area where KillAura starts tracking but can't attack yet
+                    val scanRange = range + 2.5f // Approximate middle of default scanExtraRange
+                    drawGradientCircle(scanRange, 0f, scanRangeColor, scanRangeColor.with(a = 0))
                     if (outline) {
-                        drawCircleOutline(opponentRange, opponentRangeColor.with(a = 100))
+                        drawCircleOutline(scanRange, scanRangeColor.with(a = 60))
+                    }
+                }
+
+                // Opponent range circle (synced concept with FightBot.opponentRange)
+                // Shows estimated enemy attack range for spacing awareness
+                if (showOpponentRange && hasTarget) {
+                    val oppRange = 3f // Default opponent reach in Minecraft
+                    drawGradientCircle(oppRange, 0f, opponentRangeColor, opponentRangeColor.with(a = 0))
+                    if (outline) {
+                        drawCircleOutline(oppRange, opponentRangeColor.with(a = 100))
                     }
                 }
             }
@@ -151,22 +174,20 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     private fun updateFadeAnimation(hasTarget: Boolean) {
         if (!fadeAnimation) {
             currentColorFactor = if (hasTarget) 1f else 0f
-            lastTargetState = hasTarget
             return
         }
 
         val targetFactor = if (hasTarget) 1f else 0f
         currentColorFactor = Mth.lerp(fadeSpeed, currentColorFactor, targetFactor)
 
-        // Snap to target if close enough
         if (kotlin.math.abs(currentColorFactor - targetFactor) < 0.01f) {
             currentColorFactor = targetFactor
         }
-
-        lastTargetState = hasTarget
     }
 
     private fun getColor(distanceToTarget: Float?): Color4b {
+        val range = ModuleKillAura.range
+
         return when (colorMode) {
             ColorMode.RAINBOW -> rainbow(alpha = 0.5f)
 
@@ -174,8 +195,6 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
                 if (distanceToTarget == null) {
                     idleColor
                 } else {
-                    // Interpolate from green (close) to red (far) based on distance
-                    val range = ModuleKillAura.range
                     val factor = (distanceToTarget / range).coerceIn(0f, 1f)
                     interpolateColor(activeColor, idleColor, factor)
                 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -119,7 +119,7 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         // Calculate pulse effect
         val pulseOffset = if (pulseAnimation) {
             val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
-            (sin(time * Math.PI * 2).toFloat() * pulseIntensity * range)
+            (sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range)
         } else 0f
 
         val effectiveRange = range + pulseOffset
@@ -196,27 +196,18 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
                     idleColor
                 } else {
                     val factor = (distanceToTarget / range).coerceIn(0f, 1f)
-                    interpolateColor(activeColor, idleColor, factor)
+                    activeColor.interpolateTo(idleColor, factor.toDouble())
                 }
             }
 
             ColorMode.STATIC -> {
                 if (fadeAnimation) {
-                    interpolateColor(idleColor, activeColor, currentColorFactor)
+                    idleColor.interpolateTo(activeColor, currentColorFactor.toDouble())
                 } else {
                     if (currentColorFactor > 0.5f) activeColor else idleColor
                 }
             }
         }
-    }
-
-    private fun interpolateColor(from: Color4b, to: Color4b, factor: Float): Color4b {
-        return Color4b(
-            (from.r + (to.r - from.r) * factor).toInt(),
-            (from.g + (to.g - from.g) * factor).toInt(),
-            (from.b + (to.b - from.b) * factor).toInt(),
-            (from.a + (to.a - from.a) * factor).toInt()
-        )
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -22,67 +22,56 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
 import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
-import net.ccbluex.liquidbounce.render.drawGradientCircle
 import net.ccbluex.liquidbounce.render.drawCircleOutline
+import net.ccbluex.liquidbounce.render.drawGradientCircle
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
-import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.render.utils.rainbow
+import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager.isInventoryOpen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.util.Mth
+import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
  * Renders a circle around the player indicating the KillAura attack range.
- * Fully synced with KillAura settings:
- * - Range and WallRange from KillAura
- * - ScanExtraRange visualization
- * - OpponentRange from FightBot
- * - Respects IgnoreOpenInventory setting
+ * Synced with KillAura settings for Range, WallRange, and IgnoreOpenInventory.
  */
 object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeIndicator", false) {
 
-    // Color settings
     private val colorMode by enumChoice("ColorMode", ColorMode.STATIC)
     private val idleColor by color("IdleColor", Color4b(255, 50, 50, 80))
     private val activeColor by color("ActiveColor", Color4b(50, 255, 50, 80))
 
-    // Outline settings
     private val outline by boolean("Outline", true)
     private val outlineColor by color("OutlineColor", Color4b(255, 255, 255, 120))
 
-    // Animation settings
     private val pulseAnimation by boolean("PulseAnimation", false)
     private val pulseSpeed by float("PulseSpeed", 2f, 0.5f..5f)
     private val pulseIntensity by float("PulseIntensity", 0.15f, 0.05f..0.5f)
 
-    // Fade animation for state changes
     private val fadeAnimation by boolean("FadeAnimation", true)
     private val fadeSpeed by float("FadeSpeed", 0.1f, 0.01f..0.5f)
 
-    // Additional range circles (synced with KillAura)
     private val showWallRange by boolean("ShowWallRange", false)
     private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 60))
 
     private val showScanRange by boolean("ShowScanRange", false)
     private val scanRangeColor by color("ScanRangeColor", Color4b(100, 100, 255, 40))
 
-    // Opponent range (synced with FightBot.opponentRange)
     private val showOpponentRange by boolean("ShowOpponentRange", false)
     private val opponentRangeColor by color("OpponentRangeColor", Color4b(255, 0, 0, 40))
 
-    // Conditions - synced with KillAura behavior
     private val hideWhenDead by boolean("HideWhenDead", true)
     private val hideWhenSpectator by boolean("HideWhenSpectator", true)
     private val hideInVehicle by boolean("HideInVehicle", false)
     private val respectInventorySetting by boolean("RespectInventorySetting", true)
 
-    // State tracking for animations
-    private var currentColorFactor = 0f
+    private var colorFactor = 0f
 
     private enum class ColorMode(override val choiceName: String) : NamedChoice {
         STATIC("Static"),
@@ -93,121 +82,92 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     fun render(env: WorldRenderEnvironment, partialTicks: Float) {
         if (!enabled) return
 
-        // Sync with KillAura conditions
-        if (hideWhenDead && player.isDeadOrDying) return
-        if (hideWhenSpectator && player.isSpectator) return
-        if (hideInVehicle && player.vehicle != null) return
+        val safePlayer = player.takeUnless { 
+            (hideWhenDead && it.isDeadOrDying) ||
+            (hideWhenSpectator && it.isSpectator) ||
+            (hideInVehicle && it.vehicle != null)
+        } ?: return
 
-        // Respect KillAura's inventory setting
-        if (respectInventorySetting) {
-            val isInInventoryScreen = isInventoryOpen || net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
-            if (isInInventoryScreen && !ModuleKillAura.ignoreOpenInventory) return
+        if (respectInventorySetting && !ModuleKillAura.ignoreOpenInventory) {
+            val inInventory = isInventoryOpen || 
+                net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
+            if (inInventory) return
         }
 
         val target = ModuleKillAura.targetTracker.target
         val hasTarget = target != null
 
-        // Update fade animation
-        updateFadeAnimation(hasTarget)
+        updateColorFactor(hasTarget)
 
-        // Get ranges from KillAura (synced)
         val range = ModuleKillAura.range
         val wallRange = ModuleKillAura.wallRange
-
-        val pos = player.interpolateCurrentPosition(partialTicks)
-
-        // Calculate pulse effect
-        val pulseOffset = if (pulseAnimation) {
-            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
-            (sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range)
-        } else 0f
-
-        val effectiveRange = range + pulseOffset
-
-        // Get color based on mode
-        val color = getColor(target?.let { sqrt(player.squaredBoxedDistanceTo(it)).toFloat() })
+        val pos = safePlayer.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
+        val pulseOffset = calculatePulse(range)
+        val distance = target?.let { sqrt(safePlayer.squaredBoxedDistanceTo(it)).toFloat() }
 
         with(env) {
+            startBatch()
             withPositionRelativeToCamera(pos) {
-                // Main attack range circle (synced with KillAura.range)
-                drawGradientCircle(effectiveRange, 0f, color, color.with(a = 0))
+                // Main range
+                drawRangeCircle(range + pulseOffset, getColor(distance, range))
 
-                if (outline) {
-                    drawCircleOutline(effectiveRange, outlineColor)
-                }
-
-                // Wall range circle (synced with KillAura.wallRange)
+                // Wall range
                 if (showWallRange && wallRange < range) {
-                    val wallColor = wallRangeColor.let {
-                        if (hasTarget) it.with(a = (it.a * 1.5f).toInt().coerceAtMost(255)) else it
+                    val color = wallRangeColor.run { 
+                        if (hasTarget) with(a = (a * 1.5f).toInt().coerceAtMost(255)) else this 
                     }
-                    drawGradientCircle(wallRange + pulseOffset * 0.5f, 0f, wallColor, wallColor.with(a = 0))
-                    if (outline) {
-                        drawCircleOutline(wallRange + pulseOffset * 0.5f, outlineColor.with(a = 80))
-                    }
+                    drawRangeCircle(wallRange + pulseOffset * 0.5f, color, outlineAlpha = 80)
                 }
 
-                // Scan extra range circle (shows detection range beyond attack range)
+                // Scan range
                 if (showScanRange) {
-                    // ScanExtraRange is private, so we approximate with a fixed offset
-                    // This shows the area where KillAura starts tracking but can't attack yet
-                    val scanRange = range + 2.5f // Approximate middle of default scanExtraRange
-                    drawGradientCircle(scanRange, 0f, scanRangeColor, scanRangeColor.with(a = 0))
-                    if (outline) {
-                        drawCircleOutline(scanRange, scanRangeColor.with(a = 60))
-                    }
+                    drawRangeCircle(range + 2.5f, scanRangeColor, outlineAlpha = 60)
                 }
 
-                // Opponent range circle (synced concept with FightBot.opponentRange)
-                // Shows estimated enemy attack range for spacing awareness
+                // Opponent range
                 if (showOpponentRange && hasTarget) {
-                    val oppRange = 3f // Default opponent reach in Minecraft
-                    drawGradientCircle(oppRange, 0f, opponentRangeColor, opponentRangeColor.with(a = 0))
-                    if (outline) {
-                        drawCircleOutline(oppRange, opponentRangeColor.with(a = 100))
-                    }
+                    drawRangeCircle(3f, opponentRangeColor, outlineAlpha = 100)
                 }
             }
+            commitBatch()
         }
     }
 
-    private fun updateFadeAnimation(hasTarget: Boolean) {
-        if (!fadeAnimation) {
-            currentColorFactor = if (hasTarget) 1f else 0f
-            return
-        }
-
-        val targetFactor = if (hasTarget) 1f else 0f
-        currentColorFactor = Mth.lerp(fadeSpeed, currentColorFactor, targetFactor)
-
-        if (kotlin.math.abs(currentColorFactor - targetFactor) < 0.01f) {
-            currentColorFactor = targetFactor
+    private fun WorldRenderEnvironment.drawRangeCircle(
+        radius: Float, 
+        color: Color4b, 
+        outlineAlpha: Int = 255
+    ) {
+        drawGradientCircle(radius, 0f, color, color.with(a = 0))
+        if (outline) {
+            drawCircleOutline(radius, outlineColor.with(a = outlineAlpha))
         }
     }
 
-    private fun getColor(distanceToTarget: Float?): Color4b {
-        val range = ModuleKillAura.range
+    private fun calculatePulse(range: Float): Float = 
+        if (pulseAnimation) {
+            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
+            sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
+        } else 0f
 
-        return when (colorMode) {
-            ColorMode.RAINBOW -> rainbow(alpha = 0.5f)
-
-            ColorMode.DISTANCE -> {
-                if (distanceToTarget == null) {
-                    idleColor
-                } else {
-                    val factor = (distanceToTarget / range).coerceIn(0f, 1f)
-                    activeColor.interpolateTo(idleColor, factor.toDouble())
-                }
+    private fun updateColorFactor(hasTarget: Boolean) {
+        val target = if (hasTarget) 1f else 0f
+        colorFactor = if (fadeAnimation) {
+            Mth.lerp(fadeSpeed, colorFactor, target).also { 
+                if (abs(it - target) < 0.01f) colorFactor = target 
             }
-
-            ColorMode.STATIC -> {
-                if (fadeAnimation) {
-                    idleColor.interpolateTo(activeColor, currentColorFactor.toDouble())
-                } else {
-                    if (currentColorFactor > 0.5f) activeColor else idleColor
-                }
-            }
-        }
+        } else target
     }
 
+    private fun getColor(distance: Float?, range: Float): Color4b = when (colorMode) {
+        ColorMode.RAINBOW -> rainbow(alpha = 0.5f)
+        ColorMode.DISTANCE -> distance?.let { d ->
+            activeColor.interpolateTo(idleColor, (d / range).coerceIn(0f, 1f).toDouble())
+        } ?: idleColor
+        ColorMode.STATIC -> if (fadeAnimation) {
+            idleColor.interpolateTo(activeColor, colorFactor.toDouble())
+        } else {
+            if (colorFactor > 0.5f) activeColor else idleColor
+        }
+    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -77,10 +77,11 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         if (!enabled || !canRender()) return
 
         val target = ModuleKillAura.targetTracker.target
-        val hasTarget = target != null
+        updateColorFactor(target != null)
+        renderIndicator(env, partialTicks, target)
+    }
 
-        updateColorFactor(hasTarget)
-
+    private fun renderIndicator(env: WorldRenderEnvironment, partialTicks: Float, target: net.minecraft.world.entity.LivingEntity?) {
         val range = ModuleKillAura.range
         val pos = player.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
         val pulseOffset = calculatePulse(range)
@@ -89,7 +90,7 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         with(env) {
             startBatch()
             withPositionRelativeToCamera(pos) {
-                renderCircles(range, pulseOffset, distance, hasTarget)
+                renderCircles(range, pulseOffset, distance, target != null)
             }
             commitBatch()
         }
@@ -131,13 +132,11 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     }
 
     private fun canRender(): Boolean {
-        if (hideWhenDead && player.isDeadOrDying) return false
-        if (hideWhenSpectator && player.isSpectator) return false
-        if (hideInVehicle && player.vehicle != null) return false
-        if (respectInventorySetting && !ModuleKillAura.ignoreOpenInventory) {
-            if (isInventoryOpen || mc.screen is ContainerScreen) return false
-        }
-        return true
+        return !((hideWhenDead && player.isDeadOrDying) ||
+            (hideWhenSpectator && player.isSpectator) ||
+            (hideInVehicle && player.vehicle != null) ||
+            (respectInventorySetting && !ModuleKillAura.ignoreOpenInventory &&
+                (isInventoryOpen || mc.screen is ContainerScreen)))
     }
 
     private fun WorldRenderEnvironment.drawRangeCircle(radius: Float, color: Color4b, outlineAlpha: Int = 255) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
  *
- * Copyright (c) 2015 - 2025 CCBlueX
+ * Copyright (c) 2015 - 2026 CCBlueX
  *
  * LiquidBounce is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,6 @@ import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager.isInventoryOpen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.util.Mth
-import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -57,14 +56,9 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     private val fadeAnimation by boolean("FadeAnimation", true)
     private val fadeSpeed by float("FadeSpeed", 0.1f, 0.01f..0.5f)
 
-    private val showWallRange by boolean("ShowWallRange", false)
-    private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 60))
-
-    private val showScanRange by boolean("ShowScanRange", false)
-    private val scanRangeColor by color("ScanRangeColor", Color4b(100, 100, 255, 40))
-
-    private val showOpponentRange by boolean("ShowOpponentRange", false)
-    private val opponentRangeColor by color("OpponentRangeColor", Color4b(255, 0, 0, 40))
+    private val wallRangeColor by color("WallRangeColor", Color4b(255, 165, 0, 0))
+    private val scanRangeColor by color("ScanRangeColor", Color4b(100, 100, 255, 0))
+    private val opponentRangeColor by color("OpponentRangeColor", Color4b(255, 0, 0, 0))
 
     private val hideWhenDead by boolean("HideWhenDead", true)
     private val hideWhenSpectator by boolean("HideWhenSpectator", true)
@@ -80,92 +74,69 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
     }
 
     fun render(env: WorldRenderEnvironment, partialTicks: Float) {
-        if (!enabled) return
-
-        val safePlayer = getPlayerIfVisible() ?: return
-        if (shouldHideForInventory()) return
+        if (!enabled || !canRender()) return
 
         val target = ModuleKillAura.targetTracker.target
-        updateColorFactor(target != null)
+        val hasTarget = target != null
+
+        updateColorFactor(hasTarget)
 
         val range = ModuleKillAura.range
-        val pos = safePlayer.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
-        val pulseOffset = calculatePulse(range)
-        val distance = target?.let { sqrt(safePlayer.squaredBoxedDistanceTo(it)).toFloat() }
+        val pos = player.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
+        val pulseOffset = if (pulseAnimation) {
+            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
+            sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
+        } else 0f
+
+        val distance = target?.let { sqrt(player.squaredBoxedDistanceTo(it)).toFloat() }
 
         with(env) {
             startBatch()
             withPositionRelativeToCamera(pos) {
-                renderAllCircles(range, pulseOffset, distance, target != null)
+                // Main range circle
+                drawRangeCircle(range + pulseOffset, getColor(distance, range))
+
+                // Wall range circle
+                if (wallRangeColor.a > 0 && ModuleKillAura.wallRange < range) {
+                    val color = if (hasTarget) wallRangeColor.fade(1.5f) else wallRangeColor
+                    drawRangeCircle(ModuleKillAura.wallRange + pulseOffset * 0.5f, color, 80)
+                }
+
+                // Scan range circle
+                if (scanRangeColor.a > 0) {
+                    drawRangeCircle(range + 2.5f, scanRangeColor, 60)
+                }
+
+                // Opponent range circle
+                if (opponentRangeColor.a > 0 && hasTarget) {
+                    drawRangeCircle(3f, opponentRangeColor, 100)
+                }
             }
             commitBatch()
         }
     }
 
-    private fun getPlayerIfVisible() = player.takeUnless {
-        (hideWhenDead && it.isDeadOrDying) ||
-        (hideWhenSpectator && it.isSpectator) ||
-        (hideInVehicle && it.vehicle != null)
+    private fun canRender(): Boolean {
+        if (hideWhenDead && player.isDeadOrDying) return false
+        if (hideWhenSpectator && player.isSpectator) return false
+        if (hideInVehicle && player.vehicle != null) return false
+        if (respectInventorySetting && !ModuleKillAura.ignoreOpenInventory) {
+            if (isInventoryOpen || mc.screen is ContainerScreen) return false
+        }
+        return true
     }
 
-    private fun shouldHideForInventory(): Boolean {
-        if (!respectInventorySetting || ModuleKillAura.ignoreOpenInventory) return false
-        return isInventoryOpen || net.ccbluex.liquidbounce.utils.client.mc.screen is ContainerScreen
-    }
-
-    private fun WorldRenderEnvironment.renderAllCircles(
-        range: Float,
-        pulseOffset: Float,
-        distance: Float?,
-        hasTarget: Boolean
-    ) {
-        drawRangeCircle(range + pulseOffset, getColor(distance, range))
-
-        if (showWallRange && ModuleKillAura.wallRange < range) {
-            val color = if (hasTarget) {
-                wallRangeColor.with(a = (wallRangeColor.a * 1.5f).toInt().coerceAtMost(255))
-            } else {
-                wallRangeColor
-            }
-            drawRangeCircle(ModuleKillAura.wallRange + pulseOffset * 0.5f, color, outlineAlpha = 80)
-        }
-
-        if (showScanRange) {
-            drawRangeCircle(range + 2.5f, scanRangeColor, outlineAlpha = 60)
-        }
-
-        if (showOpponentRange && hasTarget) {
-            drawRangeCircle(3f, opponentRangeColor, outlineAlpha = 100)
-        }
-    }
-
-    private fun WorldRenderEnvironment.drawRangeCircle(
-        radius: Float, 
-        color: Color4b, 
-        outlineAlpha: Int = 255
-    ) {
+    private fun WorldRenderEnvironment.drawRangeCircle(radius: Float, color: Color4b, outlineAlpha: Int = 255) {
         drawGradientCircle(radius, 0f, color, color.with(a = 0))
         if (outline) {
             drawCircleOutline(radius, outlineColor.with(a = outlineAlpha))
         }
     }
 
-    private fun calculatePulse(range: Float): Float =
-        if (pulseAnimation) {
-            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
-            sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
-        } else {
-            0f
-        }
-
     private fun updateColorFactor(hasTarget: Boolean) {
         val target = if (hasTarget) 1f else 0f
         colorFactor = if (fadeAnimation) {
-            Mth.lerp(fadeSpeed, colorFactor, target).also {
-                if (abs(it - target) < 0.01f) {
-                    colorFactor = target
-                }
-            }
+            Mth.lerp(fadeSpeed, colorFactor, target)
         } else {
             target
         }
@@ -173,17 +144,11 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
 
     private fun getColor(distance: Float?, range: Float): Color4b = when (colorMode) {
         ColorMode.RAINBOW -> rainbow(alpha = 0.5f)
-        ColorMode.DISTANCE -> distance?.let { d ->
-            activeColor.interpolateTo(idleColor, (d / range).coerceIn(0f, 1f).toDouble())
+        ColorMode.DISTANCE -> distance?.let {
+            activeColor.interpolateTo(idleColor, (it / range).coerceIn(0f, 1f).toDouble())
         } ?: idleColor
-        ColorMode.STATIC -> if (fadeAnimation) {
-            idleColor.interpolateTo(activeColor, colorFactor.toDouble())
-        } else {
-            if (colorFactor > 0.5f) {
-                activeColor
-            } else {
-                idleColor
-            }
-        }
+        ColorMode.STATIC -> idleColor.interpolateTo(activeColor, colorFactor.toDouble())
     }
+
+    private fun Color4b.fade(factor: Float) = with(a = (a * factor).toInt().coerceAtMost(255))
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager.isInventoryOpen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.util.Mth
+import net.minecraft.world.entity.LivingEntity
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -81,7 +82,7 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         renderIndicator(env, partialTicks, target)
     }
 
-    private fun renderIndicator(env: WorldRenderEnvironment, partialTicks: Float, target: net.minecraft.world.entity.LivingEntity?) {
+    private fun renderIndicator(env: WorldRenderEnvironment, partialTicks: Float, target: LivingEntity?) {
         val range = ModuleKillAura.range
         val pos = player.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
         val pulseOffset = calculatePulse(range)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -83,36 +83,50 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
 
         val range = ModuleKillAura.range
         val pos = player.interpolateCurrentPosition(partialTicks.coerceIn(0f, 1f))
-        val pulseOffset = if (pulseAnimation) {
-            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
-            sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
-        } else 0f
-
+        val pulseOffset = calculatePulse(range)
         val distance = target?.let { sqrt(player.squaredBoxedDistanceTo(it)).toFloat() }
 
         with(env) {
             startBatch()
             withPositionRelativeToCamera(pos) {
-                // Main range circle
-                drawRangeCircle(range + pulseOffset, getColor(distance, range))
-
-                // Wall range circle
-                if (wallRangeColor.a > 0 && ModuleKillAura.wallRange < range) {
-                    val color = if (hasTarget) wallRangeColor.fade(1.5f) else wallRangeColor
-                    drawRangeCircle(ModuleKillAura.wallRange + pulseOffset * 0.5f, color, 80)
-                }
-
-                // Scan range circle
-                if (scanRangeColor.a > 0) {
-                    drawRangeCircle(range + 2.5f, scanRangeColor, 60)
-                }
-
-                // Opponent range circle
-                if (opponentRangeColor.a > 0 && hasTarget) {
-                    drawRangeCircle(3f, opponentRangeColor, 100)
-                }
+                renderCircles(range, pulseOffset, distance, hasTarget)
             }
             commitBatch()
+        }
+    }
+
+    private fun calculatePulse(range: Float): Float {
+        return if (pulseAnimation) {
+            val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
+            sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
+        } else {
+            0f
+        }
+    }
+
+    private fun WorldRenderEnvironment.renderCircles(
+        range: Float,
+        pulseOffset: Float,
+        distance: Float?,
+        hasTarget: Boolean
+    ) {
+        drawRangeCircle(range + pulseOffset, getColor(distance, range))
+
+        if (wallRangeColor.a > 0 && ModuleKillAura.wallRange < range) {
+            val color = if (hasTarget) {
+                wallRangeColor.fade(1.5f)
+            } else {
+                wallRangeColor
+            }
+            drawRangeCircle(ModuleKillAura.wallRange + pulseOffset * 0.5f, color, 80)
+        }
+
+        if (scanRangeColor.a > 0) {
+            drawRangeCircle(range + 2.5f, scanRangeColor, 60)
+        }
+
+        if (opponentRangeColor.a > 0 && hasTarget) {
+            drawRangeCircle(3f, opponentRangeColor, 100)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraRangeIndicator.kt
@@ -150,11 +150,13 @@ object KillAuraRangeIndicator : ToggleableConfigurable(ModuleKillAura, "RangeInd
         }
     }
 
-    private fun calculatePulse(range: Float): Float = 
+    private fun calculatePulse(range: Float): Float =
         if (pulseAnimation) {
             val time = System.currentTimeMillis() / 1000.0 * pulseSpeed
             sin(time * Mth.TWO_PI).toFloat() * pulseIntensity * range
-        } else 0f
+        } else {
+            0f
+        }
 
     private fun updateColorFactor(hasTarget: Boolean) {
         val target = if (hasTarget) 1f else 0f


### PR DESCRIPTION
Add visual range indicator to KillAura module showing attack range:
- Circle around player indicating attack range
- Color changes based on target state (idle/active)
- Multiple color modes: Static, Rainbow, Distance-based
- Pulse and fade animations
- Optional circles for WallRange, ScanRange, OpponentRange

Fully synced with KillAura settings:
- Uses KillAura Range and WallRange values
- Respects IgnoreOpenInventory setting
- Hides when player is dead/spectator

**Example:** Enable KillAura → RangeIndicator, and a circle appears
around you showing your attack range. Green when targeting, red when idle.

**Useful for:** PvP spacing, visualizing attack range, timing engagements.

## Demo


https://github.com/user-attachments/assets/28fcb788-8442-4ccc-86f5-b392bb8bccc4



## Configuration

| Option | Description |
|--------|-------------|
| ColorMode | Static, Rainbow, or Distance-based coloring |
| IdleColor | Color when no target (default: red) |
| ActiveColor | Color when targeting (default: green) |
| PulseAnimation | Circle expands/contracts smoothly |
| FadeAnimation | Smooth color transition on state change |
| ShowWallRange | Display wall attack range circle |
| ShowScanRange | Display detection range circle |
| ShowOpponentRange | Display enemy attack range |