### PR TITLE
refactor(Module): remove locked toggle

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -57,9 +57,9 @@ open class ClientModule(
     state: Boolean = false, // default state
     @Exclude val notActivatable: Boolean = false, // disable settings that are not needed if the module can't be enabled
     @Exclude val disableActivation: Boolean = notActivatable, // disable activation
-    hide: Boolean = false, // default hide
     @Exclude val disableOnQuit: Boolean = false, // disables module when player leaves the world,
-    aliases: List<String> = emptyList() // additional names under which the module is known
+    aliases: List<String> = emptyList(), // additional names under which the module is known
+    hide: Boolean = false // default hide
 ) : ToggleableConfigurable(null, name, state, aliases = aliases), EventListener, MinecraftShortcuts {
 
     protected val logger: Logger = LogManager.getLogger("$CLIENT_NAME/$name")
@@ -93,11 +93,6 @@ open class ClientModule(
                 notAnOption()
             }
         }
-
-    /**
-     * If this value is on true, we cannot enable the module, as it likely does not bypass.
-     */
-    private var locked: Value<Boolean>? = null
 
     override val baseKey: String = "liquidbounce.module.${name.toLowerCamelCase()}"
 
@@ -147,19 +142,6 @@ open class ClientModule(
     open suspend fun enabledEffect() {}
 
     final override fun onToggled(state: Boolean): Boolean {
-        // Check if the module is locked and cannot be enabled
-        locked?.let { locked ->
-            if (locked.get()) {
-                notification(
-                    this.name,
-                    translation("liquidbounce.generic.locked"),
-                    NotificationEvent.Severity.ERROR
-                )
-
-                return false
-            }
-        }
-
         if (!inGame) {
             return state
         }
@@ -185,14 +167,6 @@ open class ClientModule(
 
         EventManager.callEvent(ModuleToggleEvent(name, hidden, state))
         return state
-    }
-
-    /**
-     * If we want a module to have the "requires bypass" option, we specifically call it
-     * on init. This will add the option and enable the feature.
-     */
-    fun enableLock() {
-        this.locked = boolean("Locked", false)
     }
 
     fun tagBy(setting: Value<*>) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleMaceKill.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleMaceKill.kt
@@ -38,12 +38,6 @@ object ModuleMaceKill : ClientModule("MaceKill", ModuleCategories.COMBAT) {
 
     private val fallHeight by int("FallHeight", 22, 1..170).apply { tagBy(this) }
 
-    init {
-        // This module will likely not bypass any anti-cheat, so to prevent someone using it,
-        // in case they don't know what it does, we allow it to be locked by config.
-        enableLock()
-    }
-
     @Suppress("unused")
     private val attackHandler = handler<AttackEntityEvent> { event ->
         // Check if player is holding a mace

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/ModuleCriticals.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/ModuleCriticals.kt
@@ -53,10 +53,6 @@ import net.minecraft.world.level.block.WebBlock
  */
 object ModuleCriticals : ClientModule("Criticals", ModuleCategories.COMBAT) {
 
-    init {
-        enableLock()
-    }
-
     val modes = choices("Mode", 1) {
         arrayOf(
             NoneChoice(it),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/ModuleVelocity.kt
@@ -52,10 +52,6 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 
 object ModuleVelocity : ClientModule("Velocity", ModuleCategories.COMBAT, aliases = listOf("AntiKnockBack")) {
 
-    init {
-        enableLock()
-    }
-
     val modes = choices(
         "Mode", VelocityModify, arrayOf(
             // Generic modes

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleElytraRecast.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleElytraRecast.kt
@@ -35,10 +35,6 @@ import net.minecraft.world.item.Items
  */
 object ModuleElytraRecast : ClientModule("ElytraRecast", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     private val shouldRecast: Boolean
         get() {
             val itemStack = player.getItemBySlot(EquipmentSlot.CHEST)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleStrafe.kt
@@ -34,10 +34,6 @@ import net.minecraft.world.entity.MoverType
  */
 object ModuleStrafe : ClientModule("Strafe", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     private var strengthInAir by float("StrengthInAir", 1f, 0.0f..1f)
     private var strengthOnGround by float("StrengthOnGround", 1f, 0.0f..1f)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleBoost.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleBoost.kt
@@ -32,10 +32,6 @@ import kotlin.math.sin
  */
 object ModuleVehicleBoost : ClientModule("VehicleBoost", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     private var horizontalSpeed by float("HorizontalSpeed", 2f, 0.1f..10f)
     private var verticalSpeed by float("VerticalSpeed", 1f, 0.1f..5f)
     private var wasInVehicle = false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleVehicleControl.kt
@@ -44,10 +44,6 @@ import net.minecraft.world.InteractionHand
  */
 object ModuleVehicleControl : ClientModule("VehicleControl", ModuleCategories.MOVEMENT, aliases = listOf("BoatFly")) {
 
-    init {
-        enableLock()
-    }
-
     object BaseSpeed : Configurable("BaseSpeed") {
         val horizontalSpeed by float("Horizontal", 0.5f, 0.1f..10f)
         val verticalSpeed by float("Vertical", 0.35f, 0.1f..10f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
@@ -60,10 +60,6 @@ import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
 
 object ModuleFly : ClientModule("Fly", ModuleCategories.MOVEMENT, aliases = listOf("Glide", "Jetpack")) {
 
-    init {
-        enableLock()
-    }
-
     internal val modes = choices(
         "Mode", FlyVanilla, arrayOf(
             // Generic fly modes

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/highjump/ModuleHighJump.kt
@@ -34,10 +34,6 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategories
  */
 object ModuleHighJump : ClientModule("HighJump", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     private val modes = choices(
         "Mode", Vanilla, arrayOf(
             Vanilla, Vulcan

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/liquidwalk/ModuleLiquidWalk.kt
@@ -40,10 +40,6 @@ object ModuleLiquidWalk : ClientModule(
     aliases = listOf("Jesus", "WaterWalk")
 ) {
 
-    init {
-        enableLock()
-    }
-
     internal val modes = choices("Mode", LiquidWalkVanilla, arrayOf(
         LiquidWalkVanilla,
         LiquidWalkNoCheatPlus,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/longjump/ModuleLongJump.kt
@@ -31,10 +31,6 @@ import net.ccbluex.liquidbounce.utils.entity.moving
 
 object ModuleLongJump : ClientModule("LongJump", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     val mode = choices(
         "Mode", NoCheatPlusBoost, arrayOf(
             // NoCheatPlus

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noweb/ModuleNoWeb.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/noweb/ModuleNoWeb.kt
@@ -39,10 +39,6 @@ import net.minecraft.world.level.block.WebBlock
  */
 object ModuleNoWeb : ClientModule("NoWeb", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     val modes = choices(
         "Mode", NoWebAir, arrayOf(
             NoWebAir,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/speed/ModuleSpeed.kt
@@ -62,10 +62,6 @@ import java.util.function.BooleanSupplier
  */
 object ModuleSpeed : ClientModule("Speed", ModuleCategories.MOVEMENT) {
 
-    init {
-        enableLock()
-    }
-
     /**
      * Initialize speeds choices independently
      *

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/spider/ModuleSpider.kt
@@ -26,10 +26,6 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.spider.modes.Sp
 
 object ModuleSpider : ClientModule("Spider", ModuleCategories.MOVEMENT, aliases = listOf("WallClimb")) {
 
-    init {
-        enableLock()
-    }
-
     internal val modes = choices("Mode", SpiderVanilla, arrayOf(
         SpiderVanilla,
         SpiderPolar29thMarch2025,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/terrainspeed/ModuleTerrainSpeed.kt
@@ -32,10 +32,6 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.terrainspeed.wa
 object ModuleTerrainSpeed : ClientModule("TerrainSpeed", ModuleCategories.MOVEMENT, aliases = listOf("FastClimb")) {
 
     init {
-        enableLock()
-    }
-
-    init {
         tree(FastClimb)
         tree(IceSpeed)
         tree(WaterSpeed)

--- a/src/main/resources/resources/liquidbounce/lang/de_de.json
+++ b/src/main/resources/resources/liquidbounce/lang/de_de.json
@@ -248,7 +248,6 @@
   "liquidbounce.generic.error": "Fehler",
   "liquidbounce.generic.forum": "Forum",
   "liquidbounce.generic.notifyDeveloper": "Überprüfe dein Spielprotokoll und benachrichtige uns.",
-  "liquidbounce.generic.locked": "Das Modul ist gesperrt und kann nicht aktiviert werden. Es bypassed wahrscheinlich nicht.",
   "liquidbounce.liquidchat.authenticationFailed": "Authentifizierung fehlgeschlagen! Für LiquidChat ist ein Minecraft-Premium-Konto erforderlich.",
   "liquidbounce.liquidchat.jwtTokenReceived": "JWT-Token erhalten! Erneut anmelden...",
   "liquidbounce.liquidchat.notConnected": "Keine Verbindung zum Chatserver! Schalte das LiquidChat-Modul ein!",

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -424,7 +424,6 @@
   "liquidbounce.generic.forum": "Forum",
   "liquidbounce.generic.guilded": "Guilded",
   "liquidbounce.generic.notifyDeveloper": "Check your game log and notify us.",
-  "liquidbounce.generic.locked": "The module is locked and cannot be enabled. It is likely not bypassing.",
   "liquidbounce.tooltip.clickToCopy": "Click to copy",
   "liquidbounce.liquidchat.authenticationFailed": "Authentication failed! LiquidChat requires Minecraft premium account.",
   "liquidbounce.liquidchat.jwtTokenReceived": "Received JWT token! Relogging...",

--- a/src/main/resources/resources/liquidbounce/lang/ja_jp.json
+++ b/src/main/resources/resources/liquidbounce/lang/ja_jp.json
@@ -231,7 +231,6 @@
 	"liquidbounce.generic.error": "エラー",
 	"liquidbounce.generic.forum": "フォーラム",
 	"liquidbounce.generic.guilded": "Guilded",
-	"liquidbounce.generic.locked": "そのモジュールはロックされていて有効化できません。バイパスしていない可能性があります。",
 	"liquidbounce.generic.notifyDeveloper": "ゲームログを確認し、通知してください。",
 	"liquidbounce.liquidchat.authenticationFailed": "認証に失敗しました！ LiquidChatはMinecraftの公式アカウントが必要です。",
 	"liquidbounce.liquidchat.jwtTokenReceived": " JWT トークンを受け取りました! 再接続しています... ",

--- a/src/main/resources/resources/liquidbounce/lang/nl_be.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_be.json
@@ -270,7 +270,6 @@
     "liquidbounce.generic.forum": "Forum",
     "liquidbounce.generic.guilded": "Guilded",
     "liquidbounce.generic.notifyDeveloper": "Bekijk je gamelog en meld dit aan ons.",
-    "liquidbounce.generic.locked": "Deze module is vergrendeld en kan niet worden ingeschakeld. Waarschijnlijk werkt de bypass niet.",
     "liquidbounce.liquidchat.authenticationFailed": "Authenticatie mislukt! LiquidChat vereist een premium Minecraft-account.",
     "liquidbounce.liquidchat.jwtTokenReceived": "JWT-token ontvangen! Opnieuw inloggen...",
     "liquidbounce.liquidchat.notConnected": "Niet verbonden met de chatserver! Schakel de LiquidChat-module in!",

--- a/src/main/resources/resources/liquidbounce/lang/nl_nl.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_nl.json
@@ -270,7 +270,6 @@
     "liquidbounce.generic.forum": "Forum",
     "liquidbounce.generic.guilded": "Guilded",
     "liquidbounce.generic.notifyDeveloper": "Bekijk je gamelog en meld dit aan ons.",
-    "liquidbounce.generic.locked": "Deze module is vergrendeld en kan niet worden ingeschakeld. Waarschijnlijk werkt de bypass niet.",
     "liquidbounce.liquidchat.authenticationFailed": "Authenticatie mislukt! LiquidChat vereist een premium Minecraft-account.",
     "liquidbounce.liquidchat.jwtTokenReceived": "JWT-token ontvangen! Opnieuw inloggen...",
     "liquidbounce.liquidchat.notConnected": "Niet verbonden met de chatserver! Schakel de LiquidChat-module in!",

--- a/src/main/resources/resources/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/resources/liquidbounce/lang/ru_ru.json
@@ -5,7 +5,6 @@
   "liquidbounce.generic.error": "Ошибка",
   "liquidbounce.generic.forum": "Форум",
   "liquidbounce.generic.guilded": "Guilded",
-  "liquidbounce.generic.locked": "Модуль заблокирован и не может быть включен. Скорее всего, он не обходит.",
   "liquidbounce.generic.notifyDeveloper": "Проверьте свои логи и оповестите нас.",
   "liquidbounce.command.autodisable.subcommand.add.result.moduleAdded": "Модуль \"%s\" добавлен.",
   "liquidbounce.command.autodisable.subcommand.add.result.moduleIsPresent": "Модуль \"%s\" уже присутствует.",

--- a/src/main/resources/resources/liquidbounce/lang/tr_tr.json
+++ b/src/main/resources/resources/liquidbounce/lang/tr_tr.json
@@ -249,7 +249,6 @@
   "liquidbounce.generic.forum": "Forum",
   "liquidbounce.generic.guilded": "Guilded",
   "liquidbounce.generic.notifyDeveloper": "Oyun günlüğünü kontrol et ve bizi bilgilendir.",
-  "liquidbounce.generic.locked": "Modül kilitli ve açılamaz. Muhtemelen engellemeyi aşmıyor.",
   "liquidbounce.liquidchat.authenticationFailed": "Kimlik doğrulama başarısız! LiquidChat premium Minecraft hesabı gerektirir.",
   "liquidbounce.liquidchat.jwtTokenReceived": "JWT token alındı! Yeniden giriş yapılıyor...",
   "liquidbounce.liquidchat.notConnected": "Sohbet sunucusuna bağlı değilsiniz! LiquidChat modülünü açın!",


### PR DESCRIPTION
The idea behind this option was great; however, this often lead to users being confused why they cannot enable a specific module when they loaded a third-party config.