### PR TITLE
chore(HUD): disable custom hotbar by default

### DIFF
--- a/src-theme/public/components/hotbar.json
+++ b/src-theme/public/components/hotbar.json
@@ -1,6 +1,6 @@
 {
   "name": "Hotbar",
-  "enabled": true,
+  "enabled": false,
   "singleton": true,
   "alignment": {
     "horizontalAlignment": "CenterTranslated",


### PR DESCRIPTION
Too many people complained about it and it is currently missing features the vanilla hotbar has (i.e., locator bar).

It can still be enabled manually under HUD settings.
