### PR TITLE
LogOffSpots Send in chat toggle and check dummy player in blink

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleBlink.kt
@@ -177,4 +177,8 @@ object ModuleBlink : ClientModule("Blink", ModuleCategories.PLAYER) {
         RESET("Reset"),
         BLINK("Blink");
     }
+
+    fun isDummyPlayer(entityId: Int): Boolean {
+        return entityId == dummyPlayer?.id
+    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleLogoffSpot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleLogoffSpot.kt
@@ -19,6 +19,7 @@
 package net.ccbluex.liquidbounce.features.module.modules.render
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
+import net.ccbluex.liquidbounce.features.module.modules.player.ModuleBlink
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldChangeEvent
@@ -58,7 +59,9 @@ object ModuleLogoffSpot : ClientModule("LogoffSpot", ModuleCategories.RENDER) {
     @Suppress("unused")
     private val entityRemoveHandler = handler<WorldEntityRemoveEvent> { event ->
         val entity = event.entity
-        if (entity !is Player || isLogoffEntity(entity.id)) {
+        if (entity !is Player
+            || isLogoffEntity(entity.id)
+            || ModuleBlink.isDummyPlayer(entity.id)) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleLogoffSpot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleLogoffSpot.kt
@@ -45,6 +45,8 @@ import java.util.UUID
  */
 object ModuleLogoffSpot : ClientModule("LogoffSpot", ModuleCategories.RENDER) {
 
+    private val enableSendInChat by boolean("SendInChat", default = true)
+
     @JvmRecord
     private data class LoggedOffPlayer(
         val time: Instant,
@@ -72,7 +74,9 @@ object ModuleLogoffSpot : ClientModule("LogoffSpot", ModuleCategories.RENDER) {
         lastSeenPlayers[entity.uuid] = LoggedOffPlayer(Instant.now(), clone)
 
         val blockPos = entity.blockPosition()
-        chat(regular(message("disappeared", entity.scoreboardName, blockPos.x, blockPos.y, blockPos.z)))
+        if (enableSendInChat) {
+            chat(regular(message("disappeared", entity.scoreboardName, blockPos.x, blockPos.y, blockPos.z)))
+        }
     }
 
     @Suppress("unused")
@@ -82,11 +86,11 @@ object ModuleLogoffSpot : ClientModule("LogoffSpot", ModuleCategories.RENDER) {
             val blockPos = playerEntity.blockPosition()
 
             if (!world.isLoaded(blockPos)) {
-                chat(regular(message("unloaded", playerEntity.scoreboardName)))
+                if (enableSendInChat) chat(regular(message("unloaded", playerEntity.scoreboardName)))
                 world.removeEntity(playerEntity.id, Entity.RemovalReason.UNLOADED_TO_CHUNK)
                 true
             } else if (world.getPlayerByUUID(id) != null) {
-                chat(regular(message("reappeared", playerEntity.scoreboardName)))
+                if (enableSendInChat) chat(regular(message("reappeared", playerEntity.scoreboardName)))
                 world.removeEntity(playerEntity.id, Entity.RemovalReason.UNLOADED_WITH_PLAYER)
                 true
             } else {


### PR DESCRIPTION
This pr adds a toggle for sending logoffspot events in chat. This also fixes a bug in logoffspots in which it would add the dummyplayer in blink as an entity.

Example screenshot showcasing the bug
<img width="1920" height="1080" alt="2026-04-29_01 00 22" src="https://github.com/user-attachments/assets/79e5ca1f-eb40-4834-bfa7-d2ebe3ea4d21" />

 