### PR TITLE
refactor(ClickGUI): persistent screen

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLocalPlayer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLocalPlayer.java
@@ -33,14 +33,12 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleSprint;
 import net.ccbluex.liquidbounce.features.module.modules.movement.NoPushBy;
 import net.ccbluex.liquidbounce.features.module.modules.movement.noslow.ModuleNoSlow;
 import net.ccbluex.liquidbounce.features.module.modules.player.ModuleNoEntityInteract;
-import net.ccbluex.liquidbounce.features.module.modules.render.ModuleClickGui;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleFreeCam;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleNoSwing;
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleLiquidPlace;
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.PlayerData;
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.PlayerInventoryData;
-import net.ccbluex.liquidbounce.integration.screen.impl.CustomMinecraftScreen;
-import net.ccbluex.liquidbounce.integration.screen.impl.InternetExplorerScreen;
+import net.ccbluex.liquidbounce.integration.screen.ScreenManager;
 import net.ccbluex.liquidbounce.interfaces.LocalPlayerAddition;
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager;
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation;
@@ -446,8 +444,7 @@ public abstract class MixinLocalPlayer extends MixinPlayer implements LocalPlaye
     @WrapWithCondition(method = "clientSideCloseContainer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;setScreen(Lnet/minecraft/client/gui/screens/Screen;)V"))
     private boolean preventCloseScreen(Minecraft instance, Screen screen) {
         // Prevent closing screen if the current screen is a client screen
-        return !(instance.screen instanceof InternetExplorerScreen || instance.screen instanceof CustomMinecraftScreen ||
-                instance.screen instanceof ModuleClickGui.ClickScreen);
+        return !ScreenManager.isClientScreen(screen);
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/AutoConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/AutoConfig.kt
@@ -66,7 +66,7 @@ object AutoConfig {
 
             // After completion of loading, sync ClickGUI
             if (!value) {
-                ModuleClickGui.reload()
+                ModuleClickGui.sync()
             }
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/ModelManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/deeplearn/ModelManager.kt
@@ -86,7 +86,7 @@ object ModelManager : EventListener, Configurable("AI") {
 
         models.choices = choices.toMutableList()
         models.setByString(models.activeChoice.name)
-        ModuleClickGui.reload()
+        ModuleClickGui.sync()
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandBind.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandBind.kt
@@ -78,7 +78,7 @@ object CommandBind : Command.Factory {
 
             if (keyName.equals("none", true)) {
                 module.bindValue.unbind()
-                ModuleClickGui.reload()
+                ModuleClickGui.sync()
                 chat(
                     regular(command.result("moduleUnbound", variable(module.name))),
                     metadata = MessageMetadata(id = "Bind#${module.name}")
@@ -88,7 +88,7 @@ object CommandBind : Command.Factory {
 
             runCatching {
                 module.bindValue.bind(inputByName(keyName), action, modifiers)
-                ModuleClickGui.reload()
+                ModuleClickGui.sync()
             }.onSuccess {
                 chat(
                     regular(command.result("moduleBound", variable(module.name), module.bind.renderText())),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandBinds.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandBinds.kt
@@ -126,7 +126,7 @@ object CommandBinds : Command.Factory {
             )
         }
 
-        ModuleClickGui.reload()
+        ModuleClickGui.sync()
     }
 
     private val removeSubcommand = CommandBuilder
@@ -178,7 +178,7 @@ object CommandBinds : Command.Factory {
             }
 
             module.bindValue.bind(bindKey, action, modifiers)
-            ModuleClickGui.reload()
+            ModuleClickGui.sync()
             chat(
                 regular(
                     command.result("moduleBound", variable(module.name), module.bind.renderText())

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandTargets.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandTargets.kt
@@ -77,7 +77,7 @@ object CommandTargets : Command.Factory {
                 metadata = MessageMetadata(id = "CTargets#info")
             )
 
-            ModuleClickGui.reload()
+            ModuleClickGui.sync()
         }
 
         return this

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandValue.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandValue.kt
@@ -77,7 +77,7 @@ object CommandValue : Command.Factory {
 
             try {
                 value.setByString(valueString)
-                ModuleClickGui.reload()
+                ModuleClickGui.sync()
             } catch (e: Exception) {
                 throw CommandException(command.result("valueError", valueName, e.message ?: ""))
             }
@@ -111,7 +111,7 @@ object CommandValue : Command.Factory {
                 ?: throw CommandException(command.result("valueNotFound", valueName))
 
             value.restore()
-            ModuleClickGui.reload()
+            ModuleClickGui.sync()
             chat(
                 regular(command.result("resetSuccess", variable(valueName), variable(module.name))),
                 metadata = MessageMetadata(id = "CValue#reset${module.name}")
@@ -132,7 +132,7 @@ object CommandValue : Command.Factory {
             module.getContainedValuesRecursively()
                 .filter { !it.name.equals("Bind", true) }
                 .forEach { it.restore() }
-            ModuleClickGui.reload()
+            ModuleClickGui.sync()
             chat(
                 regular(command.result("resetAllSuccess", variable(module.name))),
                 metadata = MessageMetadata(id = "CValue#resetAll${module.name}")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/deeplearn/CommandModels.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/deeplearn/CommandModels.kt
@@ -189,7 +189,7 @@ object CommandModels : Command.Factory {
             model.save()
 
             models.setByString(model.name)
-            ModuleClickGui.reload()
+            ModuleClickGui.sync()
         }
 
         chat(command.result("trainingEnd", name, trainingTime.toString(DurationUnit.MINUTES, decimals = 2)))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleClickGui.kt
@@ -18,32 +18,28 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.render
 
-import net.ccbluex.liquidbounce.additions.screenInitialized
-import net.ccbluex.liquidbounce.additions.setPosition
+import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.config.types.nesting.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.BrowserReadyEvent
 import net.ccbluex.liquidbounce.event.events.ClickGuiScaleChangeEvent
 import net.ccbluex.liquidbounce.event.events.ClickGuiValueChangeEvent
 import net.ccbluex.liquidbounce.event.events.ClientLanguageChangedEvent
-import net.ccbluex.liquidbounce.event.events.GameRenderEvent
+import net.ccbluex.liquidbounce.event.events.DisconnectEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.waitSeconds
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleCategories
-import net.ccbluex.liquidbounce.integration.backend.browser.Browser
 import net.ccbluex.liquidbounce.integration.interop.protocol.rest.v1.game.isTyping
 import net.ccbluex.liquidbounce.integration.screen.CustomScreenType
 import net.ccbluex.liquidbounce.integration.screen.ScreenManager
-import net.ccbluex.liquidbounce.integration.screen.impl.CustomMinecraftScreen
-import net.ccbluex.liquidbounce.integration.theme.ThemeManager
-import net.ccbluex.liquidbounce.utils.client.asPlainText
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomSharedMinecraftScreen
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomStandaloneMinecraftScreen
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.OBJECTION_AGAINST_EVERYTHING
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.READ_FINAL_STATE
-import net.minecraft.client.gui.screens.Screen
 import org.lwjgl.glfw.GLFW
 
 /**
@@ -63,36 +59,25 @@ object ModuleClickGui :
         EventManager.callEvent(ClickGuiValueChangeEvent(this))
     }
 
-    @Suppress("UnusedPrivateProperty")
-    private val cache by boolean("Cache", true).onChanged { cache ->
-        mc.execute {
-            mouseX = Double.NaN
-            mouseY = Double.NaN
-            if (cache) {
-                open()
-            } else {
-                close()
-            }
-
-            if (mc.screen is CustomMinecraftScreen || mc.screen is ClickScreen) {
-                onEnabled()
-            }
-        }
-    }
-
-    private val trackMousePosition by boolean("TrackMousePosition", false)
-
-    @Suppress("UnusedPrivateProperty")
+    @Suppress("UnusedPrivateProperty", "unused")
     private val searchBarAutoFocus by boolean("SearchBarAutoFocus", true).onChanged {
         EventManager.callEvent(ClickGuiValueChangeEvent(this))
     }
 
     val isInSearchBar: Boolean
-        get() = (mc.screen is CustomMinecraftScreen || mc.screen is ClickScreen) && isTyping
+        get() {
+            if (!isTyping) {
+                return false
+            }
+
+            val screen = mc.screen ?: return false
+            return screen is CustomSharedMinecraftScreen && screen.screenType == CustomScreenType.CLICK_GUI ||
+                screen is CustomStandaloneMinecraftScreen && screen.screenType == CustomScreenType.CLICK_GUI
+        }
 
     object Snapping : ToggleableConfigurable(this, "Snapping", true) {
 
-        @Suppress("UnusedPrivateProperty")
+        @Suppress("UnusedPrivateProperty", "unused")
         private val gridSize by int("GridSize", 10, 1..100, "px").onChanged {
             EventManager.callEvent(ClickGuiValueChangeEvent(ModuleClickGui))
         }
@@ -104,119 +89,81 @@ object ModuleClickGui :
         }
     }
 
-    private var clickGuiBrowser: Browser? = null
-    private const val WORLD_CHANGE_SECONDS_UNTIL_RELOAD = 5
-
     init {
         tree(Snapping)
     }
 
-    override fun onEnabled() {
-        // Pretty sure we are not in a game, so we can't open the clickgui
-        if (!inGame) {
-            return
-        }
-
-        mc.setScreen(
-            if (clickGuiBrowser == null) {
-                CustomMinecraftScreen(CustomScreenType.CLICK_GUI)
-            } else {
-                ClickScreen()
-            }
-        )
-        super.onEnabled()
+    @Suppress("UnusedPrivateProperty")
+    private val useStandaloneScreen by boolean("Cache", true).onChanged {
+        mc.execute(::onEnabled)
     }
 
-    private fun open() {
-        if (clickGuiBrowser != null) {
-            return
-        }
-
-        clickGuiBrowser = ThemeManager.openInputAwareImmediate(
-            CustomScreenType.CLICK_GUI,
-            true,
-            priority = 20,
-            settings = ScreenManager.browserSettings
-        ) {
-            mc.screen is ClickScreen
-        }
-    }
-
-    private fun close() {
-        clickGuiBrowser?.let {
-            it.close()
-            clickGuiBrowser = null
-        }
-    }
-
-    fun reload(restart: Boolean = false) {
-        if (restart) {
-            close()
-            open()
-            return
-        }
-
-        clickGuiBrowser?.reload()
-    }
-
-    @Suppress("unused")
-    private val gameRenderHandler = handler<GameRenderEvent>(priority = OBJECTION_AGAINST_EVERYTHING) {
-        clickGuiBrowser?.visible = mc.screen is ClickScreen
-    }
+    // Standalone screen instance for caching
+    private var standaloneScreen: CustomStandaloneMinecraftScreen? = null
 
     @Suppress("unused")
     private val browserReadyHandler = handler<BrowserReadyEvent>(priority = READ_FINAL_STATE) {
         tree(ScreenManager.browserSettings)
-        open()
+    }
+
+    override fun onEnabled() {
+        if (!LiquidBounce.isInitialized || !inGame) {
+            return
+        }
+
+        updateStandaloneScreen()
+        mc.setScreen(standaloneScreen ?: CustomSharedMinecraftScreen(CustomScreenType.CLICK_GUI))
+        super.onEnabled()
     }
 
     @Suppress("unused")
     private val worldChangeHandler = sequenceHandler<WorldChangeEvent>(
         priority = OBJECTION_AGAINST_EVERYTHING
     ) { event ->
-        if (event.world == null) {
+        if (event.world == null || !useStandaloneScreen) {
             return@sequenceHandler
         }
 
-        waitSeconds(WORLD_CHANGE_SECONDS_UNTIL_RELOAD)
-        if (mc.screen !is ClickScreen) {
-            reload()
+        waitSeconds(1)
+        if (updateStandaloneScreen()) {
+            standaloneScreen?.sync()
         }
     }
 
     @Suppress("unused")
-    private val clientLanguageChangedHandler = handler<ClientLanguageChangedEvent> {
-        if (mc.screen !is ClickScreen) {
-            reload()
-        }
+    private val disconnectHandler = handler<DisconnectEvent> {
+        standaloneScreen?.close()
+        standaloneScreen = null
     }
 
-    private var mouseX = Double.NaN
-    private var mouseY = Double.NaN
+    @Suppress("unused")
+    private val clientLanguageChangedHandler = handler<ClientLanguageChangedEvent> {
+        standaloneScreen?.sync()
+    }
 
-    /**
-     * An empty screen that acts as a hint when to draw the clickgui
-     */
-    class ClickScreen : Screen("ClickGUI".asPlainText()) {
-
-        override fun init() {
-            if (trackMousePosition && !screenInitialized && !mouseX.isNaN() && !mouseY.isNaN()) {
-                mc.mouseHandler.setPosition(mouseX, mouseY)
+    fun updateStandaloneScreen(): Boolean {
+        // Standalone Screen Cache
+        if (useStandaloneScreen) {
+            if (standaloneScreen == null) {
+                standaloneScreen = CustomStandaloneMinecraftScreen(CustomScreenType.CLICK_GUI)
+            } else {
+                // Used in [worldChangeHandler] to determine if we need to sync.
+                return true
             }
-            super.init()
+        } else if (standaloneScreen != null) {
+            standaloneScreen?.close()
+            standaloneScreen = null
         }
 
-        override fun onClose() {
-            mouseX = mc.mouseHandler.xpos()
-            mouseY = mc.mouseHandler.ypos()
-            mc.mouseHandler.grabMouse()
-            super.onClose()
+        return false
+    }
+
+    fun sync() {
+        if (!LiquidBounce.isInitialized) {
+            return
         }
 
-        override fun isPauseScreen(): Boolean {
-            // preventing game pause
-            return false
-        }
+        standaloneScreen?.sync()
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ScreenFunctions.kt
@@ -23,7 +23,7 @@ import com.google.gson.JsonObject
 import io.netty.handler.codec.http.FullHttpResponse
 import net.ccbluex.liquidbounce.integration.screen.CustomScreenType
 import net.ccbluex.liquidbounce.integration.screen.ScreenManager
-import net.ccbluex.liquidbounce.integration.screen.impl.CustomMinecraftScreen
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomSharedMinecraftScreen
 import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.netty.http.model.RequestObject
@@ -91,7 +91,7 @@ fun putScreen(requestObject: RequestObject): FullHttpResponse {
 fun deleteScreen(requestObject: RequestObject): FullHttpResponse {
     val screen = mc.screen ?: return httpForbidden("No screen")
 
-    if (screen is CustomMinecraftScreen && screen.parentScreen != null) {
+    if (screen is CustomSharedMinecraftScreen && screen.parentScreen != null) {
         mc.execute {
             mc.setScreen(screen.parentScreen)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/CustomScreenType.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/CustomScreenType.kt
@@ -21,7 +21,7 @@ package net.ccbluex.liquidbounce.integration.screen
 
 import com.google.common.base.Predicates
 import com.mojang.realmsclient.RealmsMainScreen
-import net.ccbluex.liquidbounce.integration.screen.impl.CustomMinecraftScreen
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomSharedMinecraftScreen
 import net.ccbluex.liquidbounce.integration.screen.impl.InternetExplorerScreen
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.client.openVfpProtocolSelection
@@ -52,7 +52,7 @@ enum class CustomScreenType(
     private val recognizer: Predicate<Screen> = Predicates.alwaysFalse(),
     val isInGame: Boolean = false,
     private val open: Runnable = Runnable {
-        mc.setScreen(CustomMinecraftScreen(byName(routeName)!!))
+        mc.setScreen(CustomSharedMinecraftScreen(byName(routeName)!!))
     }
 ) {
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/ScreenManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/ScreenManager.kt
@@ -40,7 +40,8 @@ import net.ccbluex.liquidbounce.integration.backend.browser.Browser
 import net.ccbluex.liquidbounce.integration.backend.browser.GlobalBrowserSettings
 import net.ccbluex.liquidbounce.integration.backend.browser.IntegrationBrowserSettings
 import net.ccbluex.liquidbounce.integration.interop.ClientInteropServer
-import net.ccbluex.liquidbounce.integration.screen.impl.CustomMinecraftScreen
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomSharedMinecraftScreen
+import net.ccbluex.liquidbounce.integration.screen.impl.CustomStandaloneMinecraftScreen
 import net.ccbluex.liquidbounce.integration.screen.impl.InternetExplorerScreen
 import net.ccbluex.liquidbounce.integration.task.TaskProgressScreen
 import net.ccbluex.liquidbounce.integration.theme.Theme
@@ -166,7 +167,7 @@ object ScreenManager : EventListener {
         }
 
         try {
-            ModuleClickGui.reload(true)
+            ModuleClickGui.sync()
         } catch (e: Exception) {
             logger.error("Failed to restart ClickGUI browser integration.", e)
         }
@@ -188,8 +189,8 @@ object ScreenManager : EventListener {
     }
 
     fun restoreOriginalScreen() {
-        if (mc.screen is CustomMinecraftScreen) {
-            mc.setScreen((mc.screen as CustomMinecraftScreen).originalScreen)
+        if (mc.screen is CustomSharedMinecraftScreen) {
+            mc.setScreen((mc.screen as CustomSharedMinecraftScreen).originalScreen)
         }
     }
 
@@ -267,9 +268,9 @@ object ScreenManager : EventListener {
         }
 
         if (HideAppearance.isHidingNow || ClientInteropServer.isSkipping) {
-            return if (screen is CustomMinecraftScreen) {
+            return if (screen is CustomSharedMinecraftScreen) {
                 val original = screen.originalScreen
-                if (original is CustomMinecraftScreen) {
+                if (original is CustomSharedMinecraftScreen) {
                     return false
                 }
 
@@ -281,7 +282,7 @@ object ScreenManager : EventListener {
             }
         }
 
-        if (screen is CustomMinecraftScreen) {
+        if (screen is CustomSharedMinecraftScreen) {
             return false
         }
 
@@ -319,7 +320,7 @@ object ScreenManager : EventListener {
         return when {
             // When we want to fully replace a screen.
             theme.isScreenSupported(name) -> {
-                mc.setScreen(CustomMinecraftScreen(customScreenType, theme, originalScreen = minecraftScreen))
+                mc.setScreen(CustomSharedMinecraftScreen(customScreenType, theme, originalScreen = minecraftScreen))
                 true
             }
             // When we just want to overlay it.
@@ -339,7 +340,8 @@ object ScreenManager : EventListener {
      * Checks if the given screen is an active client screen.
      */
     @JvmStatic
-    fun isClientScreen(screen: Screen?) = screen is CustomMinecraftScreen || screen is ModuleClickGui.ClickScreen ||
-        screen is InternetExplorerScreen
+    fun isClientScreen(screen: Screen?) = screen is CustomSharedMinecraftScreen
+        || screen is CustomStandaloneMinecraftScreen
+        || screen is InternetExplorerScreen
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/impl/CustomSharedMinecraftScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/impl/CustomSharedMinecraftScreen.kt
@@ -27,8 +27,8 @@ import net.ccbluex.liquidbounce.utils.client.asPlainText
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.minecraft.client.gui.screens.Screen
 
-class CustomMinecraftScreen(
-    private val screenType: CustomScreenType,
+class CustomSharedMinecraftScreen(
+    val screenType: CustomScreenType,
     private val theme: Theme = ThemeManager.getScreenLocation(screenType).theme,
     val originalScreen: Screen? = null,
     val parentScreen: Screen? = mc.screen
@@ -39,7 +39,7 @@ class CustomMinecraftScreen(
     }
 
     override fun onClose() {
-        if (parentScreen is CustomMinecraftScreen) {
+        if (parentScreen is CustomSharedMinecraftScreen) {
             mc.setScreen(parentScreen)
         } else {
             ScreenManager.closeScreen()
@@ -48,9 +48,6 @@ class CustomMinecraftScreen(
         }
     }
 
-    override fun isPauseScreen(): Boolean {
-        // preventing game pause
-        return false
-    }
+    override fun isPauseScreen() = false
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/impl/CustomStandaloneMinecraftScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/impl/CustomStandaloneMinecraftScreen.kt
@@ -1,0 +1,74 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.integration.screen.impl
+
+import net.ccbluex.liquidbounce.additions.setPosition
+import net.ccbluex.liquidbounce.integration.screen.CustomScreenType
+import net.ccbluex.liquidbounce.integration.screen.ScreenManager
+import net.ccbluex.liquidbounce.integration.theme.ThemeManager
+import net.ccbluex.liquidbounce.utils.client.asPlainText
+import net.ccbluex.liquidbounce.utils.client.mc
+import net.minecraft.client.gui.screens.Screen
+
+class CustomStandaloneMinecraftScreen(
+    val screenType: CustomScreenType
+) : Screen("VS-${screenType.routeName.uppercase()}".asPlainText()), AutoCloseable {
+
+    val browser = ThemeManager.openInputAwareImmediate(
+        screenType,
+        true,
+        priority = 20,
+        settings = ScreenManager.browserSettings
+    ) {
+        mc.screen == this@CustomStandaloneMinecraftScreen
+    }
+
+    init {
+        browser.visible = false
+    }
+
+    var mouseX = 0.0
+    var mouseY = 0.0
+
+    override fun init() {
+        browser.visible = true
+        mc.mouseHandler.setPosition(mouseX, mouseY)
+    }
+
+    fun sync() {
+        browser.reload()
+    }
+
+    override fun onClose() {
+        browser.visible = false
+
+        mouseX = mc.mouseHandler.xpos()
+        mouseY = mc.mouseHandler.ypos()
+        mc.mouseHandler.grabMouse()
+        super.onClose()
+    }
+
+    override fun isPauseScreen() = false
+
+    override fun close() {
+        browser.close()
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeManager.kt
@@ -55,7 +55,7 @@ object ThemeManager : Configurable("theme") {
         mc.execute {
             ScreenManager.update()
             ModuleHud.reopen()
-            ModuleClickGui.reload(true)
+            ModuleClickGui.sync()
         }
     }
 
@@ -159,7 +159,7 @@ object ThemeManager : Configurable("theme") {
         if (LiquidBounce.isInitialized) {
             ScreenManager.update()
             ModuleHud.reopen()
-            ModuleClickGui.reload(true)
+            ModuleClickGui.sync()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/ScriptManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/ScriptManager.kt
@@ -165,7 +165,7 @@ object ScriptManager {
 
         if (scripts.isNotEmpty()) {
             // Reload the ClickGUI to update the module list.
-            mc.execute(ModuleClickGui::reload)
+            mc.execute(ModuleClickGui::sync)
         }
     }
 


### PR DESCRIPTION
No longer opens on start-up, instead, limits itself to be only in-game. Also introduces the new screen type: CustomStandaloneMinecraftScreen.

Removed TrackMousePosition option, as it was confusing and now enabled by default for CustomStandaloneMinecraftScreen.