### PR TITLE
fix(wayland): cursor behaviour on Wayland

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/ScreenManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/screen/ScreenManager.kt
@@ -89,8 +89,6 @@ object ScreenManager : EventListener {
      */
     val screenAcknowledgement = ScreenAcknowledgement()
 
-    private val standardCursor = GLFW.glfwCreateStandardCursor(GLFW.GLFW_ARROW_CURSOR)
-
     internal val parent: Screen
         get() = mc.screen ?: TitleScreen()
 
@@ -237,7 +235,7 @@ object ScreenManager : EventListener {
     @Suppress("unused")
     private val screenHandler = handler<ScreenEvent> { event ->
         // Set to default GLFW cursor
-        GLFW.glfwSetCursor(mc.window.handle(), standardCursor)
+        GLFW.glfwSetCursor(mc.window.handle(), 0)
 
         if (handleCurrentScreen(event.screen)) {
             event.cancelEvent()


### PR DESCRIPTION
On some Wayland compositors (for example Hyprland) using `glfwSetCursor` with non-null cursor when cursor is grabbed breaks things by displaying the grabbed cursor. According to the GLFW documentation, you can just pass a null cursor pointer to `glfwSetCursor` in order to reset it to default, so there is no need to guess the actual default cursor by yourself.

This patch changes the behavior of `ScreenManager.kt` so that `glfwSetCursor` is invoked with a null cursor pointer during `ScreenEvent`, instead of `standardCursor`.

GLFW cursor docs: https://www.glfw.org/docs/3.4/input_guide.html#cursor_set