### PR TITLE
Updated AltManager with updated link to TheAltening

### DIFF
--- a/src-theme/src/routes/menu/altmanager/AltManager.svelte
+++ b/src-theme/src/routes/menu/altmanager/AltManager.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import {
-        deleteScreen,
-        getAccounts,
+   import {
+    browse,
+    deleteScreen,
+    getAccounts,
         loginToAccount as loginToAccountRest,
         orderAccounts,
         removeAccount as restRemoveAccount,
@@ -159,11 +160,13 @@
 
     <BottomButtonWrapper>
         <ButtonContainer>
-            <IconTextButton icon="icon-plus-circle.svg" title="Add" on:click={() => addAccountModalVisible = true}/>
-            <IconTextButton icon="icon-plane.svg" title="Direct" on:click={() => directLoginModalVisible = true}/>
-            <IconTextButton icon="icon-random.svg" disabled={renderedAccounts.length === 0} title="Random"
-                            on:click={loginToRandomAccount}/>
-            <IconTextButton icon="icon-refresh.svg" title="Restore" on:click={restoreSession}/>
+         <IconTextButton icon="icon-plus-circle.svg" title="Add" on:click={() => addAccountModalVisible = true}/>
+<IconTextButton icon="icon-plane.svg" title="Direct" on:click={() => directLoginModalVisible = true}/>
+<IconTextButton icon="altmanager/icon-thealtening.svg" title="Free Alt Pass"
+                on:click={() => browse("THE_ALTENING_LIQUIDBOUNCE_OFFER")}/>
+<IconTextButton icon="icon-random.svg" disabled={renderedAccounts.length === 0} title="Random"
+                on:click={loginToRandomAccount}/>
+<IconTextButton icon="icon-refresh.svg" title="Restore" on:click={restoreSession}/>
         </ButtonContainer>
 
         <ButtonContainer>

--- a/src/main/resources/resources/liquidbounce/client_urls.properties
+++ b/src/main/resources/resources/liquidbounce/client_urls.properties
@@ -26,3 +26,4 @@ CLIENT_WEBSITE=https://liquidbounce.net
 PROXY_WEBSITE=https://liquidproxy.net
 VIAFABRICPLUS=https://modrinth.com/mod/viafabricplus
 THE_ALTENING=https://thealtening.com/?ref=liquidbounce
+THE_ALTENING_LIQUIDBOUNCE_OFFER=https://thealtening.com/liquidbounce-offer


### PR DESCRIPTION
The promotional offer for LiquidBounce users to receive a 1 day premium pass to TheAltening has been updated. Previously users must have had to create a ticket to request the subscription, and now It's automated self service utilizing discord OAuth for verification and abuse reduction. 

The link has a dedicated page, [](https://thealtening.com/liquidbounce-offer) and this PR makes the partnership more visible to users in the alt manager, incase there were those who did not know about this benefit. 
<img width="609" height="330" alt="chrome_oNcQLb7Nzj" src="https://github.com/user-attachments/assets/77481f29-699f-4c78-b8d0-443b2d63bcd5" />
<img width="1920" height="1057" alt="javaw_k1875YGZVc" src="https://github.com/user-attachments/assets/65db23d4-aa48-4159-bf44-82f8c894fdda" />
