### PR TITLE
Fix browser renderer leaking onto loading screens (#8076)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/browser/BrowserRenderer.kt
@@ -28,6 +28,7 @@ import net.ccbluex.liquidbounce.event.events.ScreenEvent
 import net.ccbluex.liquidbounce.event.events.ScreenRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.integration.backend.BrowserTexture
+import net.ccbluex.liquidbounce.integration.screen.ScreenManager
 import net.ccbluex.liquidbounce.render.ClientRenderPipelines
 import net.ccbluex.liquidbounce.render.drawTexQuad
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -76,7 +77,7 @@ class BrowserRenderer(val browser: Browser) : EventListener, AutoCloseable {
 
     @Suppress("unused")
     private val screenRenderHandler = handler<ScreenRenderEvent>(browser.priority) { event ->
-        if (!browser.visible || rendered) {
+        if (!browser.visible || rendered || browser.priority > 0 && !ScreenManager.isClientScreen(mc.screen)) {
             return@handler
         }
 


### PR DESCRIPTION
This fixes the singleplayer browser screen still showing during the vanilla world-loading transition.

Added a small guard in BrowserRenderer.kt so browser tabs with positive priority only render while a LiquidBounce-managed screen is actually open.

Tested in-game and with ./gradlew build.

Fixes #8076