### PR TITLE
fix(NoPush): unable to push other entities in singleplayer

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinClientLevel.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinClientLevel.java
@@ -23,6 +23,8 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.ccbluex.liquidbounce.event.EventManager;
 import net.ccbluex.liquidbounce.event.events.WorldEntityRemoveEvent;
+import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleNoPush;
+import net.ccbluex.liquidbounce.features.module.modules.movement.NoPushBy;
 import net.ccbluex.liquidbounce.features.module.modules.render.DoRender;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleAntiBlind;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleTrueSight;
@@ -36,11 +38,15 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(ClientLevel.class)
 public abstract class MixinClientLevel {
@@ -78,6 +84,14 @@ public abstract class MixinClientLevel {
     private void hookAddBlockBreakParticles(BlockPos pos, BlockState state, CallbackInfo ci) {
         if (!ModuleAntiBlind.canRender(DoRender.BLOCK_BREAK_PARTICLES)) {
             ci.cancel();
+        }
+    }
+
+    @Inject(method = "getPushableEntities", at = @At("HEAD"), cancellable = true)
+    private void hookGetPushableEntities(Entity pusher, AABB boundingBox, CallbackInfoReturnable<List<Entity>> cir) {
+        if (!ModuleNoPush.canPush(NoPushBy.ENTITIES)) {
+            cir.setReturnValue(List.of());
+            cir.cancel();
         }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/entity/MixinLivingEntity.java
@@ -225,13 +225,6 @@ public abstract class MixinLivingEntity extends MixinEntity {
         return new Vec3(-Mth.sin(yaw) * 0.2F, 0.0, Mth.cos(yaw) * 0.2F);
     }
 
-    @Inject(method = "push", at = @At("HEAD"), cancellable = true)
-    private void hookNoPush(CallbackInfo callbackInfo) {
-        if (!ModuleNoPush.canPush(NoPushBy.ENTITIES)) {
-            callbackInfo.cancel();
-        }
-    }
-
     @Inject(method = "aiStep", at = @At("HEAD"))
     private void hookTickMovement(CallbackInfo callbackInfo) {
         // We don't want NoJumpDelay to interfere with AirJump which would lead to a Jetpack-like behavior


### PR DESCRIPTION
`NoPush.Entities` should only apply to `LocalPlayer` and should not affect other entities.