### PR TITLE
feat(ESP): add color setting for invisible entities

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/ModuleESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/ModuleESP.kt
@@ -63,6 +63,7 @@ object ModuleESP : ClientModule("ESP", ModuleCategories.RENDER) {
             GenericRainbowColorMode(it)
         )
     }
+    private val invisibleColor by color("Invisible", Color4b.ORANGE)
     private val friendColor by color("Friends", Color4b.GREEN)
 
     internal val maximumDistance by float("MaximumDistance", 128F, 1F..512F)
@@ -78,6 +79,10 @@ object ModuleESP : ClientModule("ESP", ModuleCategories.RENDER) {
     fun getColor(entity: LivingEntity): Color4b {
         if (entity.hurtTime > 0) {
             return Color4b.RED
+        }
+
+        if (entity.isInvisible) {
+            return invisibleColor
         }
 
         if (entity is Player) {


### PR DESCRIPTION
Allows you to change the color of invisible entities regardless of color configuration elsewhere.
Closes #8190 