### PR TITLE
fix(RichPresence): state incorrect on client startup

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/client/ModuleRichPresence.kt
@@ -204,8 +204,8 @@ object ModuleRichPresence : ClientModule("RichPresence", ModuleCategories.CLIENT
         sendRichPresence(RichPresence.Builder().apply(builderAction).build())
 
     /**
-     * Always running
+     * Always running after initialized
      */
-    override val running = true
+    override val running get() = LiquidBounce.isInitialized
 
 }


### PR DESCRIPTION
`enabled` was read before `modules.json` loaded.