### PR TITLE
AutoBuff: Better inventory open state checks + AutoSoup autostack

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
@@ -25,7 +25,6 @@ import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAu
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
-import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.inventory.findClosestSlot
 import net.minecraft.world.item.ItemStack
@@ -35,7 +34,7 @@ abstract class Buff(
 ) : ToggleableValueGroup(ModuleAutoBuff, name, true) {
 
     internal open val passesRequirements: Boolean
-        get() = enabled && (ModuleAutoBuff.ignoreInventoryOpen || !InventoryManager.isInventoryOpen)
+        get() = enabled && (ModuleAutoBuff.ignoreInventoryOpen || !ModuleAutoBuff.isInventoryOpenForCheck)
 
     /**
      * Try to run feature if possible, otherwise return false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/Buff.kt
@@ -35,7 +35,7 @@ abstract class Buff(
 ) : ToggleableValueGroup(ModuleAutoBuff, name, true) {
 
     internal open val passesRequirements: Boolean
-        get() = enabled && !InventoryManager.isInventoryOpen
+        get() = enabled && (ModuleAutoBuff.ignoreInventoryOpen || !InventoryManager.isInventoryOpen)
 
     /**
      * Try to run feature if possible, otherwise return false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
@@ -104,6 +104,7 @@ object ModuleAutoBuff : ClientModule(
 
     internal val combatPauseTime by int("CombatPauseTime", 0, 0..40, "ticks")
     private val notDuringCombat by boolean("NotDuringCombat", false)
+    internal val ignoreInventoryOpen by boolean("IgnoreInventoryOpen", false)
 
     internal val activeFeatures
         get() = features.filter { it.enabled }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/ModuleAutoBuff.kt
@@ -35,6 +35,8 @@ import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 import net.ccbluex.liquidbounce.utils.aiming.RotationsValueGroup
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
 import net.ccbluex.liquidbounce.utils.combat.CombatManager
+import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
+import net.ccbluex.liquidbounce.utils.inventory.isInInventoryScreen
 
 object ModuleAutoBuff : ClientModule(
     name = "AutoBuff",
@@ -105,6 +107,18 @@ object ModuleAutoBuff : ClientModule(
     internal val combatPauseTime by int("CombatPauseTime", 0, 0..40, "ticks")
     private val notDuringCombat by boolean("NotDuringCombat", false)
     internal val ignoreInventoryOpen by boolean("IgnoreInventoryOpen", false)
+    internal val inventoryCheckMode by enumChoice("InventoryCheckMode", InventoryCheckMode.SERVER_SIDE)
+
+    enum class InventoryCheckMode(override val tag: String) : Tagged {
+        SERVER_SIDE("ServerSide"),
+        CLIENT_SIDE("ClientSide")
+    }
+
+    internal val isInventoryOpenForCheck: Boolean
+        get() = when (inventoryCheckMode) {
+            InventoryCheckMode.SERVER_SIDE -> InventoryManager.isInventoryOpenServerSide
+            InventoryCheckMode.CLIENT_SIDE -> isInInventoryScreen
+        }
 
     internal val activeFeatures
         get() = features.filter { it.enabled }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autobuff/features/Soup.kt
@@ -20,13 +20,19 @@
 package net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features
 
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
+import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
+import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.HealthBasedBuff
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Soup.DropAfterUse.assumeEmptyBowl
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.features.Soup.DropAfterUse.wait
 import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
+import net.ccbluex.liquidbounce.utils.inventory.InventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.OffHandSlot
+import net.ccbluex.liquidbounce.utils.inventory.PlayerInventoryConstraints
+import net.ccbluex.liquidbounce.utils.inventory.hasInventorySpace
 import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
@@ -38,8 +44,37 @@ internal object Soup : HealthBasedBuff("Soup") {
         val wait by intRange("Wait", 1..2, 1..20, "ticks")
     }
 
+    private object SoupStacker : ToggleableValueGroup(this, "SoupStacker", false) {
+        val assumeEmptyBowl by boolean("AssumeEmptyBowl", true)
+        val wait by intRange("Wait", 1..2, 1..20, "ticks")
+        val ignoreInventoryFull by boolean("IgnoreInventoryFull", true)
+        val inventoryConstraints = tree(PlayerInventoryConstraints())
+    }
+
+    private var pendingBowlSlot: HotbarItemSlot? = null
+
     init {
         tree(DropAfterUse)
+        tree(SoupStacker)
+    }
+
+    @Suppress("unused")
+    private val stackerHandler = handler<ScheduleInventoryActionEvent> { event ->
+        val slot = pendingBowlSlot ?: return@handler
+        pendingBowlSlot = null
+
+        if (slot is OffHandSlot) return@handler
+
+        val shouldStack = SoupStacker.assumeEmptyBowl || slot.itemStack.`is`(Items.BOWL)
+        if (!shouldStack) return@handler
+
+        if (!SoupStacker.ignoreInventoryFull && !hasInventorySpace()) return@handler
+
+        event.schedule(
+            SoupStacker.inventoryConstraints,
+            InventoryAction.Click.performQuickMove(screen = null, slot = slot),
+            Priority.IMPORTANT_FOR_USAGE_2
+        )
     }
 
     override fun isValidItem(stack: ItemStack, forUse: Boolean): Boolean {
@@ -47,18 +82,27 @@ internal object Soup : HealthBasedBuff("Soup") {
     }
 
     override suspend fun execute(slot: HotbarItemSlot) {
-        // Use item (be aware, it will always return false in this case)
         useHotbarSlotOrOffhand(slot)
 
-        if (DropAfterUse.enabled) {
-            waitTicks(wait.random())
+        when {
+            DropAfterUse.enabled -> handleDropAfterUse(slot)
+            SoupStacker.enabled -> handleSoupStacker(slot)
+        }
+    }
 
-            if (assumeEmptyBowl || slot.itemStack.`is`(Items.BOWL) && slot !is OffHandSlot) {
-                if (player.drop(true)) {
-                    player.swing(InteractionHand.MAIN_HAND)
-                }
+    private suspend fun handleDropAfterUse(slot: HotbarItemSlot) {
+        waitTicks(wait.random())
+
+        if (assumeEmptyBowl || slot.itemStack.`is`(Items.BOWL) && slot !is OffHandSlot) {
+            if (player.drop(true)) {
+                player.swing(InteractionHand.MAIN_HAND)
             }
         }
+    }
+
+    private suspend fun handleSoupStacker(slot: HotbarItemSlot) {
+        waitTicks(SoupStacker.wait.random())
+        pendingBowlSlot = slot
     }
 
 


### PR DESCRIPTION
Better checks do open inventory when using AutoBuff:
- Ignore Open Inventory check
- Stop buff when inventory is open client side (nice to soup recraft)
- Stop buff when inventory is open client or server side

And AutoSoup auto stack module :)