### PR TITLE
Fix quote stripping in tokenizeCommand breaking .give command

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -428,7 +428,7 @@ object CommandManager : Collection<Command> by commandSet {
                 ' ' if !quote -> {
                     // Is the buffer not empty? Also ignore stuff like .friend   add SenkJu
                     if (stringBuilder.isNotBlank()) {
-                        output.add(stripOuterQuotes(stringBuilder.toString()))
+                        output.add(stripOuterQuotes(stringBuilder))
 
                         // Reset string buffer
                         stringBuilder.setLength(0)
@@ -440,16 +440,16 @@ object CommandManager : Collection<Command> by commandSet {
         }
 
         // Is there something left in the buffer?
-        if (stringBuilder.isNotBlank()) output.add(stripOuterQuotes(stringBuilder.toString()))
+        if (stringBuilder.isNotBlank()) output.add(stripOuterQuotes(stringBuilder))
 
         return Pair(output, outputIndices)
     }
 
-    private fun stripOuterQuotes(token: String): String {
-        if (token.length >= 2 && token.startsWith("\"") && token.endsWith("\"")) {
+    private fun stripOuterQuotes(token: CharSequence): String {
+        if (token.length >= 2 && token.startsWith('"') && token.endsWith('"')) {
             return token.substring(1, token.length - 1)
         }
-        return token
+        return token.toString()
     }
 
     fun autoComplete(origCmd: String, start: Int): CompletableFuture<Suggestions> {
@@ -470,7 +470,7 @@ object CommandManager : Collection<Command> by commandSet {
                 args = listOf("")
             }
 
-            val nextParameter = !args.last().endsWith(" ") && cmd.endsWith(" ")
+            val nextParameter = !args.last().endsWith(' ') && cmd.endsWith(' ')
             var currentArgStart = tokenized.second.lastOrNull()
 
             if (currentArgStart == null) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/CommandManager.kt
@@ -421,11 +421,14 @@ object CommandManager : Collection<Command> by commandSet {
             when (c) {
                 // Is the current char an escape char?
                 '\\' -> escaped = true // Enable escape for the next character
-                '"' -> quote = !quote
+                '"' -> {
+                    quote = !quote
+                    stringBuilder.append(c) // Don't throw quotes out
+                }
                 ' ' if !quote -> {
                     // Is the buffer not empty? Also ignore stuff like .friend   add SenkJu
                     if (stringBuilder.isNotBlank()) {
-                        output.add(stringBuilder.toString())
+                        output.add(stripOuterQuotes(stringBuilder.toString()))
 
                         // Reset string buffer
                         stringBuilder.setLength(0)
@@ -437,17 +440,16 @@ object CommandManager : Collection<Command> by commandSet {
         }
 
         // Is there something left in the buffer?
-        if (stringBuilder.isNotBlank()) {
-            // If a string was not closed, don't remove the quote
-            // e.g. .friend add "SenkJu -> [.friend, add, "SenkJu]
-            if (quote) {
-                output.add('"' + stringBuilder.toString())
-            } else {
-                output.add(stringBuilder.toString())
-            }
-        }
+        if (stringBuilder.isNotBlank()) output.add(stripOuterQuotes(stringBuilder.toString()))
 
         return Pair(output, outputIndices)
+    }
+
+    private fun stripOuterQuotes(token: String): String {
+        if (token.length >= 2 && token.startsWith("\"") && token.endsWith("\"")) {
+            return token.substring(1, token.length - 1)
+        }
+        return token
     }
 
     fun autoComplete(origCmd: String, start: Int): CompletableFuture<Suggestions> {


### PR DESCRIPTION
Stripping all quotes breaks the .give command, making it impossible to spawn items whose names or lore contain spaces.

For example:
`stick[custom_name="name with spaces"]`
gets transformed into
`stick[custom_name=name with spaces]`
which is invalid syntax for the give command.

Here's a demonstration of the bug:

[bug demo](https://github.com/user-attachments/assets/1c554012-db35-4fc2-bebd-2228b9cd1149)

The `tokenizeCommand` function strips all quotes from tokens by default, with the exception of unclosed quotes on the final token.

This PR changes `tokenizeCommand` so that:

- Quotes inside tokens are preserved
- Only the first balanced outer pair of quotes is removed
- Unclosed or stray quotes are preserved as-is

Here are some examples:

- "example" -> example (outer quotes removed)
- "example -> "example (unclosed quote preserved)
- example" -> example" (stray quotes preserved)
- ""example"" -> "example" (only first outer pair removed)
- "ex"amp"le" -> ex"amp"le (inner quotes are preserved)
