### PR TITLE
feat(Config): add render flag to .localconfig save include options

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/AutoConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/AutoConfig.kt
@@ -255,16 +255,29 @@ object AutoConfig {
      * Created an auto config, which stores the moduleConfigur
      */
     fun serializeAutoConfig(
-        writer: Writer,
-        includeConfiguration: IncludeConfiguration = IncludeConfiguration.DEFAULT,
-        autoSettingsType: AutoSettingsType = AutoSettingsType.RAGE,
-        statusType: AutoSettingsStatusType = AutoSettingsStatusType.BYPASSING
+     writer: Writer,
+     includeConfiguration: IncludeConfiguration = IncludeConfiguration.DEFAULT,
+     autoSettingsType: AutoSettingsType = AutoSettingsType.RAGE,
+     statusType: AutoSettingsStatusType = AutoSettingsStatusType.BYPASSING
     ) {
-        this.includeConfiguration = includeConfiguration
+     this.includeConfiguration = includeConfiguration
 
-        // Store the config
-        val moduleTree = ConfigSystem.serializeValueGroup(ModuleManager.modulesConfig, publicGson)
-        val spooferTree = ConfigSystem.serializeValueGroup(SpooferManager, publicGson)
+     // Optionally filter out render modules before serializing
+     val modulesToSerialize = if (includeConfiguration.includeRender) {
+      ModuleManager.modulesConfig
+     } else {
+      object : ValueGroup(ModuleManager.modulesConfig.name) {
+       init {
+        inner.addAll(ModuleManager.modulesConfig.inner.filter { module ->
+         module !is ClientModule || module.category != ModuleCategories.RENDER
+        })
+       }
+      }
+     }
+
+     // Store the config
+     val moduleTree = ConfigSystem.serializeValueGroup(modulesToSerialize, publicGson)
+     val spooferTree = ConfigSystem.serializeValueGroup(SpooferManager, publicGson)
 
         if (!moduleTree.isJsonObject || !spooferTree.isJsonObject) {
             error("Root element is not a json object")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/IncludeConfiguration.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/IncludeConfiguration.kt
@@ -21,12 +21,13 @@ package net.ccbluex.liquidbounce.config.autoconfig
 
 @JvmRecord
 data class IncludeConfiguration(
-    val includeBinds: Boolean = false,
-    val includeAction: Boolean = false,
-    val includeHidden: Boolean = false,
+ val includeBinds: Boolean = false,
+ val includeAction: Boolean = false,
+ val includeHidden: Boolean = false,
+ val includeRender: Boolean = false,
 ) {
-    companion object {
-        @JvmField
-        val DEFAULT = IncludeConfiguration()
-    }
+ companion object {
+  @JvmField
+  val DEFAULT = IncludeConfiguration()
+ }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
@@ -111,12 +111,12 @@ object CommandLocalConfig : Command.Factory {
                 .build()
         )
         .parameter(
-            ParameterBuilder.begin<String>("include")
-                .verifiedBy(ParameterBuilder.STRING_VALIDATOR)
-                .autocompletedFrom { listOf("binds", "hidden") }
-                .vararg()
-                .optional()
-                .build()
+         ParameterBuilder.begin<String>("include")
+         .verifiedBy(ParameterBuilder.STRING_VALIDATOR)
+         .autocompletedFrom { listOf("binds", "hidden", "render") }
+         .vararg()
+         .optional()
+         .build()
         )
         .handler {
             val name = args[0] as String
@@ -130,8 +130,9 @@ object CommandLocalConfig : Command.Factory {
             val include = args.getOrNull(2) as Array<*>? ?: emptyArray<String>()
 
             val includeConfiguration = IncludeConfiguration(
-                includeBinds = include.contains("binds"),
-                includeHidden = include.contains("hidden"),
+             includeBinds = include.contains("binds"),
+             includeHidden = include.contains("hidden"),
+             includeRender = include.contains("render"),
             )
 
             val file = ConfigSystem.userConfigsFolder.resolve("$name.json")


### PR DESCRIPTION
Adds includeRender to IncludeConfiguration and exposes it via the .localconfig save command's include parameter. When includeRender=false (default), modules from RENDER and FUN categories are excluded from saved configs, matching the existing behavior for visual modules. Setting includeRender=true includes them.

Fixes #8398