### PR TITLE
fix: perspective mod compatibility and improve mixin compatibility

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouseHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouseHandler.java
@@ -20,7 +20,8 @@
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.client;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.ccbluex.liquidbounce.additions.MouseHandlerAddition;
@@ -108,16 +109,14 @@ public abstract class MixinMouseHandler implements MouseHandlerAddition {
         return original || ModuleZoom.INSTANCE.getRunning();
     }
 
-    @WrapWithCondition(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), require = 1, allow = 1)
-    private boolean modifyMouseRotationInput(LocalPlayer instance, double cursorDeltaX, double cursorDeltaY) {
+    @WrapOperation(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), require = 1, allow = 1)
+    private void modifyMouseRotationInput(LocalPlayer instance, double cursorDeltaX, double cursorDeltaY, Operation<Void> original) {
         final MouseRotationEvent event = new MouseRotationEvent(cursorDeltaX, cursorDeltaY);
         EventManager.INSTANCE.callEvent(event);
 
         if (!event.isCancelled()) {
-            instance.turn(event.getCursorDeltaX(), event.getCursorDeltaY());
+            original.call(instance, event.getCursorDeltaX(), event.getCursorDeltaY());
         }
-
-        return false;
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
@@ -204,7 +204,8 @@ object RotationManager : EventListener {
         val partialTicks = event.partialTicks
 
         if (isRotatingAllowed(activeRotationTarget)
-            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK) {
+            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK
+            && mc.options.cameraType.isFirstPerson()) {
             val playerRotation = playerRotation ?: return@handler
             val currentRotation = currentRotation ?: return@handler
             val timerSpeed = Timer.timerSpeed
@@ -218,7 +219,8 @@ object RotationManager : EventListener {
     private val mouseMovement = handler<MouseRotationEvent> { event ->
         val activeRotationTarget = this.activeRotationTarget ?: return@handler
         if (!isRotatingAllowed(activeRotationTarget) ||
-            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK) {
+            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK ||
+            !mc.options.cameraType.isFirstPerson()) {
             return@handler
         }
 


### PR DESCRIPTION
Right now LiquidBounce forces the player's body to rotate when moving the mouse in 3rd person (F5). This breaks mods like Lunar's Perspective/Freelook because the character keeps turning while you're just trying to look around.

I've added a check so mouse input only affects the player's body in first-person. This doesn't break any internal features or modules, and it works perfectly with both Lunar's freelook and Liquid's own modules.

I also updated the Mixin in MixinMouseHandler to use @WrapOperation to ensure better compatibility with other mods. Simple fix, but makes the client much more compatible with modern modpacks...