### PR TITLE
fix(browser-backend/cef): clipboard copy and paste on wayland

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ fabric-loaderMin = "0.16.14"
 fabric-api = "0.140.0+1.21.11"
 
 # mcef
-mcef = "3.2.0-1.21.11"
+mcef = "3.2.1-1.21.11"
 # mc-authlib
 mc_authlib = "1.7.0"
 # Polyglot


### PR DESCRIPTION
When the ozone platform is set to x11, it somehow works on wayland. Makes sense.