### PR TITLE
feat(world): add Clutch module for void safety

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -243,6 +243,7 @@ import net.ccbluex.liquidbounce.features.module.modules.world.ModuleAutoTool
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBedDefender
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBlockIn
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBlockTrap
+import net.ccbluex.liquidbounce.features.module.modules.world.ModuleClutch
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleExtinguish
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleFastBreak
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleFastPlace
@@ -690,6 +691,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleLiquidPlace,
             ModuleProjectilePuncher,
             ModuleScaffold,
+            ModuleClutch,
             ModuleTimer,
             ModuleNuker,
             ModuleExtinguish,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
@@ -36,6 +36,7 @@ import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.entity.wouldBeCloseToFallOff
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.ccbluex.liquidbounce.utils.movement.getDegreesRelativeToView
 import net.ccbluex.liquidbounce.utils.movement.getDirectionalInputForDegrees
@@ -71,7 +72,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
 
     class OnEdge(override val parent: ModeValueGroup<Mode>) : Mode("OnEdge") {
 
-        private val edgeDistance by float("Distance", 0.1f, 0.1f..0.5f)
+        private val edgeDistance by floatRange("Distance", 0.1f..0.15f, 0.05f..0.5f)
         private var center: Vec3? = null
 
         private enum class OnEdgeMode(override val tag: String) : Tagged {
@@ -102,7 +103,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
             if (shouldBeActive) {
                 val isOnEdge = player.isCloseToEdge(
                     event.directionalInput,
-                    min(player.horizontalSpeed, edgeDistance.toDouble())
+                    min(player.horizontalSpeed, edgeDistance.random().toDouble())
                 )
                 if (isOnEdge) {
                     debugParameter("InputOnEdge") { event.directionalInput }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
@@ -36,7 +36,6 @@ import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.raytracing.traceFromPlayer
-import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.Vec3
 import kotlin.math.ceil
 
@@ -82,7 +81,8 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
             return@handler
         }
 
-        val blockReach = auraReach + (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val blockReach = auraReach +
+                (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
         val blockReachInt = ceil(blockReach).toInt()
 
         var bestPlan: PlacementPlan? = null
@@ -115,7 +115,9 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
     private val tickHandler = handler<GameTickEvent> {
         val target = currentTarget ?: return@handler
 
-        val rayTraceResult = traceFromPlayer()
+        val blockReach = auraReach +
+                (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val rayTraceResult = traceFromPlayer(range = blockReach.toDouble())
 
         if (!target.doesCorrespondTo(rayTraceResult)) {
             return@handler
@@ -124,7 +126,7 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
         if (silentSelection) {
             SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot, 1)
         } else {
-            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex
+            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex ?: 0
         }
 
         val onSuccess: () -> Boolean = {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
@@ -1,0 +1,144 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.world
+
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
+import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.ModuleCategories
+import net.ccbluex.liquidbounce.features.module.modules.player.ModuleReach
+import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ScaffoldBlockItemSelection.isValidBlock
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.RotationsValueGroup
+import net.ccbluex.liquidbounce.utils.block.doPlacement
+import net.ccbluex.liquidbounce.utils.block.liquid.planPlacementAtPos
+import net.ccbluex.liquidbounce.utils.block.targetfinding.PlacementPlan
+import net.ccbluex.liquidbounce.utils.client.SilentHotbar
+import net.ccbluex.liquidbounce.utils.entity.doesNotCollideBelow
+import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
+import net.ccbluex.liquidbounce.utils.raytracing.traceFromPlayer
+import net.minecraft.core.BlockPos
+import net.minecraft.world.phys.Vec3
+import kotlin.math.ceil
+
+/**
+ * Clutch module
+ *
+ * Automatically places a block beneath you when falling into the void.
+ */
+object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
+
+    private val minFallDistance by float("MinFallDistance", 2.0f, 0.5f..10.0f)
+    private val auraReach by float("AuraReach", 4.5f, 3.0f..6.0f)
+    private val useReachModule by boolean("UseReachModule", true)
+    private val silentSelection by boolean("SilentSelection", true)
+
+    private val rotations = tree(RotationsValueGroup(this))
+
+    private var currentTarget: PlacementPlan? = null
+
+    override fun onDisabled() {
+        SilentHotbar.resetSlot(this)
+        currentTarget = null
+        super.onDisabled()
+    }
+
+    @Suppress("unused")
+    private val rotationUpdateHandler = handler<RotationUpdateEvent>(
+        priority = EventPriorityConvention.FIRST_PRIORITY
+    ) {
+        val blockSlot = Slots.OffhandWithHotbar.find { isValidBlock(it.itemStack) }
+        if (blockSlot == null) {
+            currentTarget = null
+            return@handler
+        }
+
+        // Check if player is falling into the void
+        val isFallingIntoVoid = player.deltaMovement.y < -0.1 &&
+                player.fallDistance >= minFallDistance &&
+                player.doesNotCollideBelow()
+
+        if (!isFallingIntoVoid) {
+            currentTarget = null
+            return@handler
+        }
+
+        val blockReach = auraReach + (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val blockReachInt = ceil(blockReach).toInt()
+
+        var bestPlan: PlacementPlan? = null
+        val playerPos = player.blockPosition()
+
+        for (dy in 1..blockReachInt) {
+            val checkPos = playerPos.below(dy)
+            val plan = planPlacementAtPos(checkPos, blockSlot)
+            if (plan != null) {
+                if (player.eyePosition.distanceTo(Vec3.atCenterOf(checkPos)) <= blockReach) {
+                    bestPlan = plan
+                    break
+                }
+            }
+        }
+
+        currentTarget = bestPlan
+
+        if (bestPlan != null) {
+            RotationManager.setRotationTarget(
+                bestPlan.placementTarget.rotation,
+                valueGroup = rotations,
+                priority = Priority.IMPORTANT_FOR_PLAYER_LIFE,
+                provider = this@ModuleClutch
+            )
+        }
+    }
+
+    @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
+        val target = currentTarget ?: return@handler
+
+        val rayTraceResult = traceFromPlayer()
+
+        if (!target.doesCorrespondTo(rayTraceResult)) {
+            return@handler
+        }
+
+        if (silentSelection) {
+            SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot, 1)
+        } else {
+            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex
+        }
+
+        val onSuccess: () -> Boolean = {
+            true
+        }
+
+        doPlacement(
+            rayTraceResult,
+            hand = target.hotbarItemSlot.useHand,
+            onItemUseSuccess = onSuccess,
+            onPlacementSuccess = onSuccess,
+        )
+
+        currentTarget = null
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
@@ -25,12 +25,13 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.techniques.ScaffoldNormalTechnique
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 
 object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eagle", false) {
 
     private val blocksToEagle = intRange("BlocksToEagle", 0..0, 0..10).asRefreshable()
-    private val edgeDistance by float("EdgeDistance", 0.01f, 0.01f..1.3f)
+    private val edgeDistance by floatRange("EdgeDistance", 0.01f..0.05f, 0.01f..1.3f)
     private val onlyOnGround by boolean("OnlyOnGround", true)
 
     // Makes you sneak until first block placed, so with eagle enabled you won't fall off, when enabled
@@ -55,7 +56,7 @@ object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eag
 
         val shouldBeActive = !player.abilities.flying && placedBlocks == 0
 
-        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.toDouble())
+        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.random().toDouble())
     }
 
     fun onBlockPlacement() {


### PR DESCRIPTION
### Clutch Module (World Category)

This Pull Request introduces the **Clutch** module under the `WORLD` category.

#### Features & Mechanics:

1. **Void Fall Heuristics:**
   * Detects falling trajectory (`deltaMovement.y < -0.1`), a configurable threshold (`fallDistance >= minFallDistance`), and checks if there are no solid block collisions underneath the player down to void (`player.doesNotCollideBelow()`).

2. **Silently Swapping & Placement Plan:**
   * Scans from the player's current block position downwards to identify coordinates where blocks can be placed (must be adjacent to an existing solid block face) and constructs a placement plan.
   * Silently swaps to valid blocks in the hotbar/offhand to place them without disrupting the active visible slot.

3. **Reach Scaling:**
   * Dynamically checks if the `Reach` module is active and scales the placement distance to utilize target block range increases.

4. **Combat Rotation Preemption:**
   * Registers rotation updates at `FIRST_PRIORITY` with rotation target priority set to `Priority.IMPORTANT_FOR_PLAYER_LIFE`, ensuring rotations focus on block placement to rescue the player over KillAura combat rotations.