### PR TITLE
fix(render): "distance effect"

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/render/StaticMeshStorage.java
+++ b/src/main/java/net/ccbluex/liquidbounce/render/StaticMeshStorage.java
@@ -20,11 +20,16 @@
 package net.ccbluex.liquidbounce.render;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.buffers.Std140Builder;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.MeshData;
 import net.ccbluex.liquidbounce.render.mesh.MeshDraw;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -39,8 +44,11 @@ public final class StaticMeshStorage {
     public final ByteBufferBuilder byteBufferBuilder = new ByteBufferBuilder(0xC0000);
     private final GrowableMappableRingBuffer vboStorage;
     private final GrowableMappableRingBuffer iboStorage;
+    private final GpuBufferSlice baseBlockPosUniform;
 
     private @Nullable MeshDraw meshDraw;
+    private final BlockPos.MutableBlockPos baseBlockPos = new BlockPos.MutableBlockPos();
+    private boolean hasBaseBlockPosUniformValue;
 
     public final String label;
 
@@ -53,11 +61,40 @@ public final class StaticMeshStorage {
             label + " IBO",
             GpuBuffer.USAGE_INDEX
         );
+        this.baseBlockPosUniform = ClientUniformDefine.MESH_BASE_BLOCK_POS.createSingleBuffer(() -> label + " BaseBlockPos UBO");
         this.label = label;
     }
 
     public boolean isReady() {
         return this.meshDraw != null;
+    }
+
+    public BlockPos getBaseBlockPos() {
+        return this.baseBlockPos;
+    }
+
+    public GpuBufferSlice getBaseBlockPosUniform() {
+        return this.baseBlockPosUniform;
+    }
+
+    public void setBaseBlockPosUniform(RenderPass renderPass) {
+        ClientUniformDefine.MESH_BASE_BLOCK_POS.setTo(renderPass, this.baseBlockPosUniform);
+    }
+
+    public void setBaseBlockPos(Vec3i baseBlockPos) {
+        if (this.hasBaseBlockPosUniformValue && baseBlockPos.equals(this.baseBlockPos)) {
+            return;
+        }
+
+        this.writeBaseBlockPosUniform(this.baseBlockPos.set(baseBlockPos));
+        this.hasBaseBlockPosUniformValue = true;
+    }
+
+    private void writeBaseBlockPosUniform(BlockPos baseBlockPos) {
+        try (var view = RenderSystem.getDevice().createCommandEncoder().mapBuffer(this.baseBlockPosUniform, false, true)) {
+            Std140Builder.intoBuffer(view.data())
+                .putIVec3(baseBlockPos.getX(), baseBlockPos.getY(), baseBlockPos.getZ());
+        }
     }
 
     /**
@@ -92,6 +129,8 @@ public final class StaticMeshStorage {
      * Clear the render state. This won't close the buffers.
      */
     public void clearStates() {
+        this.baseBlockPos.set(0, 0, 0);
+        this.hasBaseBlockPosUniformValue = false;
         this.meshDraw = null;
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleBlockESP.kt
@@ -106,7 +106,7 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
             } else {
                 val color = colorMode.activeMode.getColor(BlockPos.ZERO to Blocks.AIR.defaultBlockState())
                 if (colorModulatorAlpha == -1) color else color.alpha(colorModulatorAlpha)
-            }
+            },
         )
     }
 
@@ -147,7 +147,9 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
                 ClientRenderPipelines.relativeQuads(useColor),
                 distanceFade,
             ) {
-                getDynamicTransformsUniform(modelView = event.matrixStack.last().pose())
+                getDynamicTransformsUniform(
+                    modelView = event.matrixStack.last().pose(),
+                )
             }
         }
 
@@ -165,15 +167,17 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
 
             val colorMode = colorMode.activeMode
             useColor = colorMode.isParamSensitive
