### PR TITLE
refactor(command/give): more like vanilla Minecraft /give command

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -24,7 +24,6 @@ import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
 import net.ccbluex.liquidbounce.features.command.builder.ParameterBuilder
 import net.ccbluex.liquidbounce.features.command.builder.item
 import net.ccbluex.liquidbounce.utils.client.chat
-import net.ccbluex.liquidbounce.utils.client.network
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.variable
@@ -62,7 +61,7 @@ object CommandItemGive : Command.Factory {
                 val item = args[0] as String
                 val amount = args.getOrElse(1, defaultValue = { 1 }) as Int // default one
 
-                val itemStack = world.createItem(item.replace("minecraft:", ""))
+                val itemStack = world.createItem(item)
                 val giveAmount = player.giveItem(itemStack, amount)
                 if (giveAmount == 0) throw CommandException(command.result("noEmptySlot"))
 
@@ -80,7 +79,6 @@ object CommandItemGive : Command.Factory {
     }
 
     fun LocalPlayer.giveItem(item: ItemStack, amount: Int): Int {
-        item.popTime = 5
         var remaining = amount
 
         while (remaining > 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -30,6 +30,7 @@ import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.variable
 import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.item.createItem
+import net.ccbluex.liquidbounce.utils.text.asPlainText
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket
 import net.minecraft.world.item.ItemStack
@@ -73,8 +74,8 @@ object CommandItemGive : Command.Factory {
                     regular(
                         command.result(
                             "itemGiven",
-                            variable(itemStack.displayName.string),
-                            variable(giveAmount.toString())
+                            itemStack.displayName,
+                            variable(itemStack.count.toString())
                         )
                     )
                 )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -62,11 +62,7 @@ object CommandItemGive : Command.Factory {
                 val item = args[0] as String
                 val amount = args.getOrElse(1, defaultValue = { 1 }) as Int // default one
 
-                val itemStack = world.createItem(item)
-                if (!network.isFeatureEnabled(itemStack.item.requiredFeatures())) {
-                    throw CommandException(command.result("mustBeCreative"))
-                }
-
+                val itemStack = world.createItem(item.replace("minecraft:", ""))
                 val giveAmount = player.giveItem(itemStack, amount)
                 if (giveAmount == 0) throw CommandException(command.result("noEmptySlot"))
 
@@ -110,10 +106,6 @@ object CommandItemGive : Command.Factory {
         }
 
         return amount - remaining
-    }
-
-    fun LocalPlayer.checkPremium() {
-
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.ingame.creative
 
-import com.mojang.brigadier.exceptions.CommandSyntaxException
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandException
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
@@ -34,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.item.createItem
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket
 import net.minecraft.world.item.ItemStack
+import kotlin.math.min
 
 /**
  * ItemGive Command
@@ -88,19 +88,32 @@ object CommandItemGive : Command.Factory {
         var remaining = amount
 
         while (remaining > 0) {
-            val emptySlot = inventory.freeSlot
-            if (emptySlot == -1) break
+            val slot = player.inventory.getSlotWithRemainingSpace(item).takeUnless { it == -1 }
+                ?: player.inventory.freeSlot.takeUnless { it == -1 }
+                ?: break
 
-            val size = minOf(item.maxStackSize, remaining)
-            remaining -= size
-            val fillItemStack = item.copyWithCount(size)
+            val selectItemStack = player.inventory.getItem(slot)
+                .takeUnless { it.isEmpty }
+                ?: item.copyWithCount(0).also {  player.inventory.setItem(slot, it) }
 
-            inventory.setItem(emptySlot, fillItemStack)
-            val packetSlot = if (emptySlot < 9) emptySlot + 36 else emptySlot
-            connection.send(ServerboundSetCreativeModeSlotPacket(packetSlot, fillItemStack))
+            val maxToAdd = player.inventory.getMaxStackSize(selectItemStack) - selectItemStack.count
+            val toAdd = min(maxToAdd, remaining)
+
+            if (toAdd > 0) {
+                remaining -= toAdd
+                selectItemStack.grow(toAdd)
+                selectItemStack.popTime = 5
+            }
+
+            val packetSlot = if (slot < 9) slot + 36 else slot
+            connection.send(ServerboundSetCreativeModeSlotPacket(packetSlot, selectItemStack))
         }
 
         return amount - remaining
+    }
+
+    fun LocalPlayer.checkPremium() {
+
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -28,8 +28,11 @@ import net.ccbluex.liquidbounce.utils.client.network
 import net.ccbluex.liquidbounce.utils.client.player
 import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.variable
+import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.item.createItem
+import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket
+import net.minecraft.world.item.ItemStack
 
 /**
  * ItemGive Command
@@ -51,31 +54,51 @@ object CommandItemGive : Command.Factory {
                     .build()
             )
             .handler {
-                if (!player.isCreative) {
+                if (!player.hasInfiniteMaterials()) {
                     throw CommandException(command.result("mustBeCreative"))
                 }
 
                 val item = args[0] as String
                 val amount = args.getOrElse(1, defaultValue = { 1 }) as Int // default one
 
-                val itemStack = createItem(item, amount.coerceIn(1, 64))
-                val emptySlot = player.inventory.freeSlot
-
-                if (emptySlot == -1) {
-                    throw CommandException(command.result("noEmptySlot"))
+                val itemStack = world.createItem(item)
+                if (!network.isFeatureEnabled(itemStack.item.requiredFeatures())) {
+                    throw CommandException(command.result("mustBeCreative"))
                 }
 
-                player.inventory.setItem(emptySlot, itemStack)
-                network.send(
-                    ServerboundSetCreativeModeSlotPacket(if (emptySlot < 9) emptySlot + 36 else emptySlot,
-                    itemStack))
+                val giveAmount = player.giveItem(itemStack, amount)
+                if (giveAmount == 0) throw CommandException(command.result("noEmptySlot"))
+
                 chat(
-                    regular(command.result("itemGiven", itemStack.displayName,
-                        variable(itemStack.count.toString()))),
-                    command
+                    regular(
+                        command.result(
+                            "itemGiven",
+                            variable(itemStack.displayName.string),
+                            variable(giveAmount.toString())
+                        )
+                    )
                 )
             }
             .build()
+    }
+
+    fun LocalPlayer.giveItem(item: ItemStack, amount: Int): Int {
+        var remaining = amount
+
+        while (remaining > 0) {
+            val emptySlot = inventory.freeSlot
+            if (emptySlot == -1) break
+
+            val size = minOf(item.maxStackSize, remaining)
+            remaining -= size
+            val fillItemStack = item.copyWithCount(size)
+
+            inventory.setItem(emptySlot, fillItemStack)
+            val packetSlot = if (emptySlot < 9) emptySlot + 36 else emptySlot
+            connection.send(ServerboundSetCreativeModeSlotPacket(packetSlot, fillItemStack))
+        }
+
+        return amount - remaining
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.command.commands.ingame.creative
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandException
 import net.ccbluex.liquidbounce.features.command.builder.CommandBuilder
@@ -83,6 +84,7 @@ object CommandItemGive : Command.Factory {
     }
 
     fun LocalPlayer.giveItem(item: ItemStack, amount: Int): Int {
+        item.popTime = 5
         var remaining = amount
 
         while (remaining > 0) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/ingame/creative/CommandItemGive.kt
@@ -30,7 +30,6 @@ import net.ccbluex.liquidbounce.utils.client.regular
 import net.ccbluex.liquidbounce.utils.client.variable
 import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.item.createItem
-import net.ccbluex.liquidbounce.utils.text.asPlainText
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket
 import net.minecraft.world.item.ItemStack
@@ -75,7 +74,7 @@ object CommandItemGive : Command.Factory {
                         command.result(
                             "itemGiven",
                             itemStack.displayName,
-                            variable(itemStack.count.toString())
+                            variable(giveAmount.toString())
                         )
                     )
                 )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/ItemExtensions.kt
@@ -30,6 +30,7 @@ import net.ccbluex.liquidbounce.utils.entity.handItems
 import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.kotlin.unmodifiable
 import net.ccbluex.liquidbounce.utils.math.sq
+import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.commands.arguments.item.ItemInput
 import net.minecraft.commands.arguments.item.ItemParser
 import net.minecraft.core.BlockPos
@@ -87,6 +88,15 @@ import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockState
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Create item with NBT tags
+ *
+ * @docs https://minecraft.gamepedia.com/Commands/give
+ */
+fun ClientLevel.createItem(raw: String) = ItemParser(registryAccess())
+    .parse(StringReader(raw))
+    .createItemStack(1)
 
 /**
  * Create item with NBT tags

--- a/src/main/resources/resources/liquidbounce/lang/en_pt.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_pt.json
@@ -91,7 +91,7 @@
   "liquidbounce.command.give.parameter.amount.description": "An optionyaw amwount of teh item",
   "liquidbounce.command.give.result.mustBeCreative": "U nyeed two be in cweatiwe mwode >w<",
   "liquidbounce.command.give.result.noEmptySlot": "Thewe awe nywo empty swots in ywouw inwentwowwy (* ^ ω ^)",
-  "liquidbounce.command.give.result.itemGiven": "Gawe u %s * %d ヽ(*・ω・)ﾉ",
+  "liquidbounce.command.give.result.itemGiven": "Gawe u %s * %s ヽ(*・ω・)ﾉ",
   "liquidbounce.command.rename.description": "Awwows u two wenyamwe items",
   "liquidbounce.command.rename.parameter.name.description": "A custwom nyamwe fwow teh item",
   "liquidbounce.command.rename.result.mustBeCreative": "U nyeed two be in cweatiwe mwode (* ^ ω ^)",

--- a/src/main/resources/resources/liquidbounce/lang/ja_jp.json
+++ b/src/main/resources/resources/liquidbounce/lang/ja_jp.json
@@ -84,7 +84,7 @@
 	"liquidbounce.command.give.description": "自分にアイテムを与えます。",
 	"liquidbounce.command.give.parameter.amount.description": "任意の量。",
 	"liquidbounce.command.give.parameter.item.description": "アイテムの名前。",
-	"liquidbounce.command.give.result.itemGiven": "あなたに %s を %d 個与えました。",
+	"liquidbounce.command.give.result.itemGiven": "あなたに %s を %s 個与えました。",
 	"liquidbounce.command.give.result.mustBeCreative": "クリエイティブ モードが必要です!",
 	"liquidbounce.command.give.result.noEmptySlot": "インベントリに空のスロットはありません。",
 	"liquidbounce.command.help.description": "利用可能なすべてのコマンドを一覧表示します。",

--- a/src/main/resources/resources/liquidbounce/lang/pt_br.json
+++ b/src/main/resources/resources/liquidbounce/lang/pt_br.json
@@ -100,7 +100,7 @@
   "liquidbounce.command.give.parameter.amount.description": "Valor opcional.",
   "liquidbounce.command.give.result.mustBeCreative": "Criativo requirido!",
   "liquidbounce.command.give.result.noEmptySlot": "Não espaçõs vazios no seu inventario.",
-  "liquidbounce.command.give.result.itemGiven": "Deu a você %s * %d.",
+  "liquidbounce.command.give.result.itemGiven": "Deu a você %s * %s.",
   "liquidbounce.command.rename.description": "Renomeia o item segurado.",
   "liquidbounce.command.rename.parameter.name.description": "Novo nome requirido.",
   "liquidbounce.command.rename.result.mustBeCreative": "Criativo requirido!",

--- a/src/main/resources/resources/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/resources/liquidbounce/lang/ru_ru.json
@@ -126,7 +126,7 @@
   "liquidbounce.command.give.description": "Выдать себе предмет.",
   "liquidbounce.command.give.parameter.amount.description": "Необязательное количество",
   "liquidbounce.command.give.parameter.item.description": "Имя предмета.",
-  "liquidbounce.command.give.result.itemGiven": "Выдано %s * %d.",
+  "liquidbounce.command.give.result.itemGiven": "Выдано %s * %s.",
   "liquidbounce.command.give.result.mustBeCreative": "Требуется творческий режим!",
   "liquidbounce.command.give.result.noEmptySlot": "Нет пустых слотов в инвентаре.",
   "liquidbounce.command.help.description": "Список всех доступных команд.",

--- a/src/main/resources/resources/liquidbounce/lang/ua_ua.json
+++ b/src/main/resources/resources/liquidbounce/lang/ua_ua.json
@@ -149,7 +149,7 @@
   "liquidbounce.command.give.parameter.amount.description": "Необов'язкова кількість.",
   "liquidbounce.command.give.result.mustBeCreative": "Вимагається творчий режим!",
   "liquidbounce.command.give.result.noEmptySlot": "Немає пустих слотів в інвентарі.",
-  "liquidbounce.command.give.result.itemGiven": "Видано %s * %d.",
+  "liquidbounce.command.give.result.itemGiven": "Видано %s * %s.",
   "liquidbounce.command.rename.description": "Перейменовує вибраний предмет.",
   "liquidbounce.command.rename.parameter.name.description": "Нове ім'я для предмета.",
   "liquidbounce.command.rename.result.mustBeCreative": "Вимагається творчий режим!",

--- a/src/main/resources/resources/liquidbounce/lang/zh_cn.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_cn.json
@@ -115,7 +115,7 @@
   "liquidbounce.command.give.description": "给自己一个物品。",
   "liquidbounce.command.give.parameter.amount.description": "数量(可选)。",
   "liquidbounce.command.give.parameter.item.description": "物品名字。",
-  "liquidbounce.command.give.result.itemGiven": "已获得 %s * %d。",
+  "liquidbounce.command.give.result.itemGiven": "已获得 %s * %s。",
   "liquidbounce.command.give.result.mustBeCreative": "需要创造模式！",
   "liquidbounce.command.give.result.noEmptySlot": "背包已满。",
   "liquidbounce.command.help.description": "列出所有可用命令。",

--- a/src/main/resources/resources/liquidbounce/lang/zh_tw.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_tw.json
@@ -100,7 +100,7 @@
   "liquidbounce.command.give.description": "給自己一個物品。",
   "liquidbounce.command.give.parameter.amount.description": "數量(可選)。",
   "liquidbounce.command.give.parameter.item.description": "物品名字。",
-  "liquidbounce.command.give.result.itemGiven": "已獲得 %s * %d。",
+  "liquidbounce.command.give.result.itemGiven": "已獲得 %s * %s。",
   "liquidbounce.command.give.result.mustBeCreative": "需要創造模式！",
   "liquidbounce.command.give.result.noEmptySlot": "背包已滿。",
   "liquidbounce.command.help.description": "列出所有可用命令。",


### PR DESCRIPTION
- [X] Check `player.abilities.instabuild` instead of player game mode
- [X] Give more than 64 amount
  - [X] Automatically stack with existing items
- [X] Fix i18n
- [x] ~- Fix `CommandSyntaxException`~
Minecraft’s command system is too complicated; I don’t really want to keep digging into it anymore.
___
If you encounter `CommandSyntaxException`, try removing all `minecraft:` prefixes.
Original:
````.give minecraft:red_shulker_box[container=[{slot:0,item:{id:"minecraft:splash_potion",components:{"potion_contents":{"custom_effects":[{"id":"minecraft:instant_health","amplifier":125},{"id":"minecraft:instant_damage","amplifier":125}]}}}}]]````
Fixed: 
````.give minecraft:red_shulker_box[container=[{slot:0,item:{id:"splash_potion",components:{"potion_contents":{"custom_effects":[{"id":"instant_health","amplifier":125},{"id":"instant_damage","amplifier":125}]}}}}]]````
