### PR TITLE
chore: follow up Kotlin 2.3 update, small cleanups

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,7 @@ dependencies {
 //    testImplementation(libs.fabric.loader.junit)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
+
 addResolvedDependencies(jij, "compileOnly", "include", "api")
 
 tasks.processResources {
@@ -351,7 +352,7 @@ kotlin {
     compilerOptions {
         suppressWarnings = true
         jvmToolchain(libs.versions.jdk.get().toInt())
-        freeCompilerArgs.add("-XXLanguage:+ExplicitBackingFields")
+        freeCompilerArgs.add("-Xexplicit-backing-fields")
         freeCompilerArgs.add("-Xcontext-parameters")
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/CommandFakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/CommandFakePlayer.kt
@@ -249,19 +249,17 @@ object CommandFakePlayer : Command.Factory, EventListener {
                     UUID.randomUUID(),
                     nameArg
                 ),
-            ).apply {
-                onRemoval = Runnable { fakePlayers.remove(this) }
-            }
+                fakePlayers::remove,
+            )
         } else {
             fakePlayer = FakePlayer(
                 world,
                 GameProfile(
                     UUID.randomUUID(),
                     nameArg
-                )
-            ).apply {
-                onRemoval = Runnable { fakePlayers.remove(this) }
-            }
+                ),
+                fakePlayers::remove,
+            )
         }
 
         fakePlayer.id = fakePlayerId

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/FakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/FakePlayer.kt
@@ -28,6 +28,7 @@ import net.minecraft.client.player.RemotePlayer
 import net.minecraft.network.protocol.game.ClientboundEntityEventPacket
 import net.minecraft.world.effect.MobEffectInstance
 import net.minecraft.world.effect.MobEffects
