### PR TITLE
feat(NameTags/BetterTab/Notifier) Display gamemode option in bettertab/nametags and notify on gamemode updates in notifier

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerTabOverlay.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerTabOverlay.java
@@ -18,6 +18,8 @@
  */
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.gui;
 
+import static net.ccbluex.liquidbounce.utils.entity.EntityExtensionsKt.shortName;
+
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -29,7 +31,7 @@ import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleAntiStaff;
 import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleBetterTab;
 import net.ccbluex.liquidbounce.features.module.modules.misc.Visibility;
 import net.ccbluex.liquidbounce.utils.text.PlainText;
-import net.ccbluex.liquidbounce.utils.text.TextList;
+import net.ccbluex.liquidbounce.utils.text.TextBuilder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.PlayerTabOverlay;
@@ -46,9 +48,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import it.unimi.dsi.fastutil.objects.ObjectList;
-
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -186,21 +185,20 @@ public abstract class MixinPlayerTabOverlay {
 
     @ModifyReturnValue(method = "getNameForDisplay", at = @At("RETURN"))
     private Component modifyPlayerName(Component original, PlayerInfo entry) {
-        var components = new ArrayList<Component>(List.of(original));
+        var components = new TextBuilder(original);
 
-        var showGameMode = ModuleBetterTab.ShowGameMode.INSTANCE;
-        if (ModuleBetterTab.INSTANCE.getRunning() && showGameMode.getRunning()) {
-            var playerGamemode = entry.getGameMode();
-            var gamemodeText = PlainText.of(" [" + playerGamemode.toString().charAt(0) + "]");
-            components.add(gamemodeText);
+        if (ModuleBetterTab.INSTANCE.getRunning() && ModuleBetterTab.INSTANCE.getShowGameMode()) {
+            var playerGameMode = entry.getGameMode();
+            var gameModeText = PlainText.of(" [" + shortName(playerGameMode) + "]");
+            components.append(gameModeText);
         }
 
         if (ModuleAntiStaff.INSTANCE.shouldShowAsStaffOnTab(entry.getProfile().name())) {
             var staffText = PlainText.of(" - (Staff)", TextColor.fromRgb(CommonColors.SOFT_RED));
-            components.add(staffText);
+            components.append(staffText);
         }
 
-        return TextList.of(components);
+        return components.build();
     }
 
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerTabOverlay.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinPlayerTabOverlay.java
@@ -46,6 +46,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import it.unimi.dsi.fastutil.objects.ObjectList;
+
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -183,14 +186,21 @@ public abstract class MixinPlayerTabOverlay {
 
     @ModifyReturnValue(method = "getNameForDisplay", at = @At("RETURN"))
     private Component modifyPlayerName(Component original, PlayerInfo entry) {
-        if (ModuleAntiStaff.INSTANCE.shouldShowAsStaffOnTab(entry.getProfile().name())) {
-            return TextList.of(
-                original,
-                PlainText.of(" - (Staff)", TextColor.fromRgb(CommonColors.SOFT_RED))
-            );
+        var components = new ArrayList<Component>(List.of(original));
+
+        var showGameMode = ModuleBetterTab.ShowGameMode.INSTANCE;
+        if (ModuleBetterTab.INSTANCE.getRunning() && showGameMode.getRunning()) {
+            var playerGamemode = entry.getGameMode();
+            var gamemodeText = PlainText.of(" [" + playerGamemode.toString().charAt(0) + "]");
+            components.add(gamemodeText);
         }
 
-        return original;
+        if (ModuleAntiStaff.INSTANCE.shouldShowAsStaffOnTab(entry.getProfile().name())) {
+            var staffText = PlainText.of(" - (Staff)", TextColor.fromRgb(CommonColors.SOFT_RED));
+            components.add(staffText);
+        }
+
+        return TextList.of(components);
     }
 
 }

--- a/src/main/java/net/ccbluex/liquidbounce/utils/text/TextBuilder.java
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/text/TextBuilder.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 public final class TextBuilder {
 
     private @Nullable Object inner;
-    // -1 -> built
     private int size;
 
     public TextBuilder() {
@@ -81,7 +80,8 @@ public final class TextBuilder {
         };
         assert result != null;
 
-        this.size = -1;
+        this.inner = null;
+        this.size = 0;
         return result;
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
@@ -76,12 +76,15 @@ object ModuleBetterTab : ClientModule("BetterTab", ModuleCategories.RENDER) {
         val filter = tree(PlayerFilter())
     }
 
+    object ShowGameMode : ToggleableValueGroup(ModuleBetterTab, "ShowGameMode", true) {}
+
     init {
         treeAll(
             Limits,
             Highlight,
             AccurateLatency,
-            PlayerHider
+            PlayerHider,
+            ShowGameMode
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
@@ -76,7 +76,7 @@ object ModuleBetterTab : ClientModule("BetterTab", ModuleCategories.RENDER) {
         val filter = tree(PlayerFilter())
     }
 
-    object ShowGameMode : ToggleableValueGroup(ModuleBetterTab, "ShowGameMode", true) {}
+    object ShowGameMode : ToggleableValueGroup(ModuleBetterTab, "ShowGameMode", true)
 
     init {
         treeAll(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleBetterTab.kt
@@ -76,7 +76,7 @@ object ModuleBetterTab : ClientModule("BetterTab", ModuleCategories.RENDER) {
         val filter = tree(PlayerFilter())
     }
 
-    object ShowGameMode : ToggleableValueGroup(ModuleBetterTab, "ShowGameMode", true)
+    val showGameMode by boolean("ShowGameMode", true)
 
     init {
         treeAll(
@@ -84,7 +84,6 @@ object ModuleBetterTab : ClientModule("BetterTab", ModuleCategories.RENDER) {
             Highlight,
             AccurateLatency,
             PlayerHider,
-            ShowGameMode
         )
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.misc
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -28,6 +29,7 @@ import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.regular
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
+import net.minecraft.world.level.GameType
 import java.util.UUID
 
 /**
@@ -47,81 +49,93 @@ object ModuleNotifier : ClientModule("Notifier", ModuleCategories.MISC) {
     private val leaveMessages by boolean("LeaveMessages", true)
     private val leaveMessageFormat by text("LeaveMessageFormat", "%s left")
 
-    private val gamemodeMessages by boolean("GamemodeMessages", false)
-    private val gamemodeMessageFormat by text("GamemodeMessageFormat", "%s changed their gamemode to %s")
+    private val gameModeMessages by boolean("GameModeMessages", false)
+    private val gameModeMessageFormat by text("GameModeMessageFormat", "%s changed their game mode to %s")
 
     private val useNotification by boolean("UseNotification", false)
 
-    private val uuidNameCache = hashMapOf<UUID, String>()
+    private val uuidNameCache = Object2ObjectOpenHashMap<UUID, String>()
+    private val uuidGameModeCache = Object2ObjectOpenHashMap<UUID, GameType>()
 
     override fun onEnabled() {
         for (entry in network.onlinePlayers) {
             uuidNameCache[entry.profile.id] = entry.profile.name
+            uuidGameModeCache[entry.profile.id] = entry.gameMode
         }
     }
 
     override fun onDisabled() {
         uuidNameCache.clear()
+        uuidGameModeCache.clear()
     }
 
     val packetHandler = handler<PacketEvent> { event ->
-        val packet = event.packet
+        when (val packet = event.packet) {
+            is ClientboundPlayerInfoUpdatePacket -> mc.execute {
+                val actions = packet.actions()
+                val entries = packet.entries()
 
-        if (packet is ClientboundPlayerInfoUpdatePacket) {
-            for (action in packet.actions()) {
-                for (entry in packet.entries()) {
-                    when (action) {
-                        ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER -> {
-                            val profile = entry.profile ?: continue
+                if (ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER in actions) {
+                    for (entry in entries) {
+                        handlePlayerAdd(entry)
+                    }
+                }
 
-                            if (profile.name != null && profile.name.length > 2) {
-                                uuidNameCache[profile.id] = profile.name
-                                if (joinMessages) {
-                                    val message = joinMessageFormat.format(profile.name)
+                if (ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE in actions) {
+                    val isInitializing = ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER in actions
 
-                                    if (useNotification) {
-                                        notification("Notifier", message, NotificationEvent.Severity.INFO)
-                                    } else {
-                                        chat(regular(message))
-                                    }
-                                }
-                            }
-                        }
-                        ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE -> {
-                            var profileName = uuidNameCache[entry.profileId] ?: continue
-                            val gameMode = entry.gameMode
-
-                            if (gamemodeMessages) {
-                                val message = gamemodeMessageFormat.format(profileName, gameMode)
-
-                                if (useNotification) {
-                                    notification("Notifier", message, NotificationEvent.Severity.INFO)
-                                } else {
-                                    chat(regular(message))
-                                }
-                            }
-                        }
-                        else -> {}
+                    for (entry in entries) {
+                        handleGameModeUpdate(entry, isInitializing)
                     }
                 }
             }
-        } else if (packet is ClientboundPlayerInfoRemovePacket) {
-            for (uuid in packet.profileIds) {
-                val entry = network.onlinePlayers.find { it.profile.id == uuid } ?: continue
 
-                if (entry.profile.name != null && entry.profile.name.length > 2) {
-                    if (leaveMessages) {
-                        val message = leaveMessageFormat.format(uuidNameCache[entry.profile.id])
-                        if (useNotification) {
-                            notification("Notifier", message, NotificationEvent.Severity.INFO)
-                        } else {
-                            chat(regular(message))
+            is ClientboundPlayerInfoRemovePacket -> mc.execute {
+                for (uuid in packet.profileIds) {
+                    val profileName = uuidNameCache.remove(uuid)
+                    uuidGameModeCache.remove(uuid)
+
+                    if (profileName != null && profileName.length > 2) {
+                        if (leaveMessages) {
+                            sendNotifierMessage(leaveMessageFormat.format(profileName))
                         }
                     }
-
-                    uuidNameCache.remove(entry.profile.id)
                 }
             }
+        }
+    }
+
+    private fun handlePlayerAdd(entry: ClientboundPlayerInfoUpdatePacket.Entry) {
+        val profile = entry.profile ?: return
+        val profileName = profile.name
+
+        if (profileName == null || profileName.length <= 2) {
+            return
+        }
+
+        uuidNameCache[profile.id] = profileName
+
+        if (joinMessages) {
+            sendNotifierMessage(joinMessageFormat.format(profileName))
+        }
+    }
+
+    private fun handleGameModeUpdate(entry: ClientboundPlayerInfoUpdatePacket.Entry, isInitializing: Boolean) {
+        val previousGameMode = uuidGameModeCache.put(entry.profileId, entry.gameMode)
+
+        if (isInitializing || previousGameMode == null || previousGameMode == entry.gameMode || !gameModeMessages) {
+            return
+        }
+
+        val profileName = uuidNameCache[entry.profileId] ?: return
+        sendNotifierMessage(gameModeMessageFormat.format(profileName, entry.gameMode))
+    }
+
+    private fun sendNotifierMessage(message: String) {
+        if (useNotification) {
+            notification(this.name, message, NotificationEvent.Severity.INFO)
+        } else {
+            chat(regular(message))
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleNotifier.kt
@@ -47,6 +47,9 @@ object ModuleNotifier : ClientModule("Notifier", ModuleCategories.MISC) {
     private val leaveMessages by boolean("LeaveMessages", true)
     private val leaveMessageFormat by text("LeaveMessageFormat", "%s left")
 
+    private val gamemodeMessages by boolean("GamemodeMessages", false)
+    private val gamemodeMessageFormat by text("GamemodeMessageFormat", "%s changed their gamemode to %s")
+
     private val useNotification by boolean("UseNotification", false)
 
     private val uuidNameCache = hashMapOf<UUID, String>()
@@ -65,19 +68,40 @@ object ModuleNotifier : ClientModule("Notifier", ModuleCategories.MISC) {
         val packet = event.packet
 
         if (packet is ClientboundPlayerInfoUpdatePacket) {
-            for (entry in packet.newEntries()) {
-                val profile = entry.profile ?: continue
+            for (action in packet.actions()) {
+                for (entry in packet.entries()) {
+                    when (action) {
+                        ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER -> {
+                            val profile = entry.profile ?: continue
 
-                if (profile.name != null && profile.name.length > 2) {
-                    uuidNameCache[profile.id] = profile.name
-                    if (joinMessages) {
-                        val message = joinMessageFormat.format(profile.name)
+                            if (profile.name != null && profile.name.length > 2) {
+                                uuidNameCache[profile.id] = profile.name
+                                if (joinMessages) {
+                                    val message = joinMessageFormat.format(profile.name)
 
-                        if (useNotification) {
-                            notification("Notifier", message, NotificationEvent.Severity.INFO)
-                        } else {
-                            chat(regular(message))
+                                    if (useNotification) {
+                                        notification("Notifier", message, NotificationEvent.Severity.INFO)
+                                    } else {
+                                        chat(regular(message))
+                                    }
+                                }
+                            }
                         }
+                        ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE -> {
+                            var profileName = uuidNameCache[entry.profileId] ?: continue
+                            val gameMode = entry.gameMode
+
+                            if (gamemodeMessages) {
+                                val message = gamemodeMessageFormat.format(profileName, gameMode)
+
+                                if (useNotification) {
+                                    notification("Notifier", message, NotificationEvent.Severity.INFO)
+                                } else {
+                                    chat(regular(message))
+                                }
+                            }
+                        }
+                        else -> {}
                     }
                 }
             }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
@@ -32,6 +32,7 @@ import net.ccbluex.liquidbounce.utils.combat.EntityTaggingManager
 import net.ccbluex.liquidbounce.utils.entity.getActualHealth
 import net.ccbluex.liquidbounce.utils.entity.hasHealthScoreboard
 import net.ccbluex.liquidbounce.utils.entity.ping
+import net.ccbluex.liquidbounce.utils.entity.shortName
 import net.ccbluex.liquidbounce.utils.text.PlainText
 import net.minecraft.ChatFormatting
 import net.minecraft.network.chat.Component
@@ -41,18 +42,20 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.level.GameType
-import java.util.function.Function
 import kotlin.math.roundToInt
 
-private val COUNT_STYLE = Style.EMPTY.applyFormats(ChatFormatting.AQUA, ChatFormatting.BOLD)
-
-private val BOT_STYLE = Style.EMPTY.applyFormats(ChatFormatting.RED, ChatFormatting.BOLD)
-
-private val BABY_TEXT = "Baby ".asPlainText()
-
-private val BOT_TEXT = "Bot".asPlainText(BOT_STYLE)
-
 internal object NametagTextFormatter : ValueGroup("Text") {
+
+    private val COUNT_STYLE = Style.EMPTY.applyFormats(ChatFormatting.AQUA, ChatFormatting.BOLD)
+
+    private val BOT_STYLE = Style.EMPTY.applyFormats(ChatFormatting.RED, ChatFormatting.BOLD)
+
+    private val BABY_TEXT = "Baby ".asPlainText()
+
+    private val BOT_TEXT = "Bot".asPlainText(BOT_STYLE)
+
+    private val leftBracket = "[".asPlainText(ChatFormatting.GRAY)
+    private val rightBracket = "]".asPlainText(ChatFormatting.GRAY)
 
     private val parts by multiEnumChoice(
         "Parts",
@@ -60,22 +63,19 @@ internal object NametagTextFormatter : ValueGroup("Text") {
         canBeNone = false
     )
 
-    private enum class Part(override val tag: String) : Tagged, Function<Entity, Component?> {
+    private enum class Part(override val tag: String) : Tagged {
         DISTANCE("Distance") {
-            override fun apply(t: Entity): Component? {
-                if (t === player) return null
+            override fun apply(entity: Entity): Component? {
+                if (entity === player) return null
 
-                val playerDistanceRounded = player.distanceTo(t).roundToInt()
+                val playerDistanceRounded = player.distanceTo(entity).roundToInt()
                 return "${playerDistanceRounded}m".asPlainText(ChatFormatting.GRAY)
             }
         },
 
         PING("Ping") {
-            private val leftBracket = "[".asPlainText(ChatFormatting.GRAY)
-            private val rightBracket = "]".asPlainText(ChatFormatting.GRAY)
-
-            override fun apply(t: Entity): Component? {
-                val entity = t as? Player ?: return null
+            override fun apply(entity: Entity): Component? {
+                if (entity !is Player) return null
 
                 val playerPing = entity.ping
 
@@ -115,8 +115,8 @@ internal object NametagTextFormatter : ValueGroup("Text") {
         },
 
         HEALTH("Health") {
-            override fun apply(t: Entity): Component? {
-                val entity = t as? LivingEntity ?: return null
+            override fun apply(entity: Entity): Component? {
+                if (entity !is LivingEntity) return null
 
                 val actualHealth = (entity.getActualHealth() +
                     if (entity.hasHealthScoreboard()) 0f else entity.absorptionAmount).toInt()
@@ -131,38 +131,34 @@ internal object NametagTextFormatter : ValueGroup("Text") {
             }
         },
 
-        GAMEMODE("Gamemode") {
-            private val leftBracket = "[".asPlainText(ChatFormatting.GRAY)
-            private val rightBracket = "]".asPlainText(ChatFormatting.GRAY)
+        GAME_MODE("GameMode") {
+            override fun apply(entity: Entity): Component? {
+                if (entity !is Player) return null
 
-            override fun apply(t: Entity): Component? {
-                val entity = t as? Player ?: return null
+                val gameMode = entity.gameMode() ?: return null
 
-                val playerGamemode = entity.gameMode() ?: return null
-
-                val gamemodeColor = when(playerGamemode) {
+                val gameModeColor = when (gameMode) {
                     GameType.SURVIVAL -> ChatFormatting.GREEN
                     GameType.CREATIVE -> ChatFormatting.RED
                     GameType.ADVENTURE -> ChatFormatting.YELLOW
                     GameType.SPECTATOR -> ChatFormatting.GRAY
-                    else -> ChatFormatting.RED
                 }
-
-                val gamemodeText = playerGamemode.toString().first()
 
                 return textOf(
                     leftBracket,
-                    "${gamemodeText}".asPlainText(gamemodeColor),
+                    gameMode.shortName().asPlainText(gameModeColor),
                     rightBracket,
                 )
             }
         },
 
         BOT_MARK("BotMark") {
-            override fun apply(t: Entity): Component? {
-                return if (t.isBot) BOT_TEXT else null
+            override fun apply(entity: Entity): Component? {
+                return if (entity.isBot) BOT_TEXT else null
             }
-        },
+        };
+
+        abstract fun apply(entity: Entity): Component?
     }
 
     fun format(entity: Entity): Component {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/nametags/NametagTextFormatter.kt
@@ -40,6 +40,7 @@ import net.minecraft.network.chat.TextColor
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.player.Player
+import net.minecraft.world.level.GameType
 import java.util.function.Function
 import kotlin.math.roundToInt
 
@@ -127,6 +128,33 @@ internal object NametagTextFormatter : ValueGroup("Text") {
                 }
 
                 return "$actualHealth HP".asPlainText(healthColor)
+            }
+        },
+
+        GAMEMODE("Gamemode") {
+            private val leftBracket = "[".asPlainText(ChatFormatting.GRAY)
+            private val rightBracket = "]".asPlainText(ChatFormatting.GRAY)
+
+            override fun apply(t: Entity): Component? {
+                val entity = t as? Player ?: return null
+
+                val playerGamemode = entity.gameMode() ?: return null
+
+                val gamemodeColor = when(playerGamemode) {
+                    GameType.SURVIVAL -> ChatFormatting.GREEN
+                    GameType.CREATIVE -> ChatFormatting.RED
+                    GameType.ADVENTURE -> ChatFormatting.YELLOW
+                    GameType.SPECTATOR -> ChatFormatting.GRAY
+                    else -> ChatFormatting.RED
+                }
+
+                val gamemodeText = playerGamemode.toString().first()
+
+                return textOf(
+                    leftBracket,
+                    "${gamemodeText}".asPlainText(gamemodeColor),
+                    rightBracket,
+                )
             }
         },
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/entity/EntityExtensions.kt
@@ -78,6 +78,7 @@ import net.minecraft.world.item.component.UseEffects
 import net.minecraft.world.item.enchantment.Enchantments
 import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.Explosion
+import net.minecraft.world.level.GameType
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.ServerExplosion
 import net.minecraft.world.level.block.Blocks
@@ -185,6 +186,13 @@ val ClientInput.initial: Input
 
 val Player.ping: Int
     get() = mc.connection?.getPlayerInfo(uuid)?.latency ?: 0
+
+fun GameType.shortName(): String = when (this) {
+    GameType.SURVIVAL -> "S"
+    GameType.CREATIVE -> "C"
+    GameType.ADVENTURE -> "A"
+    GameType.SPECTATOR -> "S"
+}
 
 val LocalPlayer.airTicks: Int
     get() = (this as LocalPlayerAddition).`liquid_bounce$getAirTicks`()


### PR DESCRIPTION
This pr adds the current players gamemode to Nametags and Bettertab. This also adds notifications for when a player changes their gamemode in notifier.

Screenshot of Nametags
<img width="1920" height="1080" alt="nametag gamemode" src="https://github.com/user-attachments/assets/3b3bd7cc-a097-4904-be17-c51476cbd4b9" />

Screenshot of BetterTab
<img width="230" height="78" alt="cropped_tab" src="https://github.com/user-attachments/assets/0f66d585-1e32-4306-934e-af7abf36fc7f" />

Screenshot of Notifier
<img width="596" height="79" alt="jeb changes his gamemode" src="https://github.com/user-attachments/assets/39bdcb29-a733-40f4-a995-11afde2678b1" />
