### PR TITLE
fix(KillAura/AutoBlock): interact using client-side rotation

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -180,7 +180,7 @@ object KillAuraAutoBlock : ToggleableValueGroup(ModuleKillAura, "AutoBlocking", 
         }
 
         val blockHand = findBlockableHand() ?: return false
-        val rotation = RotationManager.serverRotation
+        val rotation = RotationManager.currentRotation ?: player.rotation
         debugParameter("BlockHand") { blockHand }
 
         when (blockMode) {


### PR DESCRIPTION
This is the correct way because Minecraft does it that way.