### PR TITLE
fix(render): illegal GLSL identifier `shader`

### DIFF
--- a/src/main/resources/resources/liquidbounce/shaders/circle/gradient_circle.fsh
+++ b/src/main/resources/resources/liquidbounce/shaders/circle/gradient_circle.fsh
@@ -14,9 +14,9 @@ in float vInnerRatio;
 
 out vec4 fragColor;
 
-vec4 unpackColor(ivec2 packed) {
-    int rg = packed.x & 0xFFFF;
-    int ba = packed.y & 0xFFFF;
+vec4 unpackColor(ivec2 packedColor) {
+    int rg = packedColor.x & 0xFFFF;
+    int ba = packedColor.y & 0xFFFF;
     return vec4(
         float((rg >> 8) & 0xFF),
         float(rg & 0xFF),


### PR DESCRIPTION
`shader` is a layout qualifier in GLSL. This makes pipeline inavailable.