### PR TITLE
fix(jcef): enable copy, paste, cut, and select-all keyboard shortcuts on macOS

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
@@ -33,7 +33,7 @@ import net.ccbluex.liquidbounce.mcef.MCEF
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowser
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowserSettings
 import net.ccbluex.liquidbounce.utils.client.clientLogger
-import net.minecraft.util.Util
+import net.minecraft.client.input.InputQuirks
 import org.apache.logging.log4j.Logger
 import org.joml.component1
 import org.joml.component2
@@ -243,7 +243,7 @@ class CefBrowser(
     override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int) {
         browserApi.setFocus(true)
 
-        if (Util.getPlatform() == Util.OS.OSX && handleMacClipboardShortcut(keyCode, modifiers)) {
+        if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY && handleMacClipboardShortcut(keyCode, modifiers)) {
             return
         }
 
@@ -260,6 +260,7 @@ class CefBrowser(
         browserApi.sendKeyTyped(codepoint.toChar(), 0) // TODO: GLFW update removed modifiers here
     }
 
+    // TODO: Temporary fix. Should be removed after fix in JCEF
     private fun handleMacClipboardShortcut(keyCode: Int, modifiers: Int): Boolean {
         val isCommandPressed = modifiers and GLFW.GLFW_MOD_SUPER != 0
         if (!isCommandPressed) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
@@ -33,9 +33,11 @@ import net.ccbluex.liquidbounce.mcef.MCEF
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowser
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowserSettings
 import net.ccbluex.liquidbounce.utils.client.clientLogger
+import net.minecraft.Util
 import org.apache.logging.log4j.Logger
 import org.joml.component1
 import org.joml.component2
+import org.lwjgl.glfw.GLFW
 
 @Suppress("TooManyFunctions")
 class CefBrowser(
@@ -240,6 +242,11 @@ class CefBrowser(
 
     override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int) {
         browserApi.setFocus(true)
+
+        if (Util.getPlatform() == Util.OS.OSX && handleMacClipboardShortcut(keyCode, modifiers)) {
+            return
+        }
+
         browserApi.sendKeyPress(keyCode, scanCode.toLong(), modifiers)
     }
 
@@ -251,6 +258,34 @@ class CefBrowser(
     override fun charTyped(codepoint: Int) {
         browserApi.setFocus(true)
         browserApi.sendKeyTyped(codepoint.toChar(), 0) // TODO: GLFW update removed modifiers here
+    }
+
+    private fun handleMacClipboardShortcut(keyCode: Int, modifiers: Int): Boolean {
+        val isCommandPressed = modifiers and GLFW.GLFW_MOD_SUPER != 0
+        if (!isCommandPressed) {
+            return false
+        }
+
+        val frame = browserApi.focusedFrame
+        return when (keyCode) {
+            GLFW.GLFW_KEY_C -> {
+                frame.copy()
+                true
+            }
+            GLFW.GLFW_KEY_V -> {
+                frame.paste()
+                true
+            }
+            GLFW.GLFW_KEY_X -> {
+                frame.cut()
+                true
+            }
+            GLFW.GLFW_KEY_A -> {
+                frame.selectAll()
+                true
+            }
+            else -> false
+        }
     }
 
     private fun comparePaintWithViewpoint(width: Int, height: Int) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/backend/backends/cef/CefBrowser.kt
@@ -33,7 +33,7 @@ import net.ccbluex.liquidbounce.mcef.MCEF
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowser
 import net.ccbluex.liquidbounce.mcef.cef.MCEFBrowserSettings
 import net.ccbluex.liquidbounce.utils.client.clientLogger
-import net.minecraft.Util
+import net.minecraft.util.Util
 import org.apache.logging.log4j.Logger
 import org.joml.component1
 import org.joml.component2


### PR DESCRIPTION
On macOS, JCEF inside GLFW does not correctly map and process Command modifier key shortcuts (like Cmd+C, Cmd+V, Cmd+X, Cmd+A) for text fields inside JCEF OSR (Off-Screen Rendering) browser instances. By explicitly intercepting the Command key modifier combined with C, V, X, A keys in keyPressed/keyReleased and invoking CefBrowser's native copy, paste, cut, and selectAll methods directly, we restore full macOS clipboard integration for the web UI.