### PR TITLE
feat(account): from env

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -350,6 +350,10 @@ object LiquidBounce : EventListener {
             }
             launch {
                 ConfigSystem.load(ClientAccountManager)
+                if (ClientAccount.ENV_ACCOUNT != null) {
+                    ClientAccountManager.clientAccount = ClientAccount.ENV_ACCOUNT
+                }
+
                 if (ClientAccountManager.clientAccount != ClientAccount.EMPTY_ACCOUNT) {
                     runCatching {
                         ClientAccountManager.clientAccount.renew()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/api/models/auth/ClientAccount.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/api/models/auth/ClientAccount.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.api.models.user.UserInformation
 import net.ccbluex.liquidbounce.api.services.auth.OAuthClient
 import net.ccbluex.liquidbounce.api.services.user.UserApi
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
+import net.ccbluex.liquidbounce.utils.client.env
 import java.util.UUID
 
 
@@ -63,5 +64,30 @@ data class ClientAccount(
     companion object {
         @JvmField
         val EMPTY_ACCOUNT = ClientAccount(null, null, null)
+        @JvmField
+        val ENV_ACCOUNT = fromEnv()
+
+        private fun fromEnv(): ClientAccount? {
+            val accessToken = env(
+                "LB_ACCOUNT_ACCESS_TOKEN",
+                "net.ccbluex.liquidbounce.account.accessToken"
+            ) ?: return null
+            val accessTokenExpiresAt = env(
+                "LB_ACCOUNT_ACCESS_TOKEN_EXPIRES_AT",
+                "net.ccbluex.liquidbounce.account.accessTokenExpiresAt"
+            )?.toLongOrNull() ?: return null
+            val refreshToken = env(
+                "LB_ACCOUNT_REFRESH_TOKEN",
+                "net.ccbluex.liquidbounce.account.refreshToken"
+            ) ?: return null
+
+            return ClientAccount(
+                session = OAuthSession(
+                    accessToken = ExpiryValue(accessToken, accessTokenExpiresAt),
+                    refreshToken = refreshToken
+                )
+            )
+        }
+
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/ClientAccountManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/cosmetic/ClientAccountManager.kt
@@ -23,5 +23,5 @@ import net.ccbluex.liquidbounce.api.models.auth.ClientAccount
 import net.ccbluex.liquidbounce.config.types.nesting.Configurable
 
 object ClientAccountManager : Configurable("account") {
-    var clientAccount by value("account", ClientAccount.EMPTY_ACCOUNT)
+    var clientAccount by value("account", ClientAccount.ENV_ACCOUNT ?: ClientAccount.EMPTY_ACCOUNT)
 }


### PR DESCRIPTION
Allows setting access token and refresh token via env. Could be useful to pass account from launcher.