### PR TITLE
chore(Velocity): refactor jump resetting logic

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityIntave.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.utils.math.multiply
+import net.ccbluex.liquidbounce.utils.network.isMovementYFallDamage
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 
@@ -100,10 +101,7 @@ object VelocityIntave : VelocityMode("Intave") {
                 val velocityY = packet.movement.y
                 val velocityZ = packet.movement.z
 
-                // Check if the player is taking fall damage
-                // We set this on every packet, because if the player gets hit afterward,
-                // we will know that from the velocity.
-                isFallDamage = velocityX == 0.0 && velocityZ == 0.0 && velocityY < 0
+                isFallDamage = packet.isMovementYFallDamage()
                 ModuleDebug.debugParameter(this, "VelocityX", velocityX)
                 ModuleDebug.debugParameter(this, "VelocityY", velocityY)
                 ModuleDebug.debugParameter(this, "VelocityZ", velocityZ)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityJumpReset.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/velocity/mode/VelocityJumpReset.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
+import net.ccbluex.liquidbounce.utils.network.isMovementYFallDamage
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 import kotlin.random.Random
 
@@ -78,10 +79,7 @@ internal object VelocityJumpReset : VelocityMode("JumpReset") {
             val velocityY = packet.movement.y
             val velocityZ = packet.movement.z
 
-            // Check if the player is taking fall damage
-            // We set this on every packet, because if the player gets hit afterward,
-            // we will know that from the velocity.
-            isFallDamage = velocityX == 0.0 && velocityZ == 0.0 && velocityY < 0
+            isFallDamage = packet.isMovementYFallDamage()
             ModuleDebug.debugParameter(this, "VelocityX", velocityX)
             ModuleDebug.debugParameter(this, "VelocityY", velocityY)
             ModuleDebug.debugParameter(this, "VelocityZ", velocityZ)


### PR DESCRIPTION
Uses the "isMovementYFallDamage" function in PacketExtensions.
closes #5378 (should be closed anyways, but this ensures that the velocity checks are future-proof)