### PR TITLE
fix(UI): label of switches in menus not clickable

### DIFF
--- a/src-theme/src/routes/clickgui/setting/common/Switch.svelte
+++ b/src-theme/src/routes/clickgui/setting/common/Switch.svelte
@@ -8,12 +8,12 @@
 </script>
 
 <label class="switch-container">
-    <div class="switch">
+    <span class="switch">
         <input type="checkbox" bind:checked={value} on:change={() => dispatch("change")}/>
         <span class="slider"></span>
-    </div>
+    </span>
 
-    <div class="name">{name}</div>
+    <span class="name">{name}</span>
 </label>
 
 <style lang="scss">

--- a/src-theme/src/routes/menu/common/setting/SwitchSetting.svelte
+++ b/src-theme/src/routes/menu/common/setting/SwitchSetting.svelte
@@ -7,14 +7,15 @@
     const dispatch = createEventDispatcher();
 </script>
 
-<div class="switch-setting">
-    <label class="switch">
+<label class="switch-setting">
+    <span class="switch">
         <input type="checkbox" bind:checked={value} on:change={() => dispatch("change")}/>
         <span class="slider"></span>
-    </label>
+    </span>
 
-    <div class="title">{title}</div>
-</div>
+    <span class="title">{title}</span>
+</label>
+
 <style lang="scss">
   @use "sass:color";
   @use "../../../../colors.scss" as *;
@@ -22,6 +23,7 @@
   .switch-setting {
     display: flex;
     align-items: center;
+    cursor: pointer;
   }
 
   .title {
@@ -61,7 +63,6 @@
     width: 28px;
     height: 18px;
     align-items: center;
-    cursor: pointer;
     margin: 0 10px;
 
     input {


### PR DESCRIPTION
The label of switches in menus can now be clicked to toggle them.


https://github.com/user-attachments/assets/66e1fafd-b69c-40c2-8b66-43d204dd267e