+import java.util.function.Consumer
 
 /**
  * This class represents a Fake Player implementing
@@ -35,14 +36,10 @@ import net.minecraft.world.effect.MobEffects
  * into [RemotePlayer].
  */
 open class FakePlayer(
-    clientWorld: ClientLevel,
+    level: ClientLevel,
     gameProfile: GameProfile,
-) : RemotePlayer(
-    clientWorld,
-    gameProfile
-), MinecraftShortcuts {
-
-    var onRemoval: Runnable? = null
+    var onRemoval: Consumer<in FakePlayer>? = null,
+) : RemotePlayer(level, gameProfile), MinecraftShortcuts {
 
     /**
      * Loads the attributes from the player into the fake player.
@@ -94,7 +91,7 @@ open class FakePlayer(
      */
     override fun tick() {
         if (removalReason != null) {
-            onRemoval?.run()
+            onRemoval?.accept(this)
         }
 
         super.tick()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/MovingFakePlayer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/fakeplayer/MovingFakePlayer.kt
@@ -20,18 +20,18 @@ package net.ccbluex.liquidbounce.features.command.commands.ingame.fakeplayer
 
 import com.mojang.authlib.GameProfile
 import net.minecraft.client.multiplayer.ClientLevel
+import java.util.function.Consumer
 
 /**
  * A special [FakePlayer] that moves following a recorded path
  * of [PosPoseSnapshot].
  */
-class MovingFakePlayer(
+class MovingFakePlayer @JvmOverloads constructor(
     private vararg val snapshots: PosPoseSnapshot,
-    clientWorld: ClientLevel,
+    level: ClientLevel,
     gameProfile: GameProfile,
-) : FakePlayer(
-    clientWorld, gameProfile,
-) {
+    onRemoval: Consumer<in FakePlayer>? = null,
+) : FakePlayer(level, gameProfile, onRemoval) {
 
     private var index: Int = 0
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/trigger/CrystalAuraTriggerer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/crystalaura/trigger/CrystalAuraTriggerer.kt
@@ -56,7 +56,9 @@ object CrystalAuraTriggerer : ValueGroup("Triggers"), EventListener, MinecraftSh
      */
     val offThread by boolean("Off-Thread", true)
 
-    private val service = Executors.newSingleThreadExecutor()
+    private val service = Executors.newSingleThreadExecutor {
+        Thread(it, "CrystalAuraTriggerer").apply { isDaemon = true }
+    }
 
     /**
      * The currently executed placement task.
@@ -68,7 +70,7 @@ object CrystalAuraTriggerer : ValueGroup("Triggers"), EventListener, MinecraftSh
      */
     private var currentDestroyTask: Future<*>? = null
 
-    private var canCache: BooleanSupplier
+    private val canCache: BooleanSupplier
 
     init {
         // register all triggers
@@ -84,7 +86,7 @@ object CrystalAuraTriggerer : ValueGroup("Triggers"), EventListener, MinecraftSh
         )
 
         canCache = BooleanSupplier {
-            triggers.filter { it.enabled }.all { it.allowsCaching }
+            triggers.all { !it.enabled || it.allowsCaching }
         }
 
         triggers.forEach {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmBlockTracker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmBlockTracker.kt
@@ -22,9 +22,6 @@ import net.ccbluex.liquidbounce.utils.block.AbstractBlockLocationTracker
 import net.ccbluex.liquidbounce.utils.block.getState
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
-import net.minecraft.tags.BlockTags
-import net.minecraft.world.level.block.FarmBlock
-import net.minecraft.world.level.block.SoulSandBlock
 import net.minecraft.world.level.block.state.BlockState
 
 object AutoFarmBlockTracker : AbstractBlockLocationTracker.State2BlockPos<AutoFarmTrackedState>() {
@@ -34,30 +31,33 @@ object AutoFarmBlockTracker : AbstractBlockLocationTracker.State2BlockPos<AutoFa
 
             pos.canUseBoneMeal(state) -> AutoFarmTrackedState.Bonemealable
 
-            state.`is`(BlockTags.JUNGLE_LOGS) -> AutoFarmTrackedState.Plantable.JUNGLE_LOGS
+            state.supportsCocoa -> AutoFarmTrackedState.Plantable.JUNGLE_LOGS
 
             else -> {
                 val cache = BlockPos.MutableBlockPos()
-                val blockBelow = cache.setWithOffset(pos, Direction.DOWN).getState()?.block ?: return null
+                val stateBelow  = cache.setWithOffset(pos, Direction.DOWN).getState() ?: return null
                 if (state.isAir) {
                     // If this position is air, check placeable position below
-                    when (blockBelow) {
-                        is FarmBlock -> track(cache, AutoFarmTrackedState.Plantable.FARM)
-                        is SoulSandBlock -> track(cache, AutoFarmTrackedState.Plantable.SOUL_SAND)
+                    when {
+                        stateBelow.supportsCrops ->
+                            track(cache, AutoFarmTrackedState.Plantable.FARMLAND)
+
+                        stateBelow.supportsNetherWart ->
+                            track(cache, AutoFarmTrackedState.Plantable.SOUL_SAND)
                     }
 
                     // Air itself should be untracked
                     return null
-                } else if (blockBelow is SoulSandBlock || blockBelow is FarmBlock) {
+                } else if (stateBelow.supportsCrops || stateBelow.supportsNetherWart) {
                     // Not air, and block below is either farm or soul sand, untrack it
                     untrack(cache)
                 }
 
                 // Check if air above
                 if (cache.setWithOffset(pos, Direction.UP).getState()?.isAir == true) {
-                    when (state.block) {
-                        is FarmBlock -> AutoFarmTrackedState.Plantable.FARM
-                        is SoulSandBlock -> AutoFarmTrackedState.Plantable.SOUL_SAND
+                    when {
+                        state.supportsCrops -> AutoFarmTrackedState.Plantable.FARMLAND
+                        state.supportsNetherWart -> AutoFarmTrackedState.Plantable.SOUL_SAND
                         else -> null
                     }
                 } else {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmHelper.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmHelper.kt
@@ -22,6 +22,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world.autofarm
 import net.ccbluex.liquidbounce.utils.block.getBlock
 import net.ccbluex.liquidbounce.utils.client.world
 import net.minecraft.core.BlockPos
+import net.minecraft.tags.BlockTags
 import net.minecraft.world.level.block.BambooStalkBlock
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.Blocks
@@ -29,9 +30,11 @@ import net.minecraft.world.level.block.BonemealableBlock
 import net.minecraft.world.level.block.CactusBlock
 import net.minecraft.world.level.block.CocoaBlock
 import net.minecraft.world.level.block.CropBlock
+import net.minecraft.world.level.block.FarmBlock
 import net.minecraft.world.level.block.KelpPlantBlock
 import net.minecraft.world.level.block.NetherWartBlock
 import net.minecraft.world.level.block.PumpkinBlock
+import net.minecraft.world.level.block.SoulSandBlock
 import net.minecraft.world.level.block.StemBlock
 import net.minecraft.world.level.block.SugarCaneBlock
 import net.minecraft.world.level.block.SweetBerryBushBlock
@@ -93,3 +96,9 @@ fun BlockPos.readyForHarvest(state: BlockState): Boolean {
         else -> false
     }
 }
+
+inline val BlockState.supportsCrops: Boolean get() = block is FarmBlock
+
+inline val BlockState.supportsCocoa: Boolean get() = `is`(BlockTags.JUNGLE_LOGS)
+
+inline val BlockState.supportsNetherWart: Boolean get() = block is SoulSandBlock

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmTrackedState.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/autofarm/AutoFarmTrackedState.kt
@@ -26,11 +26,8 @@ import net.ccbluex.liquidbounce.utils.block.DIRECTIONS_HORIZONTAL
 import net.ccbluex.liquidbounce.utils.client.world
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
-import net.minecraft.tags.BlockTags
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Items
-import net.minecraft.world.level.block.FarmBlock
-import net.minecraft.world.level.block.SoulSandBlock
 import net.minecraft.world.level.block.state.BlockState
 
 sealed interface AutoFarmTrackedState {
@@ -38,23 +35,23 @@ sealed interface AutoFarmTrackedState {
         override val tag: String,
         val items: Collection<Item>,
     ) : AutoFarmTrackedState, Tagged {
-        FARM(
+        FARMLAND(
             "Farmland",
             objectArraySetOf(Items.WHEAT_SEEDS, Items.BEETROOT_SEEDS, Items.CARROT, Items.POTATO),
         ) {
-            override fun isBlockMatches(state: BlockState): Boolean = state.block is FarmBlock
+            override fun isBlockMatches(state: BlockState): Boolean = state.supportsCrops
         },
         SOUL_SAND(
             "SoulSand",
             setOf(Items.NETHER_WART),
         ) {
-            override fun isBlockMatches(state: BlockState): Boolean = state.block is SoulSandBlock
+            override fun isBlockMatches(state: BlockState): Boolean = state.supportsNetherWart
         },
         JUNGLE_LOGS(
             "JungleLogs",
             setOf(Items.COCOA_BEANS),
         ) {
-            override fun isBlockMatches(state: BlockState): Boolean = state.`is`(BlockTags.JUNGLE_LOGS)
+            override fun isBlockMatches(state: BlockState): Boolean = state.supportsCocoa
 
             override fun findPlantableNeighbors0(pos: BlockPos, state: BlockState): Collection<Direction> {
                 val result = enumSetOf<Direction>()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapHudComponent.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/theme/component/components/minimap/MinimapHudComponent.kt
@@ -113,15 +113,17 @@ object MinimapHudComponent : NativeHudComponent("Minimap", false, Alignment(
 
     private val extraElements = arrayOf(
         ExtraElement("Compass", 16F) { ctx ->
-            ctx.renderItem(COMPASS, 0, 0)
+            val stack = player.inventory.nonEquipmentItems.find { it.item === Items.COMPASS } ?: COMPASS
+            ctx.renderItem(stack, 0, 0)
         },
         ExtraElement("Clock", 16F) { ctx ->
-            ctx.renderItem(CLOCK, 0, 0)
+            val stack = player.inventory.nonEquipmentItems.find { it.item === Items.CLOCK } ?: CLOCK
+            ctx.renderItem(stack, 0, 0)
         },
     )
 
-    private val COMPASS = Items.COMPASS.defaultInstance
-    private val CLOCK = Items.CLOCK.defaultInstance
+    private val COMPASS by lazy(LazyThreadSafetyMode.NONE) { Items.COMPASS.defaultInstance }
+    private val CLOCK by lazy(LazyThreadSafetyMode.NONE) { Items.CLOCK.defaultInstance }
 
     init {
         tree(TextureValueGroup)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ui/ItemImageAtlas.kt
@@ -23,7 +23,6 @@ import com.mojang.blaze3d.ProjectionType
 import com.mojang.blaze3d.pipeline.TextureTarget
 import com.mojang.blaze3d.platform.Lighting
 import com.mojang.blaze3d.systems.RenderSystem
-import com.mojang.blaze3d.vertex.ByteBufferBuilder
 import com.mojang.blaze3d.vertex.PoseStack
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap
@@ -43,13 +42,13 @@ import net.ccbluex.liquidbounce.utils.render.toBufferedImage
 import net.ccbluex.liquidbounce.utils.render.withOutputTextureOverride
 import net.minecraft.client.gui.render.GuiRenderer
 import net.minecraft.client.renderer.CachedOrthoProjectionMatrixBuffer
-import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.Rect2i
 import net.minecraft.client.renderer.SubmitNodeStorage
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher
 import net.minecraft.client.renderer.item.TrackingItemStackRenderState
 import net.minecraft.client.renderer.texture.OverlayTexture
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.resources.Identifier
 import net.minecraft.world.item.Item
@@ -109,7 +108,7 @@ object ItemImageAtlas : EventListener {
 }
 
 private class ItemTextureRenderer(
-    val items: Iterable<Item>,
+    val items: Registry<Item>,
     val count: Int,
     val scale: Int,
 ) : MinecraftShortcuts {
@@ -123,14 +122,13 @@ private class ItemTextureRenderer(
         textureSize,
         true,
     )
-    private val bufferAllocator = ByteBufferBuilder(0xC0000)
-    private val vertexConsumers = MultiBufferSource.immediate(this.bufferAllocator)
-    private val commandQueue = SubmitNodeStorage()
+    private val submitNodeCollector = SubmitNodeStorage()
+    private val bufferSource = mc.gameRenderer.renderBuffers.bufferSource()
     // Note: no operation -> use shared one or skip it
-    private val renderDispatcher = FeatureRenderDispatcher(
-        this.commandQueue,
+    private val featureRenderDispatcher = FeatureRenderDispatcher(
+        this.submitNodeCollector,
         mc.blockRenderer, // No operation
-        vertexConsumers,
+        bufferSource,
         mc.atlasManager, // No operation
         mc.gameRenderer.renderBuffers.outlineBufferSource(), // No operation
         mc.gameRenderer.renderBuffers.crumblingBufferSource(), // No operation
@@ -141,10 +139,9 @@ private class ItemTextureRenderer(
 
     private fun close() {
         itemsProjectionMatrix.close()
-        bufferAllocator.close()
         itemAtlasFramebuffer.destroyBuffers()
-        commandQueue.clear()
-        renderDispatcher.close()
+        submitNodeCollector.clear()
+        featureRenderDispatcher.close()
     }
 
     /**
@@ -163,7 +160,7 @@ private class ItemTextureRenderer(
         withOutputTextureOverride(itemAtlasFramebuffer.colorTextureView, itemAtlasFramebuffer.depthTextureView) {
             val matrixStack = Pools.MatStack.borrow()
             val keyedItemRenderState = TrackingItemStackRenderState()
-            items.forEachIndexed { idx, item ->
+            for ((idx, item) in items.withIndex()) {
                 val x = (idx % itemsPerDimension) * itemPixelSize
                 val y = (idx / itemsPerDimension) * itemPixelSize
                 if (item !== Items.AIR) {
@@ -177,7 +174,7 @@ private class ItemTextureRenderer(
                         0
                     )
 
-                    this.prepareItemInitially(keyedItemRenderState, matrixStack, x, y, itemPixelSize)
+                    this.renderItemToAtlas(keyedItemRenderState, matrixStack, x, y, itemPixelSize)
                 }
                 itemMap[item] = Rect2i(x, y, itemPixelSize, itemPixelSize)
             }
@@ -205,7 +202,7 @@ private class ItemTextureRenderer(
     /**
      * @see GuiRenderer.renderItemToAtlas
      */
-    private fun prepareItemInitially(
+    private fun renderItemToAtlas(
         state: TrackingItemStackRenderState,
         matrices: PoseStack,
         scaledX: Int,
@@ -226,9 +223,9 @@ private class ItemTextureRenderer(
         RenderSystem.enableScissorForRenderTypeDraws(
             scaledX, textureSize - scaledY - itemPixelSize, itemPixelSize, itemPixelSize
         )
-        state.submit(matrices, this.commandQueue, 0xf000f0, OverlayTexture.NO_OVERLAY, 0)
-        renderDispatcher.renderAllFeatures()
-        vertexConsumers.endBatch()
+        state.submit(matrices, this.submitNodeCollector, 0xf000f0, OverlayTexture.NO_OVERLAY, 0)
+        featureRenderDispatcher.renderAllFeatures()
+        bufferSource.endBatch()
         RenderSystem.disableScissorForRenderTypeDraws()
         matrices.popPose()
     }


### PR DESCRIPTION
Replace compiler option `-XXLanguage:+ExplicitBackingFields` with `-Xexplicit-backing-fields`.