### PR TITLE
feat(scaffold/safewalk): randomize edge distance to bypass Polar & other anti-cheats

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
@@ -22,6 +22,7 @@ import net.ccbluex.liquidbounce.config.types.group.Mode
 import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import net.ccbluex.liquidbounce.config.types.group.NoneMode
 import net.ccbluex.liquidbounce.config.types.list.Tagged
+import net.ccbluex.liquidbounce.config.utils.asRefreshable
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerSafeWalkEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -36,7 +37,6 @@ import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.entity.wouldBeCloseToFallOff
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
-import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.ccbluex.liquidbounce.utils.movement.getDegreesRelativeToView
 import net.ccbluex.liquidbounce.utils.movement.getDirectionalInputForDegrees
@@ -61,7 +61,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
         )
     }
 
-    class Safe(override val parent: ModeValueGroup<Mode>) : Mode("Safe") {
+    private class Safe(override val parent: ModeValueGroup<Mode>) : Mode("Safe") {
 
         @Suppress("unused")
         val safeWalkHandler = handler<PlayerSafeWalkEvent> { event ->
@@ -70,9 +70,9 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
 
     }
 
-    class OnEdge(override val parent: ModeValueGroup<Mode>) : Mode("OnEdge") {
+    private class OnEdge(override val parent: ModeValueGroup<Mode>) : Mode("OnEdge") {
 
-        private val edgeDistance by floatRange("Distance", 0.1f..0.15f, 0.05f..0.5f)
+        private val edgeDistance = floatRange("Distance", 0.1f..0.15f, 0.05f..0.5f).asRefreshable()
         private var center: Vec3? = null
 
         private enum class OnEdgeMode(override val tag: String) : Tagged {
@@ -84,13 +84,13 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
         /**
          * Defines how many ticks we should keep running the [mode]
          */
-        private var keepTicks by intRange("Keep", 1..2, 1..20, suffix = "ticks")
+        private val keepTicks by intRange("Keep", 1..2, 1..20, suffix = "ticks")
         private var overwriteTicks = 0
 
-        private var mode by enumChoice("Mode", OnEdgeMode.STOP)
-        private var sneak by intRange("Sneak", 0..0, 0..20, suffix = "ticks")
+        private val mode by enumChoice("Mode", OnEdgeMode.STOP)
+        private val sneak by intRange("Sneak", 0..0, 0..20, suffix = "ticks")
         private var sneakTicks = 0
-        private var jump by boolean("Jump", false)
+        private val jump by boolean("Jump", false)
 
         /**
          * The input handler tracks the movement of the player and calculates the predicted future position.
@@ -103,7 +103,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
             if (shouldBeActive) {
                 val isOnEdge = player.isCloseToEdge(
                     event.directionalInput,
-                    min(player.horizontalSpeed, edgeDistance.random().toDouble())
+                    min(player.horizontalSpeed, edgeDistance.current.toDouble())
                 )
                 if (isOnEdge) {
                     debugParameter("InputOnEdge") { event.directionalInput }
@@ -127,6 +127,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
                     }
 
                     if (overwriteTicks == 0) {
+                        edgeDistance.refresh()
                         overwriteTicks = keepTicks.random()
                     }
 
@@ -185,6 +186,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
         override fun disable() {
             center = null
             overwriteTicks = 0
+            edgeDistance.refresh()
             super.disable()
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
@@ -36,6 +36,7 @@ import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.entity.wouldBeCloseToFallOff
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.ccbluex.liquidbounce.utils.movement.getDegreesRelativeToView
 import net.ccbluex.liquidbounce.utils.movement.getDirectionalInputForDegrees
@@ -71,7 +72,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
 
     class OnEdge(override val parent: ModeValueGroup<Mode>) : Mode("OnEdge") {
 
-        private val edgeDistance by float("Distance", 0.1f, 0.1f..0.5f)
+        private val edgeDistance by floatRange("Distance", 0.1f..0.15f, 0.05f..0.5f)
         private var center: Vec3? = null
 
         private enum class OnEdgeMode(override val tag: String) : Tagged {
@@ -102,7 +103,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
             if (shouldBeActive) {
                 val isOnEdge = player.isCloseToEdge(
                     event.directionalInput,
-                    min(player.horizontalSpeed, edgeDistance.toDouble())
+                    min(player.horizontalSpeed, edgeDistance.random().toDouble())
                 )
                 if (isOnEdge) {
                     debugParameter("InputOnEdge") { event.directionalInput }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
@@ -25,13 +25,12 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.techniques.ScaffoldNormalTechnique
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
-import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 
 object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eagle", false) {
 
     private val blocksToEagle = intRange("BlocksToEagle", 0..0, 0..10).asRefreshable()
-    private val edgeDistance by floatRange("EdgeDistance", 0.01f..0.05f, 0.01f..1.3f)
+    private val edgeDistance = floatRange("EdgeDistance", 0.01f..0.05f, 0.01f..1.3f).asRefreshable()
     private val onlyOnGround by boolean("OnlyOnGround", true)
 
     // Makes you sneak until first block placed, so with eagle enabled you won't fall off, when enabled
@@ -56,7 +55,7 @@ object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eag
 
         val shouldBeActive = !player.abilities.flying && placedBlocks == 0
 
-        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.random().toDouble())
+        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.current.toDouble())
     }
 
     fun onBlockPlacement() {
@@ -69,6 +68,7 @@ object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eag
         if (placedBlocks > blocksToEagle.current) {
             placedBlocks = 0
             blocksToEagle.refresh()
+            edgeDistance.refresh()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
@@ -25,12 +25,13 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.techniques.ScaffoldNormalTechnique
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 
 object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eagle", false) {
 
     private val blocksToEagle = intRange("BlocksToEagle", 0..0, 0..10).asRefreshable()
-    private val edgeDistance by float("EdgeDistance", 0.01f, 0.01f..1.3f)
+    private val edgeDistance by floatRange("EdgeDistance", 0.01f..0.05f, 0.01f..1.3f)
     private val onlyOnGround by boolean("OnlyOnGround", true)
 
     // Makes you sneak until first block placed, so with eagle enabled you won't fall off, when enabled
@@ -55,7 +56,7 @@ object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eag
 
         val shouldBeActive = !player.abilities.flying && placedBlocks == 0
 
-        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.toDouble())
+        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.random().toDouble())
     }
 
     fun onBlockPlacement() {


### PR DESCRIPTION
Modern anti-cheats (including Polar) absolutely love static/consistent patterns. Changing edge distance and safe walk distance from a static float to a floatRange allows the client to pick a random value within the range on every tick, providing excellent randomization and significantly improving bypass rates.