### PR TITLE
fix(creativetabs): wrong class name for fabric api

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTab.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTab.kt
@@ -39,14 +39,14 @@ open class CustomCreativeModeTab(
 ) {
 
     fun init(): CreativeModeTab {
-        val itemGroup = FabricCreativeModeTab.builder()
+        val creativeTab = FabricCreativeModeTab.builder()
             .title(plainName.asPlainText())
             .icon(icon)
             .displayItems { _, entries ->
                 runCatching {
                     items.accept(entries)
                 }.onFailure {
-                    logger.error("Unable to create item group $plainName", it)
+                    logger.error("Unable to create creative tab $plainName", it)
                 }
             }
             .build()
@@ -55,10 +55,10 @@ open class CustomCreativeModeTab(
         Registry.register(
             BuiltInRegistries.CREATIVE_MODE_TAB,
             LiquidBounce.identifier(plainName.lowercase()),
-            itemGroup
+            creativeTab
         )
 
-        return itemGroup
+        return creativeTab
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
@@ -62,7 +62,7 @@ object CustomCreativeModeTabs {
             }.onFailure { exception ->
                 logger.error("Unable to setup creative tabs", exception)
             }.onSuccess { creativeTabs ->
-                logger.info("Item Groups: [ ${creativeTabs.joinToString { tab -> tab.plainName }} ]")
+                logger.info("Creative Tabs: [ ${creativeTabs.joinToString { tab -> tab.plainName }} ]")
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
@@ -42,27 +42,27 @@ object CustomCreativeModeTabs {
         // Check if FabricAPI is installed, otherwise we can't use the page buttons
         // Use net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup
         runCatching {
-            Class.forName("net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup")
+            Class.forName("net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab")
         }.onFailure {
             logger.error("FabricAPI is not installed, please install it to use the page buttons " +
                 "in the creative inventory")
         }.onSuccess {
             runCatching {
-                val itemGroups = arrayOf(
+                val creativeTabs = arrayOf(
                     HeadsCreativeModeTab(),
                     ExploitsCreativeModeTab()
                 )
 
-                for (itemGroup in itemGroups) {
-                    itemGroup.init()
+                for (creativeTab in creativeTabs) {
+                    creativeTab.init()
                 }
                 isInitialized = true
 
-                itemGroups
+                creativeTabs
             }.onFailure { exception ->
                 logger.error("Unable to setup item groups", exception)
-            }.onSuccess { itemGroups ->
-                logger.info("Item Groups: [ ${itemGroups.joinToString { group -> group.plainName }} ]")
+            }.onSuccess { creativeTabs ->
+                logger.info("Item Groups: [ ${creativeTabs.joinToString { group -> group.plainName }} ]")
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
@@ -40,7 +40,7 @@ object CustomCreativeModeTabs {
         }
 
         // Check if FabricAPI is installed, otherwise we can't use the page buttons
-        // Use net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup
+        // Use net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab
         runCatching {
             Class.forName("net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab")
         }.onFailure {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/creativetab/CustomCreativeModeTabs.kt
@@ -60,9 +60,9 @@ object CustomCreativeModeTabs {
 
                 creativeTabs
             }.onFailure { exception ->
-                logger.error("Unable to setup item groups", exception)
+                logger.error("Unable to setup creative tabs", exception)
             }.onSuccess { creativeTabs ->
-                logger.info("Item Groups: [ ${creativeTabs.joinToString { group -> group.plainName }} ]")
+                logger.info("Item Groups: [ ${creativeTabs.joinToString { tab -> tab.plainName }} ]")
             }
         }
     }


### PR DESCRIPTION
This fixes a regression in which fabric-api was no longer being detected in creative tabs. 