### PR TITLE
feat(AutoArmor): add RawDefense ranking mode for legacy (1.8) PvP

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/autoarmor/ModuleAutoArmor.kt
@@ -18,6 +18,8 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat.autoarmor
 
+import net.ccbluex.liquidbounce.config.types.group.Mode
+import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -31,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.inventory.InventoryAction
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.inventory.PlayerInventoryConstraints
 import net.ccbluex.liquidbounce.utils.inventory.hasInventorySpace
+import net.ccbluex.liquidbounce.utils.item.armor.ArmorComparatorMode
 import net.ccbluex.liquidbounce.utils.item.armor.ArmorEvaluation
 import net.ccbluex.liquidbounce.utils.item.armor.ArmorPiece
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
@@ -44,6 +47,40 @@ import net.minecraft.world.item.Items
 object ModuleAutoArmor : ClientModule("AutoArmor", ModuleCategories.COMBAT) {
 
     val inventoryConstraints = tree(PlayerInventoryConstraints())
+
+    /**
+     * Selects how armor pieces are ranked against each other. See [ArmorComparatorMode].
+     */
+    val modes = choices("Mode", Smart, arrayOf(Smart, RawDefense))
+
+    /**
+     * The original damage-model ranking. Weighs every protection enchantment into the modern,
+     * toughness-aware damage formula.
+     */
+    object Smart : Mode("Smart") {
+        override val parent: ModeValueGroup<Mode>
+            get() = modes
+
+        val comparatorMode = ArmorComparatorMode.SMART
+    }
+
+    /**
+     * SkyWars/BedWars oriented ranking. Picks the armor with the highest real damage reduction under the
+     * legacy 1.8 model, ignoring niche enchantments (Fire/Blast Protection, Thorns, Unbreaking, ...) that
+     * would otherwise trick the module into preferring objectively worse armor.
+     */
+    object RawDefense : Mode("RawDefense") {
+        override val parent: ModeValueGroup<Mode>
+            get() = modes
+
+        /**
+         * Whether Projectile Protection should influence the ranking as a deciding argument (useful on
+         * archer-heavy servers). When disabled it only matters when everything else is equal.
+         */
+        val considerProjectileProtection by boolean("ConsiderProjectileProtection", true)
+
+        val comparatorMode = ArmorComparatorMode.RAW_DEFENSE
+    }
 
     /**
      * Should the module use the hotbar to equip armor pieces?
@@ -70,8 +107,15 @@ object ModuleAutoArmor : ClientModule("AutoArmor", ModuleCategories.COMBAT) {
         // Filter out already equipped armor pieces
         val durabilityThreshold = if (AutoArmorSaveArmor.enabled) durabilityThreshold else Int.MIN_VALUE
 
+        val comparatorMode = (modes.activeMode as? RawDefense)?.comparatorMode ?: Smart.comparatorMode
+        val considerProjectileProtection = RawDefense.considerProjectileProtection
+
         val armorToEquip = ArmorEvaluation
-            .findBestArmorPieces(durabilityThreshold = durabilityThreshold)
+            .findBestArmorPieces(
+                durabilityThreshold = durabilityThreshold,
+                mode = comparatorMode,
+                considerProjectileProtection = considerProjectileProtection
+            )
             .values.filterNotNull().filter { !it.isAlreadyEquipped }
 
         for (armorPiece in armorToEquip) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/armor/ArmorComparator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/armor/ArmorComparator.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.utils.item.durability
 import net.ccbluex.liquidbounce.utils.item.equipmentSlot
 import net.ccbluex.liquidbounce.utils.item.getEnchantment
 import net.ccbluex.liquidbounce.utils.item.getEnchantmentCount
+import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.utils.sorting.ComparatorChain
 import net.ccbluex.liquidbounce.utils.sorting.compareByCondition
 import net.minecraft.core.component.DataComponents
@@ -34,6 +35,28 @@ import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.enchantment.Enchantment
 import net.minecraft.world.item.enchantment.Enchantments
+
+/**
+ * Decides how [ArmorComparator] ranks armor pieces.
+ */
+enum class ArmorComparatorMode(override val tag: String) : Tagged {
+    /**
+     * The original, damage-model based ranking. It weighs every damage-reduction enchantment
+     * (Protection, Projectile-, Fire- and Blast Protection) into a single reduction value, using the
+     * toughness-aware 1.9+ damage formula. Kept for backwards compatibility and modern survival.
+     */
+    SMART("Smart"),
+
+    /**
+     * SkyWars/BedWars oriented ranking built on the legacy (1.8) armor model where one armor point is a
+     * flat 4% reduction with no toughness and no damage-strength scaling. Only relevant enchantments
+     * influence the choice (Protection always, Projectile Protection optionally). Niche enchantments
+     * (Fire/Blast Protection, Thorns, Unbreaking, ...) never out-weigh real defense - they only act as a
+     * final tie-breaker. This stops the module from picking, say, iron with high Fire Protection over
+     * plain diamond.
+     */
+    RAW_DEFENSE("RawDefense")
+}
 
 @JvmRecord
 data class ArmorParameter(val defensePoints: Float, val toughness: Float) {
@@ -101,7 +124,9 @@ value class ArmorKitParameters private constructor(
 class ArmorComparator(
     private val expectedDamage: Float,
     private val armorKitParametersForSlot: ArmorKitParameters,
-    private val durabilityThreshold : Int = Int.MIN_VALUE
+    private val durabilityThreshold : Int = Int.MIN_VALUE,
+    private val mode: ArmorComparatorMode = ArmorComparatorMode.SMART,
+    private val considerProjectileProtection: Boolean = true
 ) : Comparator<ArmorPiece> {
     companion object {
         private val DAMAGE_REDUCTION_ENCHANTMENTS: Array<ResourceKey<Enchantment>> = arrayOf(
@@ -120,9 +145,34 @@ class ArmorComparator(
             Enchantments.UNBREAKING
         )
         private val OTHER_ENCHANTMENT_PER_LEVEL = floatArrayOf(3.0f, 1.0f, 0.1f, 0.05f, 0.01f)
+
+        /**
+         * Legacy (1.8) armor model: one armor point reduces incoming damage by a flat 4%, capped at 80%.
+         * There is no toughness and no damage-strength scaling.
+         */
+        private const val LEGACY_REDUCTION_PER_POINT = 0.04f
+        private const val LEGACY_REDUCTION_CAP = 0.8f
+
+        /**
+         * Effective Protection Factor (EPF) modifiers used by the legacy enchantment-protection formula.
+         * Protection is weak per level, Projectile Protection has a higher modifier.
+         * See https://minecraft.wiki/w/Armor#Enchantments (pre-1.9 mechanics).
+         */
+        private const val PROTECTION_EPF_MODIFIER = 0.75f
+        private const val PROJECTILE_PROTECTION_EPF_MODIFIER = 1.5f
+        private const val EPF_REDUCTION_PER_POINT = 0.04f
     }
 
-    private val comparator = ComparatorChain(
+    private val comparator = when (mode) {
+        ArmorComparatorMode.SMART -> smartComparator()
+        ArmorComparatorMode.RAW_DEFENSE -> rawDefenseComparator()
+    }
+
+    override fun compare(o1: ArmorPiece, o2: ArmorPiece): Int {
+        return this.comparator.compare(o1, o2)
+    }
+
+    private fun smartComparator() = ComparatorChain(
         compareBy { it.itemSlot.itemStack.durability > durabilityThreshold },
         compareByDescending { getThresholdedDamageReduction(it.itemSlot.itemStack).roundToDecimalPlaces(3) },
         compareBy { getEnchantmentThreshold(it.itemSlot.itemStack).roundToDecimalPlaces(3) },
@@ -132,8 +182,61 @@ class ArmorComparator(
         compareByCondition(ArmorPiece::isReachableByHand)
     )
 
-    override fun compare(o1: ArmorPiece, o2: ArmorPiece): Int {
-        return this.comparator.compare(o1, o2)
+    /**
+     * SkyWars/BedWars oriented ranking. The dominating criterion is the legacy total damage reduction
+     * (raw armor points plus only the relevant protection enchantments). Niche enchantments never out-rank
+     * real defense - they merely break ties.
+     */
+    private fun rawDefenseComparator() = ComparatorChain(
+        compareBy { it.itemSlot.itemStack.durability > durabilityThreshold },
+        // maxWithOrNull picks the greatest element, so higher reduction must compare as greater (ascending).
+        compareBy { getLegacyDamageReduction(it.itemSlot.itemStack).roundToDecimalPlaces(4) },
+        compareBy { it.itemSlot.itemStack.getEnchantment(Enchantments.PROTECTION) },
+        compareBy { getEnchantmentThreshold(it.itemSlot.itemStack).roundToDecimalPlaces(3) },
+        compareBy { it.itemSlot.itemStack.getEnchantmentCount() },
+        compareBy { it.itemSlot.itemStack.get(DataComponents.ENCHANTABLE)?.value ?: 0 },
+        compareByCondition(ArmorPiece::isAlreadyEquipped),
+        compareByCondition(ArmorPiece::isReachableByHand)
+    )
+
+    /**
+     * Total damage reduction of a piece (together with the rest of the kit) under the legacy 1.8 model.
+     *
+     * Armor points give a flat 4% each (capped at 80%). On top of that only [Enchantments.PROTECTION] and -
+     * when [considerProjectileProtection] is enabled - [Enchantments.PROJECTILE_PROTECTION] are applied to the
+     * remaining damage. Fire/Blast Protection and any non-defensive enchantments are ignored on purpose so they
+     * can never beat actual armor points.
+     */
+    fun getLegacyDamageReduction(itemStack: ItemStack): Float {
+        val parameters = this.armorKitParametersForSlot.getParametersForSlot(itemStack.equipmentSlot!!)
+        val totalArmorPoints = parameters.defensePoints + itemStack.armorValue!!.toFloat()
+
+        val armorReduction = (totalArmorPoints * LEGACY_REDUCTION_PER_POINT).coerceAtMost(LEGACY_REDUCTION_CAP)
+
+        val protectionLevel = itemStack.getEnchantment(Enchantments.PROTECTION)
+        var enchantReduction = legacyEpfReduction(protectionLevel, PROTECTION_EPF_MODIFIER)
+
+        if (considerProjectileProtection) {
+            val projectileLevel = itemStack.getEnchantment(Enchantments.PROJECTILE_PROTECTION)
+            // Combine multiplicatively: protection enchantments stack on the remaining damage.
+            val projectileReduction = legacyEpfReduction(projectileLevel, PROJECTILE_PROTECTION_EPF_MODIFIER)
+            enchantReduction = 1f - (1f - enchantReduction) * (1f - projectileReduction)
+        }
+
+        // Enchantments apply to the damage that survives the armor points, capped at 80% total.
+        val total = 1f - (1f - armorReduction) * (1f - enchantReduction)
+
+        return total.coerceAtMost(LEGACY_REDUCTION_CAP)
+    }
+
+    private fun legacyEpfReduction(level: Int, modifier: Float): Float {
+        if (level <= 0) {
+            return 0f
+        }
+
+        val epf = Math.floor(((6 + level * level) * modifier / 3.0)).toInt()
+
+        return (epf * EPF_REDUCTION_PER_POINT).coerceAtMost(LEGACY_REDUCTION_CAP)
     }
 
     private fun getThresholdedDamageReduction(itemStack: ItemStack): Float {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/armor/ArmorEvaluation.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/item/armor/ArmorEvaluation.kt
@@ -33,7 +33,9 @@ object ArmorEvaluation {
 
     fun findBestArmorPieces(
         slots: List<ItemSlot> = Slots.All,
-        durabilityThreshold: Int = Int.MIN_VALUE
+        durabilityThreshold: Int = Int.MIN_VALUE,
+        mode: ArmorComparatorMode = ArmorComparatorMode.SMART,
+        considerProjectileProtection: Boolean = true
     ): Map<EquipmentSlot, ArmorPiece?> {
         val armorPiecesGroupedByType = groupArmorByType(slots)
 
@@ -44,7 +46,8 @@ object ArmorEvaluation {
 
         // Run some passes in which we try to find best armor pieces based on the parameters of the last pass
         repeat(2) {
-            val comparator = getArmorComparatorFor(currentBestPieces, durabilityThreshold)
+            val comparator =
+                getArmorComparatorFor(currentBestPieces, durabilityThreshold, mode, considerProjectileProtection)
 
             currentBestPieces.clear()
             armorPiecesGroupedByType.mapValuesTo(currentBestPieces) { it.value.maxWithOrNull(comparator) }
@@ -80,19 +83,31 @@ object ArmorEvaluation {
 
     fun getArmorComparatorFor(
         currentKit: Map<EquipmentSlot, ArmorPiece?>,
-        durabilityThreshold: Int = Int.MIN_VALUE
+        durabilityThreshold: Int = Int.MIN_VALUE,
+        mode: ArmorComparatorMode = ArmorComparatorMode.SMART,
+        considerProjectileProtection: Boolean = true
     ): ArmorComparator {
         return getArmorComparatorForParameters(
             ArmorKitParameters.getParametersForSlots(currentKit),
-            durabilityThreshold
+            durabilityThreshold,
+            mode,
+            considerProjectileProtection
         )
     }
 
     fun getArmorComparatorForParameters(
         currentParameters: ArmorKitParameters,
-        durabilityThreshold: Int = Int.MIN_VALUE
+        durabilityThreshold: Int = Int.MIN_VALUE,
+        mode: ArmorComparatorMode = ArmorComparatorMode.SMART,
+        considerProjectileProtection: Boolean = true
     ): ArmorComparator {
-        return ArmorComparator(EXPECTED_DAMAGE, currentParameters, durabilityThreshold)
+        return ArmorComparator(
+            EXPECTED_DAMAGE,
+            currentParameters,
+            durabilityThreshold,
+            mode,
+            considerProjectileProtection
+        )
     }
 
 


### PR DESCRIPTION
## Summary

AutoArmor's default ranking weighs every damage-reduction enchantment — including Fire Protection and Blast Protection — into a single, modern (toughness-aware) damage value. On legacy **1.8** servers (e.g. Hypixel SkyWars/BedWars) this is misleading: those enchantments are treated as if they reduced *all* incoming damage, so the module can rank, for example, **iron with high Fire Protection above plain diamond**, even though the diamond is objectively better there.

This PR adds a **Mode** selector to AutoArmor instead of changing the existing behaviour, so nobody's current setup regresses.

## Modes

- **Smart** *(default)* — the original behaviour, completely unchanged.
- **RawDefense** — ranks by total damage reduction under the legacy **1.8** model:
  - 1 armor point = a flat 4% reduction, capped at 80%, no toughness, no damage-strength scaling.
  - Only **Protection** and (optionally) **Projectile Protection** influence the ranking.
  - Niche enchantments (Fire/Blast Protection, Thorns, Unbreaking, …) only break exact ties, so they can never out-rank real armor.

### RawDefense option
- **ConsiderProjectileProtection** *(default on)* — when enabled, Projectile Protection acts as a deciding argument (useful on archer-heavy servers); when disabled it only matters when everything else is equal. It is shown only while RawDefense is selected.

## Compatibility

The new `mode` and `considerProjectileProtection` are threaded through `ArmorEvaluation` with `SMART` as the default, so **InvCleaner** and **AutoArmorSaveArmor** keep their exact current behaviour — only AutoArmor reads the new selector.

## Testing
- `./gradlew compileKotlin` — passes.
- `./gradlew detekt` — passes.