### PR TITLE
fix: clickgui settings not being applied

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -51,7 +51,7 @@ import net.minecraft.world.level.block.Block
 class ClickGuiScaleChangeEvent(val value: Float) : Event(), WebSocketEvent
 
 @Tag("clickGuiValueChange")
-class ClickGuiValueChangeEvent(val valueGroup: ValueGroup) : Event(), WebSocketEvent
+class ClickGuiValueChangeEvent(val configurable: ValueGroup) : Event(), WebSocketEvent
 
 @Tag("spaceSeperatedNamesChange")
 class SpaceSeperatedNamesChangeEvent(val value: Boolean) : Event(), WebSocketEvent


### PR DESCRIPTION
This PR fixes that changes to the ClickGUI's settings (specifically snapping, grid size, and search autofocus) weren't applied properly.