### PR TITLE
feat(combat): implement 1.8 block priority and void knockback priority in AutoWeapon

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -243,6 +243,7 @@ import net.ccbluex.liquidbounce.features.module.modules.world.ModuleAutoTool
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBedDefender
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBlockIn
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleBlockTrap
+import net.ccbluex.liquidbounce.features.module.modules.world.ModuleClutch
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleExtinguish
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleFastBreak
 import net.ccbluex.liquidbounce.features.module.modules.world.ModuleFastPlace
@@ -690,6 +691,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleLiquidPlace,
             ModuleProjectilePuncher,
             ModuleScaffold,
+            ModuleClutch,
             ModuleTimer,
             ModuleNuker,
             ModuleExtinguish,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -40,12 +40,17 @@ import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.item.WeaponType
 import net.ccbluex.liquidbounce.utils.item.attackSpeed
 import net.ccbluex.liquidbounce.utils.item.isAxe
-import net.ccbluex.liquidbounce.utils.item.isConsumable
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock
+import net.ccbluex.liquidbounce.utils.item.isSword
+import net.ccbluex.liquidbounce.utils.item.getEnchantment
 import net.ccbluex.liquidbounce.utils.kotlin.matchesAny
+import net.minecraft.core.BlockPos
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.MaceItem
+import net.minecraft.world.item.enchantment.Enchantments
 
 /**
  * AutoWeapon module
@@ -65,6 +70,8 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
 
     private val autoShieldBreak by boolean("AutoShieldBreak", true)
     private val autoMace by boolean("AutoMace", true)
+    private val block1_8Priority by boolean("1.8BlockPriority", true)
+    private val voidKnockbackPriority by boolean("VoidKnockbackPriority", true)
 
     private val switchBack by int("SwitchBack", 20, 1..300, "ticks")
 
@@ -173,6 +180,11 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
         val requiresShield = autoShieldBreak && (enforceShield || target?.wouldBlockHit == true)
         val requiresMace = autoMace && canMaceSmash
 
+        val requiresLegacySword = block1_8Priority && KillAuraAutoBlock.running &&
+                (!KillAuraAutoBlock.onlyWhenInDanger || KillAuraAutoBlock.isInDanger) && target != null
+
+        val prioritizeKnockback = voidKnockbackPriority && target != null && isNearVoid(target)
+
         val bestSlot = Slots.Hotbar
             .flatMap { slot -> itemCategorization.getItemFacets(slot).filterIsInstance<WeaponItemFacet>() }
             .filter { itemFacet ->
@@ -182,13 +194,75 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
                     requiresMace -> WeaponType.MACE.test(itemStack)
                     // An axe will stun the target if it is blocking with a shield
                     requiresShield -> WeaponType.AXE.test(itemStack)
+                    // If legacy block priority is active, always allow swords
+                    requiresLegacySword && itemStack.isSword -> true
+                    // If void knockback is active, always allow knockback items
+                    prioritizeKnockback && itemStack.getEnchantment(Enchantments.KNOCKBACK) > 0 -> true
                     // Fall back to a preferred weapon when no special case applies
                     else -> preferredWeapon.matchesAny(itemStack)
                 }
             }
-            .maxOrNull()
+            .maxWithOrNull(Comparator { o1, o2 ->
+                if (prioritizeKnockback) {
+                    val kb1 = o1.itemStack.getEnchantment(Enchantments.KNOCKBACK)
+                    val kb2 = o2.itemStack.getEnchantment(Enchantments.KNOCKBACK)
+                    if (kb1 != kb2) {
+                        return@Comparator kb1.compareTo(kb2)
+                    }
+                }
+                if (requiresLegacySword) {
+                    val o1Sword = o1.itemStack.isSword
+                    val o2Sword = o2.itemStack.isSword
+                    if (o1Sword != o2Sword) {
+                        return@Comparator if (o1Sword) 1 else -1
+                    }
+                }
+                o1.compareTo(o2)
+            })
 
         return bestSlot?.itemSlot as HotbarItemSlot?
+    }
+
+    private fun isNearVoid(target: LivingEntity): Boolean {
+        val level = mc.level ?: return false
+
+        val dx = target.x - player.x
+        val dz = target.z - player.z
+        val len = Math.sqrt(dx * dx + dz * dz)
+        if (len < 0.1) return false
+
+        val nx = dx / len
+        val nz = dz / len
+
+        val targetY = target.blockPosition().y
+        var voidBlocksCount = 0
+        val checkDistances = listOf(1.5, 3.0, 4.5, 6.0)
+
+        for (dist in checkDistances) {
+            val checkX = target.x + nx * dist
+            val checkZ = target.z + nz * dist
+
+            val blockPos = BlockPos(checkX.toInt(), targetY, checkZ.toInt())
+            var hasBlockBelow = false
+
+            for (dy in 0..16) {
+                val p = blockPos.below(dy)
+                if (p.y < level.minBuildHeight) {
+                    break
+                }
+                val state = level.getBlockState(p)
+                if (!state.isAir && !state.getCollisionShape(level, p).isEmpty) {
+                    hasBlockBelow = true
+                    break
+                }
+            }
+
+            if (!hasBlockBelow) {
+                voidBlocksCount++
+            }
+        }
+
+        return voidBlocksCount >= 2
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -99,7 +99,7 @@ object KillAuraAutoBlock : ToggleableValueGroup(ModuleKillAura, "AutoBlocking", 
 
     private val prioritizeBlocking by boolean("PrioritizeBlocking", true)
     val onScanRange by boolean("OnScanRange", true)
-    private val onlyWhenInDanger by boolean("OnlyWhenInDanger", false)
+    val onlyWhenInDanger by boolean("OnlyWhenInDanger", false)
 
     /** For 1.9~1.21.4 protocol on 1.8 server, server will send a shield to your offhand on using item */
     private val assumeShield by boolean("AssumeShield", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSafeWalk.kt
@@ -36,6 +36,7 @@ import net.ccbluex.liquidbounce.utils.entity.horizontalSpeed
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.entity.wouldBeCloseToFallOff
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.ccbluex.liquidbounce.utils.movement.getDegreesRelativeToView
 import net.ccbluex.liquidbounce.utils.movement.getDirectionalInputForDegrees
@@ -71,7 +72,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
 
     class OnEdge(override val parent: ModeValueGroup<Mode>) : Mode("OnEdge") {
 
-        private val edgeDistance by float("Distance", 0.1f, 0.1f..0.5f)
+        private val edgeDistance by floatRange("Distance", 0.1f..0.15f, 0.05f..0.5f)
         private var center: Vec3? = null
 
         private enum class OnEdgeMode(override val tag: String) : Tagged {
@@ -102,7 +103,7 @@ object ModuleSafeWalk : ClientModule("SafeWalk", ModuleCategories.MOVEMENT) {
             if (shouldBeActive) {
                 val isOnEdge = player.isCloseToEdge(
                     event.directionalInput,
-                    min(player.horizontalSpeed, edgeDistance.toDouble())
+                    min(player.horizontalSpeed, edgeDistance.random().toDouble())
                 )
                 if (isOnEdge) {
                     debugParameter("InputOnEdge") { event.directionalInput }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
@@ -36,7 +36,6 @@ import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.raytracing.traceFromPlayer
-import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.Vec3
 import kotlin.math.ceil
 
@@ -82,7 +81,8 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
             return@handler
         }
 
-        val blockReach = auraReach + (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val blockReach = auraReach +
+                (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
         val blockReachInt = ceil(blockReach).toInt()
 
         var bestPlan: PlacementPlan? = null
@@ -115,7 +115,9 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
     private val tickHandler = handler<GameTickEvent> {
         val target = currentTarget ?: return@handler
 
-        val rayTraceResult = traceFromPlayer()
+        val blockReach = auraReach +
+                (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val rayTraceResult = traceFromPlayer(range = blockReach.toDouble())
 
         if (!target.doesCorrespondTo(rayTraceResult)) {
             return@handler
@@ -124,7 +126,7 @@ object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
         if (silentSelection) {
             SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot, 1)
         } else {
-            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex
+            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex ?: 0
         }
 
         val onSuccess: () -> Boolean = {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/ModuleClutch.kt
@@ -1,0 +1,144 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.world
+
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
+import net.ccbluex.liquidbounce.event.events.RotationUpdateEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.ModuleCategories
+import net.ccbluex.liquidbounce.features.module.modules.player.ModuleReach
+import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.ScaffoldBlockItemSelection.isValidBlock
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.RotationsValueGroup
+import net.ccbluex.liquidbounce.utils.block.doPlacement
+import net.ccbluex.liquidbounce.utils.block.liquid.planPlacementAtPos
+import net.ccbluex.liquidbounce.utils.block.targetfinding.PlacementPlan
+import net.ccbluex.liquidbounce.utils.client.SilentHotbar
+import net.ccbluex.liquidbounce.utils.entity.doesNotCollideBelow
+import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
+import net.ccbluex.liquidbounce.utils.raytracing.traceFromPlayer
+import net.minecraft.core.BlockPos
+import net.minecraft.world.phys.Vec3
+import kotlin.math.ceil
+
+/**
+ * Clutch module
+ *
+ * Automatically places a block beneath you when falling into the void.
+ */
+object ModuleClutch : ClientModule("Clutch", ModuleCategories.WORLD) {
+
+    private val minFallDistance by float("MinFallDistance", 2.0f, 0.5f..10.0f)
+    private val auraReach by float("AuraReach", 4.5f, 3.0f..6.0f)
+    private val useReachModule by boolean("UseReachModule", true)
+    private val silentSelection by boolean("SilentSelection", true)
+
+    private val rotations = tree(RotationsValueGroup(this))
+
+    private var currentTarget: PlacementPlan? = null
+
+    override fun onDisabled() {
+        SilentHotbar.resetSlot(this)
+        currentTarget = null
+        super.onDisabled()
+    }
+
+    @Suppress("unused")
+    private val rotationUpdateHandler = handler<RotationUpdateEvent>(
+        priority = EventPriorityConvention.FIRST_PRIORITY
+    ) {
+        val blockSlot = Slots.OffhandWithHotbar.find { isValidBlock(it.itemStack) }
+        if (blockSlot == null) {
+            currentTarget = null
+            return@handler
+        }
+
+        // Check if player is falling into the void
+        val isFallingIntoVoid = player.deltaMovement.y < -0.1 &&
+                player.fallDistance >= minFallDistance &&
+                player.doesNotCollideBelow()
+
+        if (!isFallingIntoVoid) {
+            currentTarget = null
+            return@handler
+        }
+
+        val blockReach = auraReach + (if (useReachModule && ModuleReach.running) ModuleReach.blockRangeIncrease else 0.0f)
+        val blockReachInt = ceil(blockReach).toInt()
+
+        var bestPlan: PlacementPlan? = null
+        val playerPos = player.blockPosition()
+
+        for (dy in 1..blockReachInt) {
+            val checkPos = playerPos.below(dy)
+            val plan = planPlacementAtPos(checkPos, blockSlot)
+            if (plan != null) {
+                if (player.eyePosition.distanceTo(Vec3.atCenterOf(checkPos)) <= blockReach) {
+                    bestPlan = plan
+                    break
+                }
+            }
+        }
+
+        currentTarget = bestPlan
+
+        if (bestPlan != null) {
+            RotationManager.setRotationTarget(
+                bestPlan.placementTarget.rotation,
+                valueGroup = rotations,
+                priority = Priority.IMPORTANT_FOR_PLAYER_LIFE,
+                provider = this@ModuleClutch
+            )
+        }
+    }
+
+    @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
+        val target = currentTarget ?: return@handler
+
+        val rayTraceResult = traceFromPlayer()
+
+        if (!target.doesCorrespondTo(rayTraceResult)) {
+            return@handler
+        }
+
+        if (silentSelection) {
+            SilentHotbar.selectSlotSilently(this, target.hotbarItemSlot, 1)
+        } else {
+            player.inventory.selectedSlot = target.hotbarItemSlot.hotbarIndex
+        }
+
+        val onSuccess: () -> Boolean = {
+            true
+        }
+
+        doPlacement(
+            rayTraceResult,
+            hand = target.hotbarItemSlot.useHand,
+            onItemUseSuccess = onSuccess,
+            onPlacementSuccess = onSuccess,
+        )
+
+        currentTarget = null
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/world/scaffold/techniques/normal/ScaffoldEagleFeature.kt
@@ -25,12 +25,13 @@ import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.modules.world.scaffold.techniques.ScaffoldNormalTechnique
 import net.ccbluex.liquidbounce.utils.entity.isCloseToEdge
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
+import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 
 object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eagle", false) {
 
     private val blocksToEagle = intRange("BlocksToEagle", 0..0, 0..10).asRefreshable()
-    private val edgeDistance by float("EdgeDistance", 0.01f, 0.01f..1.3f)
+    private val edgeDistance by floatRange("EdgeDistance", 0.01f..0.05f, 0.01f..1.3f)
     private val onlyOnGround by boolean("OnlyOnGround", true)
 
     // Makes you sneak until first block placed, so with eagle enabled you won't fall off, when enabled
@@ -55,7 +56,7 @@ object ScaffoldEagleFeature : ToggleableValueGroup(ScaffoldNormalTechnique, "Eag
 
         val shouldBeActive = !player.abilities.flying && placedBlocks == 0
 
-        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.toDouble())
+        return shouldBeActive && player.isCloseToEdge(input, edgeDistance.random().toDouble())
     }
 
     fun onBlockPlacement() {


### PR DESCRIPTION
This PR introduces two new features to the AutoWeapon module for improved PvP mechanics:

1. **1.8BlockPriority**: Prioritizes swords during legacy PvP/1.8 combat when KillAura's AutoBlock is configured to block 'Only When in Danger' and we are actively in danger. This allows effective autoblocking since swords are required to block on legacy protocols.
2. **VoidKnockbackPriority**: Automatically prioritizes weapons or items with the highest Knockback enchantment level (such as knockback sticks) if the target is standing close to the void and the knockback direction will push them off. The module dynamically samples points along the knockback trajectory and checks if there are no solid blocks below to ensure accurate void drop detection.