### PR TITLE
chore(Render2D): improve font renderer and theme shader background

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeBackground.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/ThemeBackground.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.integration.theme
 
+import com.mojang.blaze3d.buffers.GpuBuffer
 import com.mojang.blaze3d.pipeline.BlendFunction
 import com.mojang.blaze3d.pipeline.RenderPipeline
 import com.mojang.blaze3d.platform.DepthTestFunction
@@ -36,12 +37,14 @@ import net.ccbluex.liquidbounce.render.drawTexQuad
 import net.ccbluex.liquidbounce.utils.client.gpuDevice
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.render.asTexture
+import net.ccbluex.liquidbounce.utils.render.asTextureSetup
 import net.ccbluex.liquidbounce.utils.render.asView
-import net.ccbluex.liquidbounce.utils.render.createUbo
+import net.ccbluex.liquidbounce.utils.render.std140Size
 import net.ccbluex.liquidbounce.utils.render.textureSetup
 import net.ccbluex.liquidbounce.utils.render.writeStd140
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.render.TextureSetup
+import net.minecraft.client.renderer.MappableRingBuffer
 import net.minecraft.resources.Identifier
 import java.io.Closeable
 import java.util.Locale
@@ -110,11 +113,11 @@ sealed interface ThemeBackground : Closeable {
         private val fragmentShader: String,
     ) : ThemeBackground {
 
-        private val ubo = gpuDevice.createUbo(
-            labelGetter = { "ThemeShaderBackground UBO - ${metadata.name}" }
-        ) { float + vec2 + vec2 }
-
-        private val uboSlice = ubo.slice()
+        private val ubo = MappableRingBuffer(
+            { "ThemeShaderBackground UBO - ${metadata.name}" },
+            GpuBuffer.USAGE_MAP_WRITE or GpuBuffer.USAGE_UNIFORM,
+            std140Size { float + vec2 + vec2 },
+        )
 
         private var background: GpuTexture? = null
         private var backgroundView: GpuTextureView? = null
@@ -131,6 +134,8 @@ sealed interface ThemeBackground : Closeable {
             val framebufferWidth = mc.window.width
             val framebufferHeight = mc.window.height
 
+            ubo.rotate()
+            val uboSlice = ubo.currentBuffer().slice()
             uboSlice.writeStd140 {
                 putFloat((System.currentTimeMillis() - mc.clientStartTimeMs) / 1000F)
                 putVec2(mouseX.toFloat(), mouseY.toFloat())
@@ -191,15 +196,14 @@ sealed interface ThemeBackground : Closeable {
                 )
                 backgroundView?.close()
                 backgroundView = background!!.asView()
-                textureSetup = TextureSetup.singleTexture(
-                    backgroundView!!,
-                    RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST),
-                )
+                textureSetup = backgroundView!!.asTextureSetup(SAMPLER)
             }
         }
 
         companion object {
             private const val UNIFORM_NAME = "ThemeBackgroundData"
+            @JvmStatic
+            private val SAMPLER = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST)
 
             @JvmStatic
             fun build(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
@@ -285,7 +285,7 @@ inline fun GuiGraphics.drawGlyphOnCurrentLayer(
             textureSetup,
             copyPose(),
             this.scissorStack.peek(),
-            createBounds(x0, y0, x1 - x0, y1 - y0),
+            null,
         )
     )
 }
@@ -353,7 +353,7 @@ inline fun GuiGraphics.drawBlitOnCurrentLayer(
             v2,
             argb,
             this.scissorStack.peek(),
-            createBounds(x0.toFloat(), y0.toFloat(), (x1 - x0).toFloat(), (y1 - y0).toFloat()),
+            null,
         )
     )
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/RenderExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/RenderExtensions.kt
@@ -31,6 +31,7 @@ import com.mojang.blaze3d.pipeline.RenderTarget
 import com.mojang.blaze3d.platform.NativeImage
 import com.mojang.blaze3d.systems.GpuDevice
 import com.mojang.blaze3d.systems.RenderSystem
+import com.mojang.blaze3d.textures.GpuSampler
 import com.mojang.blaze3d.textures.GpuTexture
 import com.mojang.blaze3d.textures.GpuTextureView
 import com.mojang.blaze3d.vertex.PoseStack
@@ -298,6 +299,9 @@ fun NativeImage.asTexture(
 
 val AbstractTexture.textureSetup: TextureSetup
     get() = TextureSetup.singleTexture(textureView, sampler)
+
+inline fun GpuTextureView.asTextureSetup(sampler: GpuSampler) =
+    TextureSetup.singleTexture(this, sampler)
 
 inline fun ByteBuffer.toGpuBuffer(
     labelGetter: Supplier<String>? = null,


### PR DESCRIPTION
`GuiRenderState#submitGlyphToCurrentLayer` and `GuiRenderState#submitBlitToCurrentLayer` doesn't need `ScreenArea#bounds`.