### PR TITLE
feat(CriticalsJump): add OnlyOnJumpKey option

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
@@ -60,6 +60,7 @@ object CriticalsJump : Mode("Jump") {
     private val checkKillaura by boolean("CheckKillaura", false)
     private val checkAutoClicker by boolean("CheckAutoClicker", false)
     private val canBeSeen by boolean("CanBeSeen", true)
+    private val onlyOnJumpKey by boolean("OnlyOnJumpKey", false)
 
     /**
      * Should the upwards velocity be set to the `height`-value on next jump?
@@ -75,6 +76,17 @@ object CriticalsJump : Mode("Jump") {
             return@handler
         }
 
+        val enemies = world.findEnemies(0f..range)
+            .filter { (entity, _) -> !canBeSeen || player.hasLineOfSight(entity) }
+
+        if (enemies.isEmpty()) {
+            return@handler
+        }
+
+        if (onlyOnJumpKey) {
+            event.jump = false
+        }
+
         if (!allowsCriticalHit(true)) {
             return@handler
         }
@@ -83,14 +95,10 @@ object CriticalsJump : Mode("Jump") {
             return@handler
         }
 
-        val enemies = world.findEnemies(0f..range)
-            .filter { (entity, _) -> !canBeSeen || player.hasLineOfSight(entity) }
-
-        // Change the jump motion only if the jump is a normal jump (small jumps, i.e. honey blocks
-        // are not affected) and currently.
-        if (enemies.isNotEmpty() && player.onGround()) {
-            event.jump = true
-            adjustNextJump = true
+        // Allow jumping when on ground and conditions are met
+        if (player.onGround()) {
+            event.jump = !onlyOnJumpKey || mc.options.keyJump.isDown
+            adjustNextJump = event.jump
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/criticals/modes/CriticalsJump.kt
@@ -76,27 +76,20 @@ object CriticalsJump : Mode("Jump") {
             return@handler
         }
 
-        val enemies = world.findEnemies(0f..range)
-            .filter { (entity, _) -> !canBeSeen || player.hasLineOfSight(entity) }
-
-        if (enemies.isEmpty()) {
-            return@handler
-        }
-
-        if (onlyOnJumpKey) {
-            event.jump = false
-        }
-
         if (!allowsCriticalHit(true)) {
             return@handler
         }
 
         if (optimizeForCooldown && shouldWaitForJump()) {
+            event.jump = false
             return@handler
         }
 
+        val enemies = world.findEnemies(0f..range)
+            .filter { (entity, _) -> !canBeSeen || player.hasLineOfSight(entity) }
+
         // Allow jumping when on ground and conditions are met
-        if (player.onGround()) {
+        if (enemies.isNotEmpty() && player.onGround()) {
             event.jump = !onlyOnJumpKey || mc.options.keyJump.isDown
             adjustNextJump = event.jump
         }


### PR DESCRIPTION
Adds the OnlyOnJumpKey option for manual jump control in CriticalsJump. Unlike Smart Criticals, which only manages attack timings and often leads to desync and sweeping attacks, this option allows the user to trigger the logic manually via the jump key

Addresses #7520