### PR TITLE
feat(StorageESP): entity tracers

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinGameRenderer.java
@@ -173,7 +173,8 @@ public abstract class MixinGameRenderer {
     private void injectBobView(CameraRenderState cameraState, PoseStack poseStack, CallbackInfo ci) {
         if (ModuleNoBob.INSTANCE.getRunning() ||
             ModuleTracers.INSTANCE.getRunning() ||
-            (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.INSTANCE.getShowTracers())) {
+            (ModuleItemESP.INSTANCE.getRunning() && ModuleItemESP.INSTANCE.getShowTracers()) ||
+            ModuleStorageESP.INSTANCE.showTracers()) {
 
             ci.cancel();
             return;

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -374,7 +374,7 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
                 val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3f()
                 val topPos = pos.add(0f, entity.bbHeight, 0f)
 
-                drawLines(category.color.argb,eyeVector,pos,pos,topPos)
+                drawLines(category.color.argb, eyeVector, pos, pos, topPos)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -356,13 +356,14 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
         renderEnvironmentForWorld(event.matrixStack) {
             val eyeVector = Vec3f.eyeVector(camera)
 
-            for (type in types) {
-                if (StorageScanner.isEmpty()) continue
-                for (blockPos in StorageScanner.iterate(type)) {
-                    if (!type.shouldRender(blockPos)) continue
-                    val pos = relativeToCamera(blockPos.center).toVec3f()
+            if (!StorageScanner.isEmpty()) {
+                for (type in types) {
+                    for (blockPos in StorageScanner.iterate(type)) {
+                        if (!type.shouldRender(blockPos)) continue
+                        val pos = relativeToCamera(blockPos.center).toVec3f()
 
-                    drawLine(eyeVector, pos, type.color.argb)
+                        drawLine(eyeVector, pos, type.color.argb)
+                    }
                 }
             }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -353,8 +353,6 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
 
     @Suppress("unused")
     private val renderHandler = handler<WorldRenderEvent> { event ->
-        if (StorageScanner.isEmpty()) return@handler
-
         val types = allTypes.filter { it.tracers && !it.color.isTransparent }
         if (types.isEmpty()) return@handler
 
@@ -362,6 +360,7 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
             val eyeVector = Vec3f.eyeVector(camera)
 
             for (type in types) {
+                if (StorageScanner.isEmpty()) continue
                 for (blockPos in StorageScanner.iterate(type)) {
                     if (!type.shouldRender(blockPos)) continue
                     val pos = relativeToCamera(blockPos.center).toVec3f()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -372,7 +372,7 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
 
             for (entity in mc.level?.entitiesForRendering() ?: return@handler) {
                 val category = entity.categorize() ?: continue
-                if (!category.shouldRender(entity)) continue
+                if (!category.shouldRender(entity) || !category.tracers) continue
 
                 val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3f()
                 val topPos = pos.add(0f, entity.bbHeight, 0f)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -453,4 +453,7 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
             return super.running
         }
 
+    fun showTracers() : Boolean {
+        return allTypes.any {it.tracers}
+    }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -38,6 +38,7 @@ import net.ccbluex.liquidbounce.render.buildMesh
 import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.drawGenericBlockESP
 import net.ccbluex.liquidbounce.render.drawLine
+import net.ccbluex.liquidbounce.render.drawLines
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.ccbluex.liquidbounce.render.getDynamicTransformsUniform
@@ -367,6 +368,16 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
 
                     drawLine(eyeVector, pos, type.color.argb)
                 }
+            }
+
+            for (entity in mc.level?.entitiesForRendering() ?: return@handler) {
+                val category = entity.categorize() ?: continue
+                if (!category.shouldRender(entity)) continue
+
+                val pos = relativeToCamera(entity.interpolateCurrentPosition(event.partialTicks)).toVec3f()
+                val topPos = pos.add(0f, entity.bbHeight, 0f)
+
+                drawLines(category.color.argb,eyeVector,pos,pos,topPos)
             }
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleStorageESP.kt
@@ -451,6 +451,6 @@ object ModuleStorageESP : ClientModule("StorageESP", ModuleCategories.RENDER, al
         }
 
     fun showTracers() : Boolean {
-        return allTypes.any {it.tracers}
+        return this.running && allTypes.any { it.tracers }
     }
 }


### PR DESCRIPTION
This PR adds tracers to ChestType entities. It also toggles view bobbing off when any ChestType tracer is toggled.

Example Screenshot
<img width="1920" height="1080" alt="entity esp" src="https://github.com/user-attachments/assets/3e6e6991-03b0-4abf-a97d-1d2225675b5d" />
