### PR TITLE
fix(Hotbar): incorrect y offset in mixin

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinGui.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinGui.java
@@ -212,7 +212,7 @@ public abstract class MixinGui {
         var bounds = hudComponent.getAlignment().getBounds(0, 0);
 
         int center = (int) bounds.xMin();
-        var y = bounds.yMin() - 12;
+        var y = bounds.yMin() - 16;
 
         int l = 1;
         for (int m = 0; m < 9; ++m) {


### PR DESCRIPTION
MixinGUI.java had an incorrect y-offset for items.

**before** _(var y = bounds.yMin() - 12;)_ **:**

<img width="433" height="75" alt="Снимок экрана 2026-05-27 225911" src="https://github.com/user-attachments/assets/50ffbe12-7ea3-4230-9393-497e1501345f" />


**after** _(var y = bounds.yMin() - 16;)_ **:**

<img width="418" height="54" alt="image" src="https://github.com/user-attachments/assets/9273b3de-6f70-4cbd-876b-841c047f6ef0" />