+            val origin = player.blockPosition()
 
             facesRenderState.buildMesh(
                 pipeline = ClientRenderPipelines.relativeQuads(useColor),
+                origin = origin,
             ) { pose ->
                 forEachTrackedBlocks { blockPos, blockState, outlineShape ->
                     val color = if (useColor) colorMode.getColor(blockPos to blockState) else null
 
                     pose.withPush {
-                        translate(blockPos)
+                        translate(blockPos.subtract(origin))
                         addShapeFaces(last().pose(), outlineShape, color)
                     }
                 }
@@ -182,12 +186,13 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
             if (outline) {
                 outlinesRenderState.buildMesh(
                     pipeline = ClientRenderPipelines.relativeLines(useColor),
+                    origin = origin,
                 ) { pose ->
                     forEachTrackedBlocks { blockPos, blockState, outlineShape ->
                         val color = if (useColor) colorMode.getColor(blockPos to blockState) else null
 
                         pose.withPush {
-                            translate(blockPos)
+                            translate(blockPos.subtract(origin))
                             addShapeOutlines(last().pose(), outlineShape, color)
                         }
                     }
@@ -217,7 +222,9 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
                 ClientRenderPipelines.outlineQuads(useColor),
                 distanceFade,
             ) {
-                getDynamicTransformsUniform(colorModulatorAlpha = 255)
+                getDynamicTransformsUniform(
+                    colorModulatorAlpha = 255,
+                )
             }
 
             if (dirty) {
@@ -238,15 +245,17 @@ object ModuleBlockESP : ClientModule("BlockESP", ModuleCategories.RENDER) {
 
             val colorMode = colorMode.activeMode
             useColor = colorMode.isParamSensitive
+            val origin = player.blockPosition()
 
             renderState.buildMesh(
                 pipeline = ClientRenderPipelines.outlineQuads(useColor),
+                origin = origin,
             ) { pose ->
                 forEachTrackedBlocks { blockPos, blockState, outlineShape ->
                     val color = if (useColor) colorMode.getColor(blockPos to blockState) else null
 
                     pose.withPush {
-                        translate(blockPos)
+                        translate(blockPos.subtract(origin))
                         addShapeFaces(last().pose(), outlineShape, color?.alpha(255))
                     }
                 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleItemESP.kt
@@ -46,6 +46,7 @@ import net.ccbluex.liquidbounce.utils.math.sq
 import net.ccbluex.liquidbounce.utils.math.KeyedAabb
 import net.ccbluex.liquidbounce.utils.math.mergeIntersectingAabbsSweep
 import net.ccbluex.liquidbounce.utils.math.toVec3f
+import net.ccbluex.liquidbounce.utils.math.worldToLocal
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.entity.projectile.arrow.AbstractArrow.Pickup
@@ -180,9 +181,10 @@ object ModuleItemESP : ClientModule("ItemESP", ModuleCategories.RENDER) {
                     }.asList()
                 )
 
-                withPositionRelativeToCamera {
-                    for ((mergedBox, _) in mergedBoxes) {
-                        drawBox(mergedBox, faceColor, outlineColor)
+                for ((mergedBox, _) in mergedBoxes) {
+                    val (origin, localBox) = mergedBox.worldToLocal()
+                    withPositionRelativeToCamera(origin) {
+                        drawBox(localBox, faceColor, outlineColor)
                     }
                 }
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -179,7 +179,9 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
                     pipeline = ClientRenderPipelines.relativeLines(useColor = true),
                     distanceFade = distanceFade,
                 ) {
-                    getDynamicTransformsUniform(modelView = event.matrixStack.last().pose())
+                    getDynamicTransformsUniform(
+                        modelView = event.matrixStack.last().pose(),
+                    )
                 }
             }
 
@@ -188,7 +190,9 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
                 pipeline = ClientRenderPipelines.relativeQuads(useColor = true),
                 distanceFade = distanceFade,
             ) {
-                getDynamicTransformsUniform(modelView = event.matrixStack.last().pose())
+                getDynamicTransformsUniform(
+                    modelView = event.matrixStack.last().pose(),
+                )
             }
 
             if (entityBoxes.isEmpty()) return@handler
@@ -240,12 +244,15 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
                 return@handler
             }
 
+            val origin = BlockPos.containing(player.position())
+
             blockFacesRenderState.buildMesh(
                 pipeline = ClientRenderPipelines.relativeQuads(useColor = true),
+                origin = origin,
             ) { pose ->
                 forEachTrackedBlockShapes { blockPos, type, outlineShape ->
                     pose.withPush {
-                        translate(blockPos)
+                        translate(blockPos.subtract(origin))
                         addShapeFaces(last().pose(), outlineShape, type.color.alpha(50))
                     }
                 }
@@ -254,10 +261,11 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
             if (outline) {
                 blockOutlinesRenderState.buildMesh(
                     pipeline = ClientRenderPipelines.relativeLines(useColor = true),
+                    origin = origin,
                 ) { pose ->
                     forEachTrackedBlockShapes { blockPos, type, outlineShape ->
                         pose.withPush {
-                            translate(blockPos)
+                            translate(blockPos.subtract(origin))
                             addShapeOutlines(last().pose(), outlineShape, type.color.alpha(100))
                         }
                     }
@@ -316,12 +324,14 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
 
             renderState.buildMesh(
                 pipeline = ClientRenderPipelines.outlineQuads(useColor = true),
+                origin = player.blockPosition(),
             ) { pose ->
+                val origin = renderState.baseBlockPos
                 // non-model blocks are already processed by WorldRenderer where we injected code which renders
                 // their outline
                 forEachTrackedBlockShapes({ it.renderShape != RenderShape.MODEL }) { blockPos, type, outlineShape ->
                     pose.withPush {
-                        translate(blockPos)
+                        translate(blockPos.subtract(origin))
                         addShapeFaces(last().pose(), outlineShape, type.color)
                     }
                 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/esp/modes/EspBoxMode.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.math.KeyedAabb
 import net.ccbluex.liquidbounce.utils.math.mergeIntersectingAabbsSweep
+import net.ccbluex.liquidbounce.utils.math.worldToLocal
 import net.minecraft.world.phys.AABB
 
 object EspBoxMode : EspMode.BoxBased("Box") {
@@ -56,9 +57,10 @@ object EspBoxMode : EspMode.BoxBased("Box") {
                 }.asList()
             )
 
-            withPositionRelativeToCamera {
-                for ((box, color) in mergedBoxes) {
-                    drawColoredBox(box, color)
+            for ((box, color) in mergedBoxes) {
+                val (origin, localBox) = box.worldToLocal()
+                withPositionRelativeToCamera(origin) {
+                    drawColoredBox(localBox, color)
                 }
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -209,7 +209,7 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                 partialTicks,
                 trajectoryColor = Color4b.WHITE,
                 blockHitColor = Color4b(0, 160, 255, 150),
-                entityHitColor = Color4b(255, 0, 0, 100),
+                entityHitColor = Color4b.RED.alpha(100),
             )
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleStrongholdFinder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleStrongholdFinder.kt
@@ -29,10 +29,8 @@ import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleCategories
-import net.ccbluex.liquidbounce.render.ClientRenderPipelines
 import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
-import net.ccbluex.liquidbounce.render.addVertex
-import net.ccbluex.liquidbounce.render.drawCustomMesh
+import net.ccbluex.liquidbounce.render.drawLine
 import net.ccbluex.liquidbounce.render.drawPlane
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.longLines
@@ -45,6 +43,7 @@ import net.ccbluex.liquidbounce.utils.client.toRadians
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
 import net.ccbluex.liquidbounce.utils.math.toFixed
 import net.ccbluex.liquidbounce.utils.math.toVec3d
+import net.ccbluex.liquidbounce.utils.math.toVec3f
 import net.ccbluex.liquidbounce.utils.world.forEachSectionBlock
 import net.ccbluex.liquidbounce.utils.world.stronghold.EyeMeasurement
 import net.ccbluex.liquidbounce.utils.world.stronghold.PosteriorSnapshot
@@ -256,19 +255,19 @@ object ModuleStrongholdFinder : ClientModule(
             }
 
             if (renderRays) {
-                withPositionRelativeToCamera {
-                    longLines {
-                        val color = Color4b.WHITE.alpha(170).argb
-                        drawCustomMesh(ClientRenderPipelines.Lines) { pose ->
-                            for (measurement in measurements) {
-                                val start = measurement.throwPos
-                                val yawRad = measurement.angleDeg.toDouble().toRadians()
-                                val direction = Vec3(-sin(yawRad), 0.0, cos(yawRad))
-                                val end = measurement.throwPos.add(direction.scale(RAY_RENDER_LENGTH))
-                                addVertex(pose, start).setColor(color)
-                                addVertex(pose, end).setColor(color)
-                            }
-                        }
+                longLines {
+                    val color = Color4b.WHITE.alpha(170).argb
+                    for (measurement in measurements) {
+                        val start = measurement.throwPos
+                        val yawRad = measurement.angleDeg.toDouble().toRadians()
+                        val direction = Vec3(-sin(yawRad), 0.0, cos(yawRad))
+                        val end = measurement.throwPos.add(direction.scale(RAY_RENDER_LENGTH))
+
+                        drawLine(
+                            relativeToCamera(start).toVec3f(),
+                            relativeToCamera(end).toVec3f(),
+                            color,
+                        )
                     }
                 }
             }
@@ -446,26 +445,22 @@ object ModuleStrongholdFinder : ClientModule(
         val start = playerPos.add(0.0, 0.05, 0.0)
         val target = closestPortalPos.center
 
-        withPositionRelativeToCamera {
-            longLines {
-                drawCustomMesh(ClientRenderPipelines.Lines) { pose ->
-                    val lineColor = Color4b(255, 80, 80, 220).argb
-                    addVertex(pose, start).setColor(lineColor)
-                    addVertex(pose, target).setColor(lineColor)
+        longLines {
+            val lineColor = Color4b(255, 80, 80, 220).argb
+            val startRelative = relativeToCamera(start).toVec3f()
 
-                    val deltaX = target.x - start.x
-                    val deltaZ = target.z - start.z
-                    val horizontalLength = hypot(deltaX, deltaZ)
-                    if (horizontalLength > 1e-6) {
-                        val markerEnd = Vec3(
-                            start.x + deltaX / horizontalLength * 2.0,
-                            start.y,
-                            start.z + deltaZ / horizontalLength * 2.0
-                        )
-                        addVertex(pose, start).setColor(lineColor)
-                        addVertex(pose, markerEnd).setColor(lineColor)
-                    }
-                }
+            drawLine(startRelative, relativeToCamera(target).toVec3f(), lineColor)
+
+            val deltaX = target.x - start.x
+            val deltaZ = target.z - start.z
+            val horizontalLength = hypot(deltaX, deltaZ)
+            if (horizontalLength > 1e-6) {
+                val markerEnd = Vec3(
+                    start.x + deltaX / horizontalLength * 2.0,
+                    start.y,
+                    start.z + deltaZ / horizontalLength * 2.0
+                )
+                drawLine(startRelative, relativeToCamera(markerEnd).toVec3f(), lineColor)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientRenderPipelines.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientRenderPipelines.kt
@@ -206,6 +206,7 @@ object ClientRenderPipelines {
     private val LinesRelativeToCamera = newPipeline("lines_relative_to_camera") {
         withSnippet(RenderPipelines.DEBUG_FILLED_SNIPPET)
         relativePosColorSnippet(VertexFormat.Mode.DEBUG_LINES)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         forWorldRender()
     }
@@ -213,6 +214,7 @@ object ClientRenderPipelines {
     private val LinesRelativeToCameraNoColor = newPipeline("lines_relative_to_camera_no_color") {
         withSnippet(RenderPipelines.DEBUG_FILLED_SNIPPET)
         relativePosColorSnippet(VertexFormat.Mode.DEBUG_LINES)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         forWorldRender()
     }
@@ -254,6 +256,7 @@ object ClientRenderPipelines {
     private val QuadsRelativeToCamera = newPipeline("quads_relative_to_camera") {
         withSnippet(RenderPipelines.DEBUG_FILLED_SNIPPET)
         relativePosColorSnippet(VertexFormat.Mode.QUADS)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         forWorldRender()
     }
@@ -261,6 +264,7 @@ object ClientRenderPipelines {
     private val QuadsRelativeToCameraNoColor = newPipeline("quads_relative_to_camera_no_color") {
         withSnippet(RenderPipelines.DEBUG_FILLED_SNIPPET)
         relativePosSnippet(VertexFormat.Mode.QUADS)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         forWorldRender()
     }
@@ -277,6 +281,7 @@ object ClientRenderPipelines {
         withSnippet(RenderPipelines.GLOBALS_SNIPPET)
         withVertexShader(ClientShaders.Vertex.PosColorRelativeToCamera)
         withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         withBlend(BlendFunction.TRANSLUCENT)
     }
@@ -287,6 +292,7 @@ object ClientRenderPipelines {
         withVertexShader(ClientShaders.Vertex.PosRelativeToCamera)
         withFragmentShader(ClientShaders.Fragment.PosRelativeToCamera)
         withVertexFormat(DefaultVertexFormat.POSITION, VertexFormat.Mode.QUADS)
+        withUniformBuffer(ClientUniformDefine.MESH_BASE_BLOCK_POS)
         withUniformBuffer(ClientUniformDefine.DISTANCE_FADE)
         withBlend(BlendFunction.TRANSLUCENT)
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientUniformDefine.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/ClientUniformDefine.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.render
 
 import com.mojang.blaze3d.buffers.GpuBuffer
 import com.mojang.blaze3d.buffers.GpuBufferSlice
+import com.mojang.blaze3d.systems.RenderPass
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.utils.client.gpuDevice
 import net.ccbluex.liquidbounce.utils.render.std140Size
@@ -29,6 +30,7 @@ import java.util.function.Supplier
 
 enum class ClientUniformDefine(val uboName: String, val size: Int) {
     DISTANCE_FADE("u_DistanceFade", std140Size { vec4 }),
+    MESH_BASE_BLOCK_POS("u_MeshBaseBlockPos", std140Size { ivec3 }),
     ROUNDED_RECT("u_RoundedRect", std140Size { vec2 + float }),
     HAND_ITEM_LIGHTMAP("ItemChamsData", std140Size { int + float + vec4 + float + vec4 + float + int }),
     GUI_BLUR("BlurData", std140Size { float + float + float }),
@@ -58,6 +60,10 @@ enum class ClientUniformDefine(val uboName: String, val size: Int) {
             GpuBuffer.USAGE_UNIFORM or GpuBuffer.USAGE_MAP_WRITE,
             this.size,
         )
+    }
+
+    fun setTo(renderPass: RenderPass, slice: GpuBufferSlice) {
+        renderPass.setUniform(this.uboName, slice)
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderPassExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderPassExtensions.kt
@@ -34,6 +34,7 @@ import net.minecraft.client.renderer.texture.AbstractTexture
 import org.joml.Matrix4f
 import org.joml.Matrix4fc
 import org.joml.Vector3f
+import org.joml.Vector3fc
 import org.joml.Vector4f
 import java.util.OptionalDouble
 import java.util.OptionalInt
@@ -108,19 +109,20 @@ fun RenderPass.bindAndDraw(
 }
 
 private val COLOR_MODULATOR = Vector4f(1f)
-private val MODEL_OFFSET = Vector3f()
+private val VECTOR3F_0 = Vector3f()
 private val TEXTURE_MATRIX = Matrix4f()
 
 @JvmOverloads
 fun getDynamicTransformsUniform(
     modelView: Matrix4fc? = null,
     colorModulator: Color4b = Color4b.WHITE,
+    modelOffset: Vector3fc? = null,
 ): GpuBufferSlice {
     val slice = RenderSystem.getDynamicUniforms()
         .writeTransform(
             modelView ?: RenderSystem.getModelViewMatrix(),
             colorModulator.toVector4f(COLOR_MODULATOR),
-            MODEL_OFFSET,
+            modelOffset ?: VECTOR3F_0,
             TEXTURE_MATRIX,
         )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -156,6 +156,7 @@ internal inline fun RenderTarget.drawGenericBlockESP(
         pass.bindProjectionUniform()
         pass.bindGlobalsUniform()
         pass.bindDynamicTransformsUniform(dynamicTransforms)
+        renderState.setBaseBlockPosUniform(pass)
         distanceFade.bindUniform(pass)
         renderState.bindAndDraw(pass)
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexBuilder.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/VertexBuilder.kt
@@ -30,6 +30,7 @@ import net.ccbluex.liquidbounce.utils.math.forAllFaces
 import net.ccbluex.liquidbounce.utils.math.forAllSideFaces
 import net.ccbluex.liquidbounce.utils.math.forAllSideOutlineEdges
 import net.ccbluex.liquidbounce.utils.render.begin
+import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
@@ -230,9 +231,11 @@ private fun VertexConsumer.addColoredVertex(
 inline fun StaticMeshStorage.buildMesh(
     pipeline: RenderPipeline,
     rotate: Boolean = true,
+    origin: BlockPos = BlockPos.ZERO,
     block: VertexConsumer.(pose: PoseStack) -> Unit,
 ) {
     clearStates()
+    this.setBaseBlockPos(origin)
 
     val bufferBuilder = this.byteBufferBuilder.begin(pipeline)
     usePoseStack {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/math/BoxExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/math/BoxExtensions.kt
@@ -46,6 +46,11 @@ inline operator fun AABB.plus(offset: Vec3i): AABB =
 inline operator fun AABB.minus(offset: Vec3i): AABB =
     this.move(-offset.x.toDouble(), -offset.y.toDouble(), -offset.z.toDouble())
 
+fun AABB.worldToLocal(): Pair<Vec3, AABB> {
+    val origin = this.minPosition
+    return origin to (this - origin)
+}
+
 fun AABB.iterateBlockPos(
     minYInclusive: Int = minY.floorToInt(),
     maxYInclusive: Int = maxY.ceilToInt(),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/WorldToScreen.kt
@@ -23,8 +23,6 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debug
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.ccbluex.liquidbounce.utils.client.mc
 import net.ccbluex.liquidbounce.utils.math.geometry.Line
-import net.ccbluex.liquidbounce.utils.math.set
-import net.ccbluex.liquidbounce.utils.math.sub
 import net.ccbluex.liquidbounce.utils.math.toVec3d
 import net.minecraft.world.phys.Vec2
 import net.minecraft.world.phys.Vec3
@@ -54,8 +52,11 @@ object WorldToScreen {
         pos: Vec3,
         cameraPos: Vec3 = mc.gameRenderer.mainCamera.position(),
     ): Vec3f? {
-        val transformedPos = cacheVec3f.set(pos).sub(cameraPos)
-            .mulProject(this.projModelViewMatrix)
+        val transformedPos = cacheVec3f.set(
+            pos.x - cameraPos.x,
+            pos.y - cameraPos.y,
+            pos.z - cameraPos.z
+        ).mulProject(this.projModelViewMatrix)
 
         val scaleFactor = mc.window.guiScale
         val guiScaleMul = 0.5f / scaleFactor.toFloat()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
@@ -280,10 +280,13 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
     }
 
     private fun WorldRenderEnvironment.drawTrajectoryForProjectile(positions: List<Vec3>, argb: Int) {
+        val renderedPositions = if (positions.size and 1 != 0) positions.subList(1) else positions
+        val origin = renderedPositions.firstOrNull() ?: return
+
         // Don't use LineStrip because in batch mode
         poseStack.pushPose()
-        poseStack.translate(renderOffset - camera.position())
-        drawLineStripAsLines(argb, if (positions.size and 1 != 0) positions.subList(1) else positions)
+        poseStack.translate(origin.add(renderOffset).subtract(camera.position()))
+        drawLineStripAsLines(argb, renderedPositions.map { it - origin })
         poseStack.popPose()
     }
 

--- a/src/main/resources/resources/liquidbounce/shaders/relative_to_camera/position.vsh
+++ b/src/main/resources/resources/liquidbounce/shaders/relative_to_camera/position.vsh
@@ -29,6 +29,10 @@ layout(std140) uniform Globals {
     int UseRgss;
 };
 
+layout(std140) uniform u_MeshBaseBlockPos {
+    ivec3 BaseBlockPos;
+};
+
 layout(std140) uniform u_DistanceFade {
     // x = nearStart
     // y = nearEnd
@@ -42,8 +46,7 @@ in vec3 Position;
 out float alphaFactor;
 
 void main() {
-    vec3 cameraPos = vec3(CameraBlockPos) - CameraOffset;
-    vec3 relativePos = Position - cameraPos;
+    vec3 relativePos = Position + vec3(BaseBlockPos - CameraBlockPos) + CameraOffset;
     gl_Position = ProjMat * ModelViewMat * vec4(relativePos, 1.0);
 
     float dist = length(relativePos);

--- a/src/main/resources/resources/liquidbounce/shaders/relative_to_camera/position_color.vsh
+++ b/src/main/resources/resources/liquidbounce/shaders/relative_to_camera/position_color.vsh
@@ -28,6 +28,10 @@ layout(std140) uniform Globals {
     int UseRgss;
 };
 
+layout(std140) uniform u_MeshBaseBlockPos {
+    ivec3 BaseBlockPos;
+};
+
 layout(std140) uniform u_DistanceFade {
     // x = nearStart
     // y = nearEnd
@@ -42,8 +46,7 @@ in vec4 Color;
 out vec4 vertexColor;
 
 void main() {
-    vec3 cameraPos = vec3(CameraBlockPos) - CameraOffset;
-    vec3 relativePos = Position - cameraPos;
+    vec3 relativePos = Position + vec3(BaseBlockPos - CameraBlockPos) + CameraOffset;
     gl_Position = ProjMat * ModelViewMat * vec4(relativePos, 1.0);
 
     float dist = length(relativePos);


### PR DESCRIPTION
Float data for Vec3(d) positions introduce precision loss. Replacing the absolute positions with relative positions + base position in `ivec3` resolves this issue.

fixes #7928 