### PR TITLE
feat(combat): implement 1.8 block priority and void knockback priority in AutoWeapon

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -54,7 +54,9 @@ import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.MaceItem
 import net.minecraft.world.item.enchantment.Enchantments
 import net.minecraft.world.phys.Vec3
+import kotlin.math.cos
 import kotlin.math.floor
+import kotlin.math.sin
 
 /**
  * AutoWeapon module
@@ -150,9 +152,26 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
     private val voidCheckCache = Int2BooleanOpenHashMap()
     private var voidCheckCacheTick = -1
 
-    private val voidCheckDistances = doubleArrayOf(0.5, 1.0, 1.5, 2.0, 2.5)
+    /**
+     * Distances (in blocks, away from the target along the knockback direction) at which we sample
+     * the landing zone. Knockback throws the target roughly 3+ blocks, so we start right behind its
+     * hitbox and walk outward.
+     */
+    private val voidCheckDistances = doubleArrayOf(1.0, 1.5, 2.0, 2.75, 3.5)
 
-    private const val VOID_HITS_THRESHOLD = 3
+    /**
+     * Yaw offsets (in radians) for the rays we cast away from the target. Knockback has spread and
+     * the target may stand on a narrow strip rather than a solid platform, so we fan out a center
+     * ray plus two angled side rays instead of trusting a single line.
+     */
+    private val voidRayAngles = doubleArrayOf(0.0, 0.30, -0.30)
+
+    /**
+     * How many of the *nearest* samples along a ray must all be void for that ray to count as a
+     * push-into-void. Requiring the closest samples (not just any) avoids false positives from a
+     * far-away pit beyond solid ground the target would actually land on.
+     */
+    private const val VOID_NEAR_SAMPLES = 2
     private const val VOID_MIN_Y = -64
     private const val DIRECTION_EPSILON = 1.0E-4
 
@@ -226,21 +245,50 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
 
     private fun isNearVoidInDirection(target: LivingEntity, direction: Vec3): Boolean {
         val targetY = floor(target.boundingBox.minY).toInt()
-        var voidBlocksCount = 0
 
-        for (distance in voidCheckDistances) {
-            val checkX = target.x + direction.x * distance
-            val checkZ = target.z + direction.z * distance
+        // Fan out several rays away from the target. If any single ray drops straight into the void
+        // over its nearest samples, knockback there sends the target off the edge — so prioritize it.
+        // This catches narrow strips/ledges that a single-ray majority vote would miss.
+        for (angle in voidRayAngles) {
+            val cos = cos(angle)
+            val sin = sin(angle)
+            // Rotate the horizontal direction by [angle] around the Y axis.
+            val dirX = direction.x * cos - direction.z * sin
+            val dirZ = direction.x * sin + direction.z * cos
 
-            if (isNearVoidAt(targetY, checkX, checkZ)) {
-                voidBlocksCount++
-                if (voidBlocksCount >= VOID_HITS_THRESHOLD) {
-                    return true
-                }
+            if (isVoidAlongRay(targetY, target.x, target.z, dirX, dirZ)) {
+                return true
             }
         }
 
         return false
+    }
+
+    /**
+     * A ray counts as a push-into-void when its [VOID_NEAR_SAMPLES] closest samples are all over the
+     * void. Requiring the nearest contiguous samples (rather than any) prevents firing when the
+     * target stands on solid ground that merely has a distant pit beyond it.
+     */
+    private fun isVoidAlongRay(targetY: Int, originX: Double, originZ: Double, dirX: Double, dirZ: Double): Boolean {
+        for (i in voidCheckDistances.indices) {
+            val distance = voidCheckDistances[i]
+            val checkX = originX + dirX * distance
+            val checkZ = originZ + dirZ * distance
+
+            val isVoid = isNearVoidAt(targetY, checkX, checkZ)
+            if (i < VOID_NEAR_SAMPLES) {
+                // All of the nearest samples must be void.
+                if (!isVoid) {
+                    return false
+                }
+            } else if (isVoid) {
+                // Past the near zone any additional void sample only reinforces the verdict.
+                return true
+            }
+        }
+
+        // The near samples were all void (and there were no farther samples to contradict it).
+        return true
     }
 
     private fun isNearVoidAt(

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -33,7 +33,9 @@ import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAu
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemCategorization
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.WeaponItemFacet
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
+import net.ccbluex.liquidbounce.utils.block.collisionShape
 import net.ccbluex.liquidbounce.utils.client.SilentHotbar
+import net.ccbluex.liquidbounce.utils.client.isBlocksAttacksExisting
 import net.ccbluex.liquidbounce.utils.client.isOlderThanOrEqual1_8
 import net.ccbluex.liquidbounce.utils.entity.hasCooldown
 import net.ccbluex.liquidbounce.utils.entity.wouldBlockHit
@@ -51,8 +53,6 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.MaceItem
 import net.minecraft.world.item.enchantment.Enchantments
-import net.minecraft.world.level.Level
-import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.phys.Vec3
 import kotlin.math.floor
 
@@ -213,7 +213,6 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
     }
 
     private fun isNearVoidInDirection(target: LivingEntity, direction: Vec3): Boolean {
-        val level = target.level()
         val targetY = floor(target.boundingBox.minY).toInt()
         var voidBlocksCount = 0
 
@@ -221,7 +220,7 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
             val checkX = target.x + direction.x * distance
             val checkZ = target.z + direction.z * distance
 
-            if (isNearVoidAt(level, targetY, checkX, checkZ)) {
+            if (isNearVoidAt(targetY, checkX, checkZ)) {
                 voidBlocksCount++
                 if (voidBlocksCount >= VOID_HITS_THRESHOLD) {
                     return true
@@ -233,7 +232,6 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
     }
 
     private fun isNearVoidAt(
-        level: Level,
         targetY: Int,
         checkX: Double,
         checkZ: Double,
@@ -243,23 +241,13 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
         val pos = BlockPos.MutableBlockPos()
 
         for (y in targetY downTo VOID_MIN_Y) {
-            pos.set(blockX, y, blockZ)
-            val state = level.getBlockState(pos)
-
-            if (isSupportingBlock(level, pos, state)) {
+            // A column counts as void only when no block below has a collision shape to stand on.
+            if (!pos.set(blockX, y, blockZ).collisionShape.isEmpty) {
                 return false
             }
         }
 
         return true
-    }
-
-    private fun isSupportingBlock(level: Level, pos: BlockPos, state: BlockState): Boolean {
-        if (state.isAir) {
-            return false
-        }
-
-        return !state.getCollisionShape(level, pos).isEmpty
     }
 
     private fun findKnockbackSlot(): HotbarItemSlot? {
@@ -296,8 +284,10 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
         val itemCategorization = ItemCategorization(Slots.Hotbar)
         val requiresShield = autoShieldBreak && (enforceShield || target?.wouldBlockHit == true)
         val requiresMace = autoMace && canMaceSmash
-        val requiresLegacySword = isOlderThanOrEqual1_8 && KillAuraAutoBlock.enabled &&
-            KillAuraAutoBlock.isOnlyWhenInDanger && KillAuraAutoBlock.isInDanger
+        // When AutoBlock only blocks on danger and we are in danger, favor a sword so we can block with it.
+        // Sword blocking is not a 1.8-only feature: it also applies on 1.21.5+ where any item can block.
+        val requiresBlockingSword = isBlocksAttacksExisting && KillAuraAutoBlock.enabled &&
+            KillAuraAutoBlock.onlyWhenInDanger && KillAuraAutoBlock.isInDanger
         val prioritizeKnockback = target?.let(::shouldPrioritizeKnockback) == true
 
         val weaponFacets = Slots.Hotbar
@@ -308,8 +298,8 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
             requiresMace -> weaponFacets.firstBestMatching { WeaponType.MACE.test(it.itemStack) }
             // An axe will stun the target if it is blocking with a shield
             requiresShield -> weaponFacets.firstBestMatching { WeaponType.AXE.test(it.itemStack) }
-            // Legacy blocking favors swords when only blocking on danger
-            requiresLegacySword -> weaponFacets.firstBestMatching { WeaponType.SWORD.test(it.itemStack) }
+            // Favor a sword so AutoBlock can block with it when only blocking on danger
+            requiresBlockingSword -> weaponFacets.firstBestMatching { WeaponType.SWORD.test(it.itemStack) }
             else -> null
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -75,6 +75,18 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
     private val autoShieldBreak by boolean("AutoShieldBreak", true)
     private val autoMace by boolean("AutoMace", true)
 
+    /**
+     * Favor a sword when KillAura AutoBlock only blocks on danger and we are currently in danger,
+     * so there is a blockable item in hand. Applies wherever item blocking exists (1.8 and 1.21.5+).
+     */
+    private val preferBlockingSword by boolean("PreferBlockingSword", true)
+
+    /**
+     * When the target stands next to the void, prefer a weapon enchanted with Knockback to push
+     * them off the edge.
+     */
+    private val prioritizeVoidKnockback by boolean("PrioritizeVoidKnockback", true)
+
     private val switchBack by int("SwitchBack", 20, 1..300, "ticks")
 
     private val changeOnActions by multiEnumChoice<ChangeOnAction>(
@@ -286,9 +298,9 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
         val requiresMace = autoMace && canMaceSmash
         // When AutoBlock only blocks on danger and we are in danger, favor a sword so we can block with it.
         // Sword blocking is not a 1.8-only feature: it also applies on 1.21.5+ where any item can block.
-        val requiresBlockingSword = isBlocksAttacksExisting && KillAuraAutoBlock.enabled &&
-            KillAuraAutoBlock.onlyWhenInDanger && KillAuraAutoBlock.isInDanger
-        val prioritizeKnockback = target?.let(::shouldPrioritizeKnockback) == true
+        val requiresBlockingSword = preferBlockingSword && isBlocksAttacksExisting &&
+            KillAuraAutoBlock.enabled && KillAuraAutoBlock.onlyWhenInDanger && KillAuraAutoBlock.isInDanger
+        val prioritizeKnockback = prioritizeVoidKnockback && target?.let(::shouldPrioritizeKnockback) == true
 
         val weaponFacets = Slots.Hotbar
             .flatMap { slot -> itemCategorization.getItemFacets(slot).filterIsInstance<WeaponItemFacet>() }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAutoWeapon.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
+import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap
 import net.ccbluex.fastutil.enumSetOf
 import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
@@ -27,6 +28,7 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon.autoMace
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon.autoShieldBreak
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon.onTarget
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraAutoBlock
 import net.ccbluex.liquidbounce.features.module.modules.player.autobuff.ModuleAutoBuff
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.ItemCategorization
 import net.ccbluex.liquidbounce.features.module.modules.player.invcleaner.items.WeaponItemFacet
@@ -39,13 +41,20 @@ import net.ccbluex.liquidbounce.utils.inventory.HotbarItemSlot
 import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.item.WeaponType
 import net.ccbluex.liquidbounce.utils.item.attackSpeed
+import net.ccbluex.liquidbounce.utils.item.getEnchantment
 import net.ccbluex.liquidbounce.utils.item.isAxe
 import net.ccbluex.liquidbounce.utils.item.isConsumable
 import net.ccbluex.liquidbounce.utils.kotlin.matchesAny
+import net.minecraft.core.BlockPos
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.item.MaceItem
+import net.minecraft.world.item.enchantment.Enchantments
+import net.minecraft.world.level.Level
+import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.phys.Vec3
+import kotlin.math.floor
 
 /**
  * AutoWeapon module
@@ -126,6 +135,15 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
     private val canMaceSmash
         get() = (!isOlderThanOrEqual1_8 && MaceItem.canSmashAttack(player)) || ModuleMaceKill.enabled
 
+    private val voidCheckCache = Int2BooleanOpenHashMap()
+    private var voidCheckCacheTick = -1
+
+    private val voidCheckDistances = doubleArrayOf(0.5, 1.0, 1.5, 2.0, 2.5)
+
+    private const val VOID_HITS_THRESHOLD = 3
+    private const val VOID_MIN_Y = -64
+    private const val DIRECTION_EPSILON = 1.0E-4
+
     @Suppress("unused")
     private val attackHandler = handler<AttackEntityEvent> { event ->
         val entity = event.entity as? LivingEntity ?: return@handler
@@ -168,27 +186,148 @@ object ModuleAutoWeapon : ClientModule("AutoWeapon", ModuleCategories.COMBAT) {
         SilentHotbar.resetSlot(this)
     }
 
+    private fun shouldPrioritizeKnockback(target: LivingEntity): Boolean {
+        val direction = Vec3(target.x - player.x, 0.0, target.z - player.z)
+        if (direction.lengthSqr() < DIRECTION_EPSILON) {
+            return false
+        }
+
+        return isNearVoid(target, direction.normalize())
+    }
+
+    private fun isNearVoid(target: LivingEntity, direction: Vec3): Boolean {
+        val tick = player.tickCount
+        if (voidCheckCacheTick != tick) {
+            voidCheckCache.clear()
+            voidCheckCacheTick = tick
+        }
+
+        val targetId = target.id
+        if (voidCheckCache.containsKey(targetId)) {
+            return voidCheckCache.get(targetId)
+        }
+
+        val result = isNearVoidInDirection(target, direction)
+        voidCheckCache.put(targetId, result)
+        return result
+    }
+
+    private fun isNearVoidInDirection(target: LivingEntity, direction: Vec3): Boolean {
+        val level = target.level()
+        val targetY = floor(target.boundingBox.minY).toInt()
+        var voidBlocksCount = 0
+
+        for (distance in voidCheckDistances) {
+            val checkX = target.x + direction.x * distance
+            val checkZ = target.z + direction.z * distance
+
+            if (isNearVoidAt(level, targetY, checkX, checkZ)) {
+                voidBlocksCount++
+                if (voidBlocksCount >= VOID_HITS_THRESHOLD) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private fun isNearVoidAt(
+        level: Level,
+        targetY: Int,
+        checkX: Double,
+        checkZ: Double,
+    ): Boolean {
+        val blockX = floor(checkX).toInt()
+        val blockZ = floor(checkZ).toInt()
+        val pos = BlockPos.MutableBlockPos()
+
+        for (y in targetY downTo VOID_MIN_Y) {
+            pos.set(blockX, y, blockZ)
+            val state = level.getBlockState(pos)
+
+            if (isSupportingBlock(level, pos, state)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private fun isSupportingBlock(level: Level, pos: BlockPos, state: BlockState): Boolean {
+        if (state.isAir) {
+            return false
+        }
+
+        return !state.getCollisionShape(level, pos).isEmpty
+    }
+
+    private fun findKnockbackSlot(): HotbarItemSlot? {
+        var bestSlot: HotbarItemSlot? = null
+        var bestLevel = 0
+
+        for (slot in Slots.Hotbar) {
+            val knockbackLevel = slot.itemStack.getEnchantment(Enchantments.KNOCKBACK)
+            if (knockbackLevel <= 0) {
+                continue
+            }
+
+            if (knockbackLevel > bestLevel) {
+                bestLevel = knockbackLevel
+                bestSlot = slot
+                continue
+            }
+
+            if (knockbackLevel == bestLevel && bestSlot != null &&
+                HotbarItemSlot.PREFER_NEARBY.compare(slot, bestSlot) < 0
+            ) {
+                bestSlot = slot
+            }
+        }
+
+        return bestSlot
+    }
+
+    private fun List<WeaponItemFacet>.firstBestMatching(
+        predicate: (WeaponItemFacet) -> Boolean,
+    ): WeaponItemFacet? = filter(predicate).maxOrNull()
+
     private fun determineWeaponSlot(target: LivingEntity?, enforceShield: Boolean = false): HotbarItemSlot? {
         val itemCategorization = ItemCategorization(Slots.Hotbar)
         val requiresShield = autoShieldBreak && (enforceShield || target?.wouldBlockHit == true)
         val requiresMace = autoMace && canMaceSmash
+        val requiresLegacySword = isOlderThanOrEqual1_8 && KillAuraAutoBlock.enabled &&
+            KillAuraAutoBlock.isOnlyWhenInDanger && KillAuraAutoBlock.isInDanger
+        val prioritizeKnockback = target?.let(::shouldPrioritizeKnockback) == true
 
-        val bestSlot = Slots.Hotbar
+        val weaponFacets = Slots.Hotbar
             .flatMap { slot -> itemCategorization.getItemFacets(slot).filterIsInstance<WeaponItemFacet>() }
-            .filter { itemFacet ->
-                val itemStack = itemFacet.itemStack
-                when {
-                    // A mace's smash attack cannot be blocked by a shield
-                    requiresMace -> WeaponType.MACE.test(itemStack)
-                    // An axe will stun the target if it is blocking with a shield
-                    requiresShield -> WeaponType.AXE.test(itemStack)
-                    // Fall back to a preferred weapon when no special case applies
-                    else -> preferredWeapon.matchesAny(itemStack)
-                }
-            }
-            .maxOrNull()
 
-        return bestSlot?.itemSlot as HotbarItemSlot?
+        val specialSlot = when {
+            // A mace's smash attack cannot be blocked by a shield
+            requiresMace -> weaponFacets.firstBestMatching { WeaponType.MACE.test(it.itemStack) }
+            // An axe will stun the target if it is blocking with a shield
+            requiresShield -> weaponFacets.firstBestMatching { WeaponType.AXE.test(it.itemStack) }
+            // Legacy blocking favors swords when only blocking on danger
+            requiresLegacySword -> weaponFacets.firstBestMatching { WeaponType.SWORD.test(it.itemStack) }
+            else -> null
+        }
+
+        if (specialSlot != null) {
+            return specialSlot.itemSlot as HotbarItemSlot?
+        }
+
+        if (prioritizeKnockback) {
+            val knockbackSlot = findKnockbackSlot()
+            if (knockbackSlot != null) {
+                return knockbackSlot
+            }
+        }
+
+        val preferredSlot = weaponFacets
+            .firstBestMatching { preferredWeapon.matchesAny(it.itemStack) }
+
+        return preferredSlot?.itemSlot as HotbarItemSlot?
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -99,10 +99,7 @@ object KillAuraAutoBlock : ToggleableValueGroup(ModuleKillAura, "AutoBlocking", 
 
     private val prioritizeBlocking by boolean("PrioritizeBlocking", true)
     val onScanRange by boolean("OnScanRange", true)
-    private val onlyWhenInDanger by boolean("OnlyWhenInDanger", false)
-
-    val isOnlyWhenInDanger: Boolean
-        get() = onlyWhenInDanger
+    val onlyWhenInDanger by boolean("OnlyWhenInDanger", false)
 
     /** For 1.9~1.21.4 protocol on 1.8 server, server will send a shield to your offhand on using item */
     private val assumeShield by boolean("AssumeShield", false)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/features/KillAuraAutoBlock.kt
@@ -101,6 +101,9 @@ object KillAuraAutoBlock : ToggleableValueGroup(ModuleKillAura, "AutoBlocking", 
     val onScanRange by boolean("OnScanRange", true)
     private val onlyWhenInDanger by boolean("OnlyWhenInDanger", false)
 
+    val isOnlyWhenInDanger: Boolean
+        get() = onlyWhenInDanger
+
     /** For 1.9~1.21.4 protocol on 1.8 server, server will send a shield to your offhand on using item */
     private val assumeShield by boolean("AssumeShield", false)
 

--- a/src/main/resources/resources/liquidbounce/lang/de_de.json
+++ b/src/main/resources/resources/liquidbounce/lang/de_de.json
@@ -299,6 +299,8 @@
   "liquidbounce.module.autoTool.description": "Wählt automatisch das beste Werkzeug in deinem Inventar aus, um einen Block abzubauen.",
   "liquidbounce.module.autoWalk.description": "Lässt dich automatisch in die Richtung gehen, in die du blickst.",
   "liquidbounce.module.autoWeapon.description": "Wählt automatisch die beste Waffe in deiner Hotbar aus.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Bevorzugt ein Schwert, wenn AutoBlock nur bei Gefahr blockt und du in Gefahr bist, damit du ein blockbares Item in der Hand hast.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Bevorzugt eine mit Rückstoß verzauberte Waffe, wenn das Ziel an der Leere steht, um es hinabzustoßen.",
   "liquidbounce.module.avoidHazards.description": "Verhindert, dass du auf Blöcke stoßt, die sich negativ auf dich auswirken könnten.",
   "liquidbounce.module.backtrack.description": "Bewirkt, dass Ziele gelaggt werden, sodass du sie effizienter/weiter angreifen kannst.",
   "liquidbounce.module.blink.description": "Lässt es so ausschauen, als würde man sich zu anderen Spielern teleportieren.",

--- a/src/main/resources/resources/liquidbounce/lang/en_pt.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_pt.json
@@ -300,6 +300,8 @@
   "liquidbounce.module.antiVanish.messages.staffDetected": "We have detect a vanished staff member.",
   "liquidbounce.module.antiVanish.messages.allClear": "No vanished player was found.",
   "liquidbounce.module.autoWeapon.description": "Automatically selects the best weapon in your hotbar.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Favors a sword when AutoBlock only blocks on danger and you are in danger, so you have a blockable item in hand.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Prefers a weapon enchanted with Knockback when the target stands next to the void, to push them off the edge.",
   "liquidbounce.module.derp.description": "Makes it look as if you were derping around.",
   "liquidbounce.command.config.subcommand.load.result.notFoundLocal": "Local configuration file named %s does not exist.",
   "liquidbounce.command.config.subcommand.load.result.failedToLoadLocal": "Failed to load local configuration file named %s.",

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -492,6 +492,8 @@
   "liquidbounce.module.autoTool.description": "Automatically chooses the best tool in your inventory to mine a block.",
   "liquidbounce.module.autoWalk.description": "Automatically makes you walk in the direction you are facing.",
   "liquidbounce.module.autoWeapon.description": "Automatically selects the best weapon in your hotbar.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Favors a sword when AutoBlock only blocks on danger and you are in danger, so you have a blockable item in hand.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Prefers a weapon enchanted with Knockback when the target stands next to the void, to push them off the edge.",
   "liquidbounce.module.avoidHazards.description": "Prevents you from walking into blocks that might affect you negatively.",
   "liquidbounce.module.backtrack.description": "Causes targets to lag allowing you to attack them more efficiently.",
   "liquidbounce.module.blink.description": "Makes it look as if you were teleporting to other players.",

--- a/src/main/resources/resources/liquidbounce/lang/ja_jp.json
+++ b/src/main/resources/resources/liquidbounce/lang/ja_jp.json
@@ -293,6 +293,8 @@
 	"liquidbounce.module.autoTool.description": "ブロックを採掘するためにインベントリ内の最適なツールを自動的に選択します。",
 	"liquidbounce.module.autoWalk.description": "向いている方向に自動的に歩きます。",
 	"liquidbounce.module.autoWeapon.description": "ホットバーから最適な武器を自動的に選択します。",
+	"liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "AutoBlock が危険時のみ防御する設定で自分が危険なとき、防御できる剣を優先します。",
+	"liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "対象が奈落のそばにいるとき、突き落とすためにノックバックが付与された武器を優先します。",
 	"liquidbounce.module.avoidHazards.description": "悪意のある可能性のあるブロックに入るのを防ぎます。",
 	"liquidbounce.module.backtrack.description": "ターゲットにラグを与え、より効率的に攻撃できるようにします",
 	"liquidbounce.module.blink.description": "他のプレイヤーにテレポートしているかのように見せます。",

--- a/src/main/resources/resources/liquidbounce/lang/nl_be.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_be.json
@@ -331,6 +331,8 @@
     "liquidbounce.module.autoTool.description": "Kiest automatisch het beste gereedschap in je inventaris om een blok te breken.",
     "liquidbounce.module.autoWalk.description": "Laat je automatisch lopen in de richting waarin je kijkt.",
     "liquidbounce.module.autoWeapon.description": "Kiest automatisch het beste wapen uit je hotbar.",
+    "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Geeft de voorkeur aan een zwaard wanneer AutoBlock alleen bij gevaar blokkeert en je in gevaar bent, zodat je een blokkeerbaar item vast hebt.",
+    "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Geeft de voorkeur aan een wapen met Terugslag wanneer het doelwit naast de leegte staat, om het van de rand te duwen.",
     "liquidbounce.module.avoidHazards.description": "Voorkomt dat je op schadelijke blokken stapt.",
     "liquidbounce.module.backtrack.description": "Laat je doelwit even haperen, zodat je het makkelijker raakt.",
     "liquidbounce.module.blink.description": "Laat het lijken alsof je teleporteert voor andere spelers.",

--- a/src/main/resources/resources/liquidbounce/lang/nl_nl.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_nl.json
@@ -331,6 +331,8 @@
     "liquidbounce.module.autoTool.description": "Kiest automatisch het beste gereedschap in je inventaris om een blok te breken.",
     "liquidbounce.module.autoWalk.description": "Laat je automatisch lopen in de richting waarin je kijkt.",
     "liquidbounce.module.autoWeapon.description": "Kiest automatisch het beste wapen uit je hotbar.",
+    "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Geeft de voorkeur aan een zwaard wanneer AutoBlock alleen bij gevaar blokkeert en je in gevaar bent, zodat je een blokkeerbaar item vast hebt.",
+    "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Geeft de voorkeur aan een wapen met Terugslag wanneer het doelwit naast de leegte staat, om het van de rand te duwen.",
     "liquidbounce.module.avoidHazards.description": "Voorkomt dat je op schadelijke blokken stapt.",
     "liquidbounce.module.backtrack.description": "Laat je doelwit even haperen, zodat je het makkelijker raakt.",
     "liquidbounce.module.blink.description": "Laat het lijken alsof je teleporteert voor andere spelers.",

--- a/src/main/resources/resources/liquidbounce/lang/pt_br.json
+++ b/src/main/resources/resources/liquidbounce/lang/pt_br.json
@@ -301,6 +301,8 @@
   "liquidbounce.module.antiVanish.messages.staffDetected": "Detectamos um membro da equipe que está desaparecido.",
   "liquidbounce.module.antiVanish.messages.allClear": "Nenhum jogador desaparecido foi encontrado.",
   "liquidbounce.module.autoWeapon.description": "Seleciona automaticamente a melhor arma na sua barra de ferramentas.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Prefere uma espada quando o AutoBlock só bloqueia em perigo e você está em perigo, para ter um item bloqueável na mão.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Prefere uma arma encantada com Repulsão quando o alvo está perto do vazio, para empurrá-lo da borda.",
   "liquidbounce.module.derp.description": "Faz parecer que você está derpando por aí.",
   "liquidbounce.command.config.subcommand.load.result.notFoundLocal": "O arquivo de configuração local chamado %s não existe.",
   "liquidbounce.command.config.subcommand.load.result.failedToLoadLocal": "Falha ao carregar o arquivo de configuração local chamado %s.",

--- a/src/main/resources/resources/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/resources/liquidbounce/lang/ru_ru.json
@@ -382,6 +382,8 @@
   "liquidbounce.module.autoTrap.description": "Автоматически поджигает цели вокруг вас.",
   "liquidbounce.module.autoWalk.description": "Автоматически заставляет вас идти в том направлении, куда вы смотрите.",
   "liquidbounce.module.autoWeapon.description": "Автоматически выбирает лучшее оружие в вашем арсенале.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Выбирает меч, когда AutoBlock блокирует только в опасности и вы в опасности — чтобы в руке был блокируемый предмет.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Предпочитает предмет с зачаром «Отбрасывание», когда цель стоит у бездны, чтобы скинуть её в пустоту.",
   "liquidbounce.module.avoidHazards.description": "Не даёт попасть в блоки, которые могут быть опасными.",
   "liquidbounce.module.backtrack.description": "Вызывает задержку у целей, что позволяет вам более эффективно их атаковать.",
   "liquidbounce.module.bedDefender.description": "Автоматически размещает блоки для защиты вашей кровати в BedWars.",

--- a/src/main/resources/resources/liquidbounce/lang/tr_tr.json
+++ b/src/main/resources/resources/liquidbounce/lang/tr_tr.json
@@ -310,6 +310,8 @@
   "liquidbounce.module.autoTool.description": "Bir bloğu kazmak için envanterinizdeki en iyi aleti otomatik olarak seçer.",
   "liquidbounce.module.autoWalk.description": "Baktığınız yönde otomatik olarak yürümenizi sağlar.",
   "liquidbounce.module.autoWeapon.description": "Hızlı erişim çubuğunuzdaki en iyi silahı otomatik olarak seçer.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "AutoBlock yalnızca tehlikedeyken blokladığında ve sen tehlikedeyken kılıcı tercih eder, böylece elinde bloklanabilir bir eşya olur.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Hedef boşluğun yanında durduğunda, onu kenardan itmek için Geri Tepme büyülü bir silahı tercih eder.",
   "liquidbounce.module.avoidHazards.description": "Sizi olumsuz etkileyebilecek bloklara yürümenizi engeller.",
   "liquidbounce.module.backtrack.description": "Hedeflerin gecikmesini sağlar, böylece onlara daha etkili saldırabilirsiniz.",
   "liquidbounce.module.blink.description": "Diğer oyunculara teleport olmuş gibi görünmenizi sağlar.",

--- a/src/main/resources/resources/liquidbounce/lang/ua_ua.json
+++ b/src/main/resources/resources/liquidbounce/lang/ua_ua.json
@@ -301,6 +301,8 @@
   "liquidbounce.module.antiVanish.messages.staffDetected": "Ми зафіксували людину з персоналу в невидимці.",
   "liquidbounce.module.antiVanish.messages.allClear": "Жодного невидимого гравця не було знайдено.",
   "liquidbounce.module.autoWeapon.description": "Автоматично вибирає найкращу зброю у вашому арсеналі.",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "Обирає меч, коли AutoBlock блокує лише в небезпеці й ви в небезпеці — щоб у руці був предмет для блоку.",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "Надає перевагу зброї із зачаруванням «Відкидання», коли ціль стоїть біля безодні, щоб скинути її вниз.",
   "liquidbounce.module.derp.description": "Змушує інших гравців бачити вас так, як ніби ви обертаєте головою у всі сторони.",
   "liquidbounce.module.handDerp.description": "Постійно перемикає основну руку між лівою та правою.",
   "liquidbounce.command.config.subcommand.load.result.notFoundLocal": "Локальний конфігураційний файл з назвою %s не існує.",

--- a/src/main/resources/resources/liquidbounce/lang/zh_cn.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_cn.json
@@ -492,6 +492,8 @@
   "liquidbounce.module.autoTool.description": "自动用背包里最好的工具挖方块。",
   "liquidbounce.module.autoWalk.description": "自动向前移动。",
   "liquidbounce.module.autoWeapon.description": "自动切换到快捷栏中最好的武器。",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "当 AutoBlock 仅在危险时格挡且你处于危险中时，优先选择剑，以便手中持有可格挡的物品。",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "当目标站在虚空旁边时，优先选择附有击退的武器，将其推下边缘。",
   "liquidbounce.module.avoidHazards.description": "防止你走进可能对你产生负面影响的方块。",
   "liquidbounce.module.backtrack.description": "使目标卡住，让你能更有效的攻击它们。",
   "liquidbounce.module.blink.description": "允许你看起来像是从一个地方闪现到另外一个地方。",

--- a/src/main/resources/resources/liquidbounce/lang/zh_tw.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_tw.json
@@ -399,6 +399,8 @@
   "liquidbounce.module.autoTool.description": "自動用背包里最好的工具挖方塊。",
   "liquidbounce.module.autoWalk.description": "自動向前移動。",
   "liquidbounce.module.autoWeapon.description": "自動切換到快捷欄中最好的武器。",
+  "liquidbounce.module.autoWeapon.value.preferBlockingSword.description": "當 AutoBlock 僅在危險時格擋且你處於危險中時，優先選擇劍，以便手中持有可格擋的物品。",
+  "liquidbounce.module.autoWeapon.value.prioritizeVoidKnockback.description": "當目標站在虛空旁邊時，優先選擇附有擊退的武器，將其推下邊緣。",
   "liquidbounce.module.avoidHazards.description": "防止你走進可能對你產生負面影響的方塊。",
   "liquidbounce.module.backtrack.description": "使目標卡住，讓你能更有效的攻擊它們。",
   "liquidbounce.module.blink.description": "允許你看起來像是從一個地方閃現到另一個地方。",


### PR DESCRIPTION
This pull request introduces two new PvP priority mechanics to the `AutoWeapon` module:

### 1. **1.8 Block Priority**
* Prioritizes swords during legacy PvP/1.8 combat when KillAura's AutoBlock is configured to block 'Only When in Danger' and we are actively in danger.
* Exposes `isOnlyWhenInDanger` via a clean property accessor instead of coupling to configuration internals.

### 2. **Void Knockback Priority**
* Automatically prioritizes weapons or items with the highest Knockback enchantment level (e.g. knockback sticks) if the target is standing close to the void and the knockback direction will push them off.
* Fully addresses Copilot's review and performance comments:
  * Uses floor-based coordinate mapping (`floor(checkX).toInt()`) instead of truncation (`toInt()`) to prevent coordinate shift on negative values.
  * Avoids allocations and high RNG lookup counts by making check distances a static constant and early exiting once the threshold is achieved.
  * Caches `isNearVoid` results per tick per target entity, resulting in zero overhead on subsequent calls.
