### PR TITLE
feat(cheststealer): add InvCleaner priority & distance randomization bypass

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/cheststealer/ModuleChestStealer.kt
@@ -18,8 +18,11 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.player.cheststealer
 
+import it.unimi.dsi.fastutil.ints.Int2DoubleOpenHashMap
 import net.ccbluex.fastutil.objectHashSetOf
 import net.ccbluex.fastutil.swap
+import net.ccbluex.liquidbounce.config.types.group.Mode
+import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -30,7 +33,9 @@ import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.feat
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.CleanupPlanGenerator
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.InventoryCleanupPlan
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemCategorization
+import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemType
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ModuleInventoryCleaner
+import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.WeaponItemFacet
 import net.ccbluex.liquidbounce.utils.inventory.CheckScreenHandlerTypeValueGroup
 import net.ccbluex.liquidbounce.utils.inventory.CheckScreenTitleValueGroup
 import net.ccbluex.liquidbounce.utils.inventory.ContainerItemSlot
@@ -48,6 +53,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.world.item.ItemStack
 import kotlin.math.ceil
+import net.ccbluex.liquidbounce.utils.kotlin.random
 
 /**
  * ChestStealer module
@@ -60,7 +66,8 @@ object ModuleChestStealer : ClientModule("ChestStealer", ModuleCategories.PLAYER
     private val inventoryConstrains = tree(InventoryConstraints())
     private val autoClose by boolean("AutoClose", true)
 
-    private val selectionMode by enumChoice("SelectionMode", SelectionMode.DISTANCE)
+    private val selectionMode = choices("SelectionMode", Distance, arrayOf(Distance, Index, Random, InvCleanerPriority))
+
     private val itemMoveMode by enumChoice("MoveMode", ItemMoveMode.QUICK_MOVE)
     private val quickSwaps by boolean("QuickSwaps", true)
 
@@ -94,7 +101,7 @@ object ModuleChestStealer : ClientModule("ChestStealer", ModuleCategories.PLAYER
         val itemsToCollect = cleanupPlan.usefulItems.filterIsInstanceTo(ArrayList<ContainerItemSlot>())
 
         val stillRequiredSpace = getStillRequiredSpace(cleanupPlan, itemsToCollect.size)
-        selectionMode.process(itemsToCollect)
+        selectionMode.activeMode.process(itemsToCollect)
 
         val targetBlacklist = objectHashSetOf<ItemSlot>()
 
@@ -312,44 +319,117 @@ object ModuleChestStealer : ClientModule("ChestStealer", ModuleCategories.PLAYER
         return cleanupPlan
     }
 
-    @Suppress("unused")
-    private enum class SelectionMode(
-        override val tag: String,
-    ) : Tagged {
-        DISTANCE("Distance") {
-            override fun process(slots: MutableList<ContainerItemSlot>) {
-                val n = slots.size
-                if (n <= 2) return
+    private fun sortByDistance(slots: MutableList<ContainerItemSlot>, factorRange: ClosedFloatingPointRange<Float>) {
+        val n = slots.size
+        if (n <= 2) return
 
-                for (i in 0..<n - 1) {
-                    var bestIdx = i + 1
-                    var bestDist = Int.MAX_VALUE
+        val hasRandom = factorRange.start != factorRange.endInclusive
+        val randomFactors = if (hasRandom) Int2DoubleOpenHashMap(n) else null
 
-                    val current = slots[i]
+        if (randomFactors != null) {
+            for (slot in slots) {
+                randomFactors.put(slot.slotInContainer, factorRange.random().toDouble())
+            }
+        }
 
-                    for (j in i + 1..<n) {
-                        val d = current.distance(slots[j])
+        for (i in 0..<n - 1) {
+            var bestIdx = i + 1
+            var bestDist = Double.MAX_VALUE
 
-                        if (d < bestDist) {
-                            bestDist = d
-                            bestIdx = j
-                        }
-                    }
+            val current = slots[i]
 
-                    slots.swap(i + 1, bestIdx)
+            for (j in i + 1..<n) {
+                val candidate = slots[j]
+                val baseDist = current.distance(candidate).toDouble()
+                val randomizedDist = if (randomFactors == null) {
+                    baseDist
+                } else {
+                    baseDist * randomFactors.get(candidate.slotInContainer)
+                }
+
+                if (randomizedDist < bestDist) {
+                    bestDist = randomizedDist
+                    bestIdx = j
                 }
             }
-        },
-        INDEX("Index")  {
-            private val comparator: Comparator<ContainerItemSlot> = Comparator.comparingInt { it.slotInContainer }
 
-            override fun process(slots: MutableList<ContainerItemSlot>) = slots.sortWith(this.comparator)
-        },
-        RANDOM("Random") {
-            override fun process(slots: MutableList<ContainerItemSlot>) = slots.shuffle()
-        };
+            slots.swap(i + 1, bestIdx)
+        }
+    }
+
+    private fun invCleanerPriorityFor(slot: ItemSlot): Int {
+        val categoryType = primaryItemType(slot)
+        return when (categoryType) {
+            ItemType.ARMOR -> 5
+            ItemType.SWORD -> 4
+            ItemType.WEAPON, ItemType.SPEAR, ItemType.MACE -> 3
+            ItemType.PEARL -> 2
+            ItemType.TOOL -> 1
+            else -> 0
+        }
+    }
+
+    private fun primaryItemType(slot: ItemSlot): ItemType {
+        val facets = ItemCategorization.Default.getItemFacets(slot)
+        val nonWeaponFacets = facets.filterNot { it is WeaponItemFacet }
+        val facetsToCheck = if (nonWeaponFacets.isEmpty()) facets else nonWeaponFacets
+
+        return facetsToCheck
+            .maxBy { it.category.type.allocationPriority }
+            .category
+            .type
+    }
+
+    /**
+     * Mode pattern (as requested in review): each selection mode owns its own settings, so the
+     * DistanceRandomFactor only shows for the modes that actually sort by distance and is hidden for the
+     * others — no doNotIncludeWhen hacks.
+     */
+    abstract class SelectionMode(name: String) : Mode(name) {
+        override val parent: ModeValueGroup<SelectionMode> get() = selectionMode
 
         abstract fun process(slots: MutableList<ContainerItemSlot>)
+    }
+
+    /** Steal nearest-first (greedy nearest-neighbour), optionally randomized by [distanceRandomFactor]. */
+    object Distance : SelectionMode("Distance") {
+        val distanceRandomFactor by floatRange("DistanceRandomFactor", 1.0f..1.0f, 0.0f..5.0f, "factor")
+
+        override fun process(slots: MutableList<ContainerItemSlot>) = sortByDistance(slots, distanceRandomFactor)
+    }
+
+    /** Steal in raw container-slot order. */
+    object Index : SelectionMode("Index") {
+        private val comparator: Comparator<ContainerItemSlot> = Comparator.comparingInt { it.slotInContainer }
+
+        override fun process(slots: MutableList<ContainerItemSlot>) = slots.sortWith(comparator)
+    }
+
+    /** Steal in a fully random order. */
+    object Random : SelectionMode("Random") {
+        override fun process(slots: MutableList<ContainerItemSlot>) = slots.shuffle()
+    }
+
+    /**
+     * Steal highest-priority items first (armor > sword > weapon > pearl > tool), and WITHIN each
+     * priority group take them nearest-first, optionally randomized by [distanceRandomFactor].
+     */
+    object InvCleanerPriority : SelectionMode("InvCleanerPriority") {
+        val distanceRandomFactor by floatRange("DistanceRandomFactor", 1.0f..1.0f, 0.0f..5.0f, "factor")
+
+        override fun process(slots: MutableList<ContainerItemSlot>) {
+            if (slots.size <= 2) return
+
+            val grouped = slots.groupBy { invCleanerPriorityFor(it) }
+            val sortedPriorities = grouped.keys.sortedDescending()
+
+            slots.clear()
+            for (priority in sortedPriorities) {
+                val groupSlots = grouped.getValue(priority).toMutableList()
+                sortByDistance(groupSlots, distanceRandomFactor)
+                slots.addAll(groupSlots)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request adds two key improvements to the `ChestStealer` module to improve combat-preparedness and bypass checks on strict anti-cheats (like Polar):

### 1. **InvCleaner Priority** Selection Mode
* Dynamically evaluates chest items using the standard `ItemCategorization` facets.
* Prioritizes high-value combat and survival items (Armor, Swords, Weapons, Ender Pearls, Tools) before clearing lesser utility slots (blocks, food, etc.).
* Within each priority tier, items are cleared using a proximity-based path (`DISTANCE`), ensuring both logical priority and local slot efficiency.

### 2. **Distance Randomization** Bypass
* Adds a `DistanceRandomFactor` setting group (hides automatically if selection mode is not `Distance` or `InvCleanerPriority`).
* Instead of following a perfectly linear, deterministic proximity path (which strict anti-cheats easily flag as automated), it perturbs slot distances using a random multiplier from your configured factor range.
* This generates a slightly chaotic but highly efficient path (stealing nearby slots first, but occasionally choosing slightly further ones), defeating heuristic checks while maintaining maximum speed.

---

### Предлагаемое изменение в документацию (Suggested changes to documentation):

```markdown
### ChestStealer

Automatically steals all items from a chest.

Category: Player  
Enabled by default: No  

#### Settings

Below is the complete tree of all configurable settings for this module.

├── Constraints (Setting Group)
│   ├── StartDelay (Integer Range | default: 1..2 | range: 0..20 | ticks)
│   ├── ClickDelay (Integer Range | default: 2..4 | range: 0..20 | ticks)
│   ├── CloseDelay (Integer Range | default: 1..2 | range: 0..20 | ticks)
│   ├── MissChance (Integer Range | default: 0..0 | range: 0..100 | %)
│   └── Requires (Multi-Select | options: NoMovement, NoRotation)
├── AutoClose (Toggle | default: true)
├── SelectionMode (Choice | default: DISTANCE | options: Distance, Index, Random, InvCleanerPriority)
├── DistanceRandomFactor (Decimal Range | default: 1.0..1.0 | range: 0.0..5.0)
├── MoveMode (Choice | default: QUICK_MOVE | options: QuickMove, DragAndDrop)
...

#### Settings Details

* **SelectionMode** (Choice) — default: `DISTANCE`; options: `Distance`, `Index`, `Random`, `InvCleanerPriority`
  * `Distance`: Steals items starting from the closest slot in a proximity path.
  * `Index`: Steals items slot-by-slot from left to right.
  * `Random`: Steals items in a completely random order.
  * `InvCleanerPriority`: Dynamically analyzes item utility using Inventory Cleaner facets, prioritizing high-value combat items (Armor, Swords, Weapons, Ender Pearls, Tools) before stealing lesser items. Slots within each priority group are cleared using proximity-based distance.

* **DistanceRandomFactor** (Decimal Range) — default: `1.0..1.0`; range: `0.0..5.0`
  * Controls the randomization jitter applied to proximity-based stealing paths.
  * Setting this to a range like `0.8..1.3` adds natural, human-like variance to the path, completely bypassing heuristics while maintaining top-speed efficiency.
```
