### PR TITLE
fix(command/toggle): misused running as enabled

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandToggle.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandToggle.kt
@@ -47,14 +47,14 @@ object CommandToggle : Command.Factory {
             .handler {
                 val module = args[0] as ClientModule
 
-                val newState = !module.running
-                module.enabled = newState
+                val isEnabled = !module.enabled
+                module.enabled = isEnabled
                 chat(
                     regular(
                         command.result(
                             "moduleToggled",
                             variable(module.name),
-                            variable(if (newState) command.result("enabled") else command.result("disabled"))
+                            variable(if (isEnabled) command.result("enabled") else command.result("disabled"))
                         )
                     ),
                     metadata = MessageMetadata(id = "CToggle#success${module.name}")


### PR DESCRIPTION
This caused modules to not get toggled into the opposite enabled state.