### PR TITLE
fix(integration): correct CREATE_WORLD screen navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /logs/
 /.kotlin/
 .DS_Store
+*.log

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/VirtualScreenType.kt
@@ -90,9 +90,16 @@ enum class VirtualScreenType(
     CREATE_WORLD(
         "create_world",
         recognizer = { it is CreateWorldScreen },
-        open = { CreateWorldScreen.openFresh(mc) {
-            mc.setScreen(IntegrationListener.parent)
-        } }
+        open = {
+            // Store parent before opening CreateWorldScreen, since IntegrationListener.parent
+            // will change to CreateWorldScreen once it's opened
+            val parentScreen = IntegrationListener.parent
+            CreateWorldScreen.openFresh(mc) {
+                // Return to SelectWorldScreen instead of the stored parent,
+                // as this is the expected navigation flow from Create World
+                mc.setScreen(SelectWorldScreen(parentScreen))
+            }
+        }
     ),
 
     OPTIONS(


### PR DESCRIPTION
## Summary
Fix the cancel button in CreateWorldScreen not working - it stayed on the same screen instead of returning to SelectWorldScreen.

## Problem
When clicking 'Add' from Single Player and then 'Cancel' in Create World screen, nothing happened - the user stayed on CreateWorldScreen.

## Cause
`IntegrationListener.parent` returns the current screen (`mc.screen`) at callback time, which was already `CreateWorldScreen`. When Minecraft receives `setScreen` with the same screen, it does nothing.

https://github.com/user-attachments/assets/dbcaee14-fabc-42e8-8fa8-cc2deb27cdb5

## Solution
Create a new `SelectWorldScreen` instance in the callback to ensure proper navigation back to the world selection screen.

https://github.com/user-attachments/assets/ddf7877f-4885-491a-be3a-307939c0dbf7

Fixes CCBlueX/LiquidBounce#7560