### PR TITLE
feat(config): include Render/Fun modules in .localconfig save

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/OptionalInclusion.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/OptionalInclusion.kt
@@ -16,22 +16,13 @@
  * You should have received a copy of the GNU General Public License
  * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
  */
-package net.ccbluex.liquidbounce.features.module
 
-import net.ccbluex.liquidbounce.config.OptionalInclusion
-import net.ccbluex.liquidbounce.config.types.list.Tagged
+package net.ccbluex.liquidbounce.config
 
-class ModuleCategory(
-    override val tag: String,
-    val inclusionGroup: OptionalInclusion? = null
-) : Tagged {
-
-    @Deprecated(
-        message = "For script compatibility only. Use choiceName instead",
-        replaceWith = ReplaceWith("choiceName"),
-        level = DeprecationLevel.ERROR
-    )
-    val readableName: String
-        get() = tag
-
+/**
+ * Groups of settings that can be optionally included or excluded during configuration saving.
+ */
+enum class OptionalInclusion {
+    RENDER,
+    FUN
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/IncludeConfiguration.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/autoconfig/IncludeConfiguration.kt
@@ -19,11 +19,13 @@
 
 package net.ccbluex.liquidbounce.config.autoconfig
 
+import net.ccbluex.liquidbounce.config.OptionalInclusion
+
 @JvmRecord
 data class IncludeConfiguration(
     val includeBinds: Boolean = false,
-    val includeAction: Boolean = false,
     val includeHidden: Boolean = false,
+    val optionalInclusions: Set<OptionalInclusion> = emptySet(),
 ) {
     companion object {
         @JvmField

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/GsonInstance.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/GsonInstance.kt
@@ -106,7 +106,7 @@ val publicGson: Gson = GsonBuilder()
     .setPrettyPrinting()
     .addSerializationExclusionStrategy(ExcludeStrategy)
     .registerCommonTypeAdapters()
-    .registerTypeAdapter(ModeValueGroup::class.java, ModeValueGroupSerializer.FILE_SERIALIZER)
+    .registerTypeAdapter(ModeValueGroup::class.java, ModeValueGroupSerializer.PUBLIC_CONFIG_SERIALIZER)
     .registerTypeHierarchyAdapter(ValueGroup::class.java, ValueGroupSerializer.PUBLIC_SERIALIZER)
     .create()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ModeValueGroupSerializer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ModeValueGroupSerializer.kt
@@ -22,12 +22,17 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
+import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
+import net.ccbluex.liquidbounce.config.OptionalInclusion
+import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.group.Mode
 import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import java.lang.reflect.Type
 
 class ModeValueGroupSerializer private constructor(
     private val withValueType: Boolean,
+    private val includePrivate: Boolean,
+    private val includeNotAnOption: Boolean
 ) : JsonSerializer<ModeValueGroup<Mode>> {
 
     override fun serialize(
@@ -37,12 +42,21 @@ class ModeValueGroupSerializer private constructor(
 
         obj.addProperty("name", src.name)
         obj.addProperty("active", src.activeMode.tag)
-        obj.add("value", context.serialize(src.inner))
+        obj.add(
+            "value",
+            context.serialize(
+                src.inner
+                    .filter { includeNotAnOption || !it.notAnOption }
+                    .filter { includePrivate || it.checkIfInclude() }
+            )
+        )
 
         val choices = JsonObject()
 
         for (choice in src.modes) {
-            choices.add(choice.name, context.serialize(choice))
+            if (includePrivate || choice.checkIfInclude()) {
+                choices.add(choice.name, context.serialize(choice))
+            }
         }
 
         obj.add("choices", choices)
@@ -55,10 +69,19 @@ class ModeValueGroupSerializer private constructor(
 
     companion object {
         @JvmField
-        val INTEROP_SERIALIZER = ModeValueGroupSerializer(withValueType = true)
+        val INTEROP_SERIALIZER = ModeValueGroupSerializer(
+            withValueType = true, includePrivate = true, includeNotAnOption = false
+        )
 
         @JvmField
-        val FILE_SERIALIZER = ModeValueGroupSerializer(withValueType = false)
+        val FILE_SERIALIZER = ModeValueGroupSerializer(
+            withValueType = false, includePrivate = true, includeNotAnOption = true
+        )
+
+        @JvmField
+        val PUBLIC_CONFIG_SERIALIZER = ModeValueGroupSerializer(
+            withValueType = false, includePrivate = false, includeNotAnOption = true
+        )
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ValueGroupSerializer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/gson/serializer/ValueGroupSerializer.kt
@@ -22,10 +22,10 @@ package net.ccbluex.liquidbounce.config.gson.serializer
 import com.google.gson.JsonObject
 import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
+import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.group.ValueGroup
-import net.ccbluex.liquidbounce.features.module.ClientModule
-import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.text.toLowerCamelCase
 import net.ccbluex.liquidbounce.utils.render.Alignment
@@ -88,14 +88,12 @@ class ValueGroupSerializer(
     ) = JsonObject().apply {
         addProperty("name", src.name)
         try {
-
             add(
                 "value",
                 context.serialize(
-                    src.inner.filter { includeNotAnOption || !it.notAnOption }
-                        .filter {
-                            includePrivate || checkIfInclude(it)
-                        }
+                    src.inner
+                        .filter { includeNotAnOption || !it.notAnOption }
+                        .filter { includePrivate || it.checkIfInclude() }
                 )
             )
         } catch (e: Exception) {
@@ -105,32 +103,6 @@ class ValueGroupSerializer(
         if (withValueType) {
             add("valueType", context.serialize(src.valueType))
         }
-    }
-
-    /**
-     * Checks if value should be included in public config
-     */
-    private fun checkIfInclude(value: Value<*>): Boolean {
-        /**
-         * Do not include values that are not supposed to be shared
-         * with other users
-         */
-        if (value.doNotInclude.asBoolean) {
-            return false
-        }
-
-        // Might check if value is module
-        if (value is ClientModule) {
-            /**
-             * Do not include modules that are heavily user-personalised
-             */
-            if (value.category == ModuleCategories.RENDER || value.category == ModuleCategories.FUN) {
-                return false
-            }
-        }
-
-        // Otherwise include value
-        return true
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/Value.kt
@@ -25,6 +25,8 @@ import com.mojang.blaze3d.platform.InputConstants
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
 import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
@@ -94,9 +96,8 @@ open class Value<T : Any>(
     fun asStateFlow(): StateFlow<T> = stateFlow
 
     /**
-     * If true, value will not be included in generated public config
-     *
-     * @see
+     * If true, value will not be included in generated public config.
+     * Can be set using [doNotIncludeWhen] or [doNotIncludeAlways].
      */
     @Exclude
     @ProtocolExclude
@@ -104,7 +105,16 @@ open class Value<T : Any>(
         private set
 
     /**
-     * If true, value will not be included in generated RestAPI config
+     * Group for optional inclusion during configuration saving.
+     * Managed by [AutoConfig].
+     */
+    @Exclude
+    @ProtocolExclude
+    var inclusionGroup: OptionalInclusion? = null
+        private set
+
+    /**
+     * If true, value will not be included in generated RestAPI config.
      */
     @Exclude
     @ProtocolExclude
@@ -112,12 +122,27 @@ open class Value<T : Any>(
         private set
 
     /**
-     * If true, value will always keep [inner] equals [defaultValue]
+     * If true, value will always keep [inner] equals [defaultValue].
      */
     @Exclude
     @ProtocolExclude
     var isImmutable = false
         private set
+
+    /**
+     * Checks if this value should be included in the public configuration based on
+     * its [doNotInclude] condition and [inclusionGroup].
+     */
+    fun checkIfInclude(): Boolean {
+        if (doNotInclude.asBoolean) {
+            return false
+        }
+
+        val group = inclusionGroup ?: return true
+        val includeConfiguration = AutoConfig.includeConfiguration
+
+        return group in includeConfiguration.optionalInclusions
+    }
 
     @Exclude
     var key: String? = null
@@ -276,6 +301,10 @@ open class Value<T : Any>(
 
     fun doNotIncludeWhen(condition: BooleanSupplier) = apply {
         doNotInclude = condition
+    }
+
+    open fun inclusionGroup(group: OptionalInclusion) = apply {
+        this.inclusionGroup = group
     }
 
     fun notAnOption() = apply {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ModeValueGroup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ModeValueGroup.kt
@@ -20,6 +20,7 @@ package net.ccbluex.liquidbounce.config.types.group
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import net.ccbluex.fastutil.mapToArray
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.gson.stategies.ProtocolExclude
 import net.ccbluex.liquidbounce.config.types.ValueType
@@ -95,6 +96,14 @@ class ModeValueGroup<T : Mode>(
 
     override fun restore() {
         this.setAndUpdate(defaultMode)
+    }
+
+    override fun inclusionGroup(group: OptionalInclusion) = apply {
+        super.inclusionGroup(group)
+
+        for (m in modes) {
+            m.inclusionGroup(group)
+        }
     }
 
     @ScriptApiRequired

--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ValueGroup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ValueGroup.kt
@@ -28,6 +28,7 @@ import net.ccbluex.fastutil.enumSetOf
 import net.ccbluex.fastutil.forEachIsInstance
 import net.ccbluex.fastutil.toEnumSet
 import net.ccbluex.liquidbounce.config.ConfigSystem
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import net.ccbluex.liquidbounce.config.gson.publicGson
 import net.ccbluex.liquidbounce.config.types.BindValue
 import net.ccbluex.liquidbounce.config.types.Config
@@ -288,6 +289,14 @@ open class ValueGroup(
         inner.forEach(Value<*>::restore)
     }
 
+    override fun inclusionGroup(group: OptionalInclusion) = apply {
+        super.inclusionGroup(group)
+
+        for (v in inner) {
+            v.inclusionGroup(group)
+        }
+    }
+
     // Common value types
 
     fun <T : ValueGroup> tree(valueGroup: T): T {
@@ -299,7 +308,7 @@ open class ValueGroup(
             logger.warn("ValueGroup '${valueGroup.name}' is already added to a parent '${valueGroup.base?.name}'")
         }
 
-        inner.add(valueGroup)
+        value(valueGroup)
         valueGroup.base = this
         return valueGroup
     }
@@ -323,50 +332,38 @@ open class ValueGroup(
         defaultValue: T,
         valueType: ValueType = ValueType.INVALID,
         aliases: List<String> = emptyList(),
-    ) = Value(name, aliases = aliases, defaultValue = defaultValue, valueType = valueType).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(Value(name, aliases = aliases, defaultValue = defaultValue, valueType = valueType))
 
     internal inline fun <T : MutableCollection<E>, reified E> list(
         name: String,
         defaultValue: T,
         valueType: ValueType,
-    ) = ListValue(name, defaultValue, innerValueType = valueType, innerType = E::class.java).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(ListValue(name, defaultValue, innerValueType = valueType, innerType = E::class.java))
 
     internal inline fun <T : MutableCollection<E>, reified E> mutableList(
         name: String,
         defaultValue: T,
         valueType: ValueType,
-    ) = MutableListValue(name, defaultValue, valueType, E::class.java).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(MutableListValue(name, defaultValue, valueType, E::class.java))
 
     internal inline fun <T : MutableSet<E>, reified E> itemList(
         name: String,
         defaultValue: T,
         items: Set<ItemListValue.NamedItem<E>>,
         valueType: ValueType,
-    ) = ItemListValue(name, defaultValue, items, valueType, E::class.java).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(ItemListValue(name, defaultValue, items, valueType, E::class.java))
 
     internal inline fun <T : SequencedSet<E>, reified E> registryList(
         name: String,
         defaultValue: T,
         valueType: ValueType,
-    ) = RegistryListValue(name, defaultValue, valueType, E::class.java).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(RegistryListValue(name, defaultValue, valueType, E::class.java))
 
     internal inline fun <T : MutableList<E>, reified E> registryMutableList(
         name: String,
         defaultValue: T,
         valueType: ValueType,
-    ) = RegistryMutableListValue(name, defaultValue, valueType, E::class.java).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(RegistryMutableListValue(name, defaultValue, valueType, E::class.java))
 
     private fun <T : Any> rangedValue(
         name: String,
@@ -375,16 +372,16 @@ open class ValueGroup(
         suffix: String,
         valueType: ValueType,
         aliases: List<String> = emptyList(),
-    ) = RangedValue(
-        name,
-        aliases = aliases,
-        defaultValue = defaultValue,
-        range = range,
-        suffix = suffix,
-        valueType = valueType,
-    ).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(
+        RangedValue(
+            name,
+            aliases = aliases,
+            defaultValue = defaultValue,
+            range = range,
+            suffix = suffix,
+            valueType = valueType,
+        )
+    )
 
     // Fixed data types
 
@@ -431,9 +428,7 @@ open class ValueGroup(
         InputBind(InputConstants.Type.KEYSYM, default, InputBind.BindAction.TOGGLE)
     )
 
-    fun bind(name: String, default: InputBind) = BindValue(name, defaultValue = default).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    fun bind(name: String, default: InputBind) = value(BindValue(name, defaultValue = default))
 
     fun key(name: String, default: Int) = key(name, InputConstants.Type.KEYSYM.getOrCreate(default))
 
@@ -464,7 +459,7 @@ open class ValueGroup(
         default: Vec3i = Vec3i.ZERO,
         useLocateButton: Boolean = true,
         aliases: List<String> = emptyList(),
-    ): Value<Vec3i> = Vec3Value(name, aliases, default, useLocateButton, ValueType.VECTOR3_I).also(inner::add)
+    ): Value<Vec3i> = value(Vec3Value(name, aliases, default, useLocateButton, ValueType.VECTOR3_I))
 
     @JvmOverloads
     fun vec3d(
@@ -472,7 +467,7 @@ open class ValueGroup(
         default: Vec3 = Vec3.ZERO,
         useLocateButton: Boolean = true,
         aliases: List<String> = emptyList(),
-    ): Value<Vec3> = Vec3Value(name, aliases, default, useLocateButton, ValueType.VECTOR3_D).also(inner::add)
+    ): Value<Vec3> = value(Vec3Value(name, aliases, default, useLocateButton, ValueType.VECTOR3_D))
 
     fun <C : SequencedSet<Block>> blocks(name: String, default: C) =
         registryList(name, default, ValueType.BLOCK)
@@ -507,14 +502,12 @@ open class ValueGroup(
         xAxis: Axis,
         yAxis: Axis,
         tension: Float = CurveValue.DEFAULT_TENSION,
-    ) = CurveValue(name, default, xAxis, yAxis, tension).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(CurveValue(name, default, xAxis, yAxis, tension))
 
     inline fun curve(name: String, block: CurveValue.Builder.() -> Unit): CurveValue {
         val builder = CurveValue.Builder()
         builder.name = name
-        return builder.apply(block).build().also(::value)
+        return value(builder.apply(block).build())
     }
 
     fun file(
@@ -522,9 +515,7 @@ open class ValueGroup(
         default: File? = null,
         dialogMode: FileDialogMode = FileDialogMode.OPEN_FILE,
         supportedExtensions: Set<String>? = null,
-    ) = FileValue(name, default, dialogMode, supportedExtensions).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(FileValue(name, default, dialogMode, supportedExtensions))
 
     inline fun <reified T> multiEnumChoice(
         name: String,
@@ -562,9 +553,7 @@ open class ValueGroup(
         choices: Set<T>,
         canBeNone: Boolean,
         isOrderSensitive: Boolean,
-    ) = MultiChoiceListValue(name, default, choices, canBeNone, isOrderSensitive).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ) = value(MultiChoiceListValue(name, default, choices, canBeNone, isOrderSensitive))
 
     inline fun <reified T> enumChoice(
         name: String,
@@ -577,9 +566,7 @@ open class ValueGroup(
         default: T,
         choices: Set<T>,
         aliases: List<String> = emptyList(),
-    ): ChoiceListValue<T> = ChoiceListValue(name, defaultValue = default, choices = choices, aliases = aliases).apply {
-        this@ValueGroup.inner.add(this)
-    }
+    ): ChoiceListValue<T> = value(ChoiceListValue(name, defaultValue = default, choices = choices, aliases = aliases))
 
     protected fun <T : Mode> modes(
         eventListener: EventListener,
@@ -602,10 +589,9 @@ open class ValueGroup(
         activeCallback: ToIntFunction<List<T>>,
         modesCallback: (ModeValueGroup<T>) -> Array<T>,
     ): ModeValueGroup<T> {
-        return ModeValueGroup(eventListener, name, activeCallback, modesCallback).apply {
-            this@ValueGroup.inner.add(this)
+        return value(ModeValueGroup(eventListener, name, activeCallback, modesCallback).apply {
             this.base = this@ValueGroup
-        }
+        })
     }
 
     protected fun <T : Mode> modes(
@@ -615,7 +601,10 @@ open class ValueGroup(
         choicesCallback: (ModeValueGroup<T>) -> Array<T>,
     ) = modes(eventListener, name, { activeIndex }, choicesCallback)
 
-    fun <V : Value<*>> value(value: V) = value.apply { this@ValueGroup.inner.add(this) }
+    fun <V : Value<*>> value(value: V) = value.apply {
+        this@ValueGroup.inner.add(this)
+        this@ValueGroup.inclusionGroup?.let { this.inclusionGroup(it) }
+    }
 
     /**
      * Assigns the value of the settings to the component

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/client/CommandLocalConfig.kt
@@ -22,10 +22,12 @@ import kotlinx.coroutines.async
 import net.ccbluex.liquidbounce.api.core.ioScope
 import net.ccbluex.liquidbounce.api.models.client.AutoSettings
 import net.ccbluex.liquidbounce.config.ConfigSystem
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig.serializeAutoConfig
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfigMetadata
 import net.ccbluex.liquidbounce.config.autoconfig.IncludeConfiguration
+import net.ccbluex.fastutil.enumSetOf
 import net.ccbluex.liquidbounce.config.gson.publicGson
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.features.command.CommandException
@@ -113,7 +115,7 @@ object CommandLocalConfig : Command.Factory {
         .parameter(
             ParameterBuilder.begin<String>("include")
                 .verifiedBy(ParameterBuilder.STRING_VALIDATOR)
-                .autocompletedFrom { listOf("binds", "hidden") }
+                .autocompletedFrom { listOf("binds", "hidden", "render", "fun") }
                 .vararg()
                 .optional()
                 .build()
@@ -128,10 +130,14 @@ object CommandLocalConfig : Command.Factory {
             val overwrite = args.getOrNull(1) as Boolean? ?: false
             @Suppress("UNCHECKED_CAST")
             val include = args.getOrNull(2) as Array<*>? ?: emptyArray<String>()
+            val inclusions = enumSetOf<OptionalInclusion>()
+            if (include.contains("render")) inclusions.add(OptionalInclusion.RENDER)
+            if (include.contains("fun")) inclusions.add(OptionalInclusion.FUN)
 
             val includeConfiguration = IncludeConfiguration(
                 includeBinds = include.contains("binds"),
                 includeHidden = include.contains("hidden"),
+                optionalInclusions = inclusions,
             )
 
             val file = ConfigSystem.userConfigsFolder.resolve("$name.json")

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -68,6 +68,12 @@ open class ClientModule(
 
     protected val logger = clientLogger("Module/$name")
 
+    init {
+        category.inclusionGroup?.let { group ->
+            this.inclusionGroup(group)
+        }
+    }
+
     override val debugDisplayName: Component
         get() = this.name.asPlainText(Style.EMPTY + ChatFormatting.GOLD + ChatFormatting.BOLD)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleCategories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleCategories.kt
@@ -18,6 +18,7 @@
  */
 package net.ccbluex.liquidbounce.features.module
 
+import net.ccbluex.liquidbounce.config.OptionalInclusion
 import java.util.TreeMap
 
 object ModuleCategories {
@@ -34,7 +35,7 @@ object ModuleCategories {
     val MOVEMENT = register(ModuleCategory("Movement"))
 
     @JvmField
-    val RENDER = register(ModuleCategory("Render"))
+    val RENDER = register(ModuleCategory("Render", inclusionGroup = OptionalInclusion.RENDER))
 
     @JvmField
     val WORLD = register(ModuleCategory("World"))
@@ -46,7 +47,7 @@ object ModuleCategories {
     val EXPLOIT = register(ModuleCategory("Exploit"))
 
     @JvmField
-    val FUN = register(ModuleCategory("Fun"))
+    val FUN = register(ModuleCategory("Fun", inclusionGroup = OptionalInclusion.FUN))
 
     @JvmStatic
     val entries: Collection<ModuleCategory> get() = registry.sequencedValues()


### PR DESCRIPTION
Adds support for including Render and Fun modules when saving local configs through `.localconfig save`.

## Summary

- **New enum** `OptionalInclusion` in `config/` package with `RENDER` and `FUN` entries.
- **Refactored** `IncludeConfiguration` from individual boolean fields (`includeRender`, `includeFun`) to `Set<OptionalInclusion>` — rendering, fun, and future groups handled uniformly.
- **Removed dead code** `includeAction: Boolean` from `IncludeConfiguration`.
- **Added** `render` and `fun` tokens to the `.localconfig save` include options.
- **Moved** Render/Fun public-config exclusion into `ClientModule` via `inclusionGroup` propagation from `ModuleCategory`.
- **Renamed** `ModeValueGroupSerializer.PUBLIC_SERIALIZER` to `PUBLIC_CONFIG_SERIALIZER` to avoid confusion with `ValueGroupSerializer.PUBLIC_SERIALIZER`.
- **Moved** `OptionalInclusion` from `config/autoconfig/` to `config/` package — used across 3 subpackages.
- **Consolidated** `checkIfInclude()` into `Value.kt` — serializers now call `it.checkIfInclude()` instead of duplicating the logic.

## Behavior

- `.localconfig save <name>` — previous behavior, excludes Render/Fun modules.
- `.localconfig save <name> true render fun` — includes Render and Fun modules.
- `.localconfig save <name> true binds hidden render` — combines all include options.
- Existing `binds` and `hidden` options keep their behavior.

## Mechanism

- `ModuleCategory.inclusionGroup: OptionalInclusion?` — Render/Fun categories tag themselves with their group.
- `ClientModule.init {}` propagates `category.inclusionGroup` to the module.
- `ValueGroup` and `ModeValueGroup` propagate `inclusionGroup` to their inner values.
- `Value.checkIfInclude()` returns `false` if `doNotInclude` is set, otherwise checks whether the value's `inclusionGroup` is in `IncludeConfiguration.optionalInclusions`.
- The new `PUBLIC_CONFIG_SERIALIZER` (with `includePrivate = false`) respects `checkIfInclude()`, so Render/Fun values are excluded from public configs unless their group is in the set.

Fixes #8398