### PR TITLE
fix(autoshop): fail fast on invalid tier format instead of silent fallback to 0

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/TierItemUtils.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/autoshop/TierItemUtils.kt
@@ -33,7 +33,10 @@ fun String.autoShopItemTier() : Int {
     }
 
     // example: sword:tier:2 -> 2
-    return this.split(TIER_ID)[1].toIntOrNull() ?: 0
+    val tierPart = this.split(TIER_ID)[1]
+    val tier = tierPart.toIntOrNull()
+        ?: throw IllegalArgumentException("Invalid tier format in item '$this': expected numeric tier after '$TIER_ID'")
+    return tier
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace silent fallback `toIntOrNull() ?: 0` with explicit validation in `TierItemUtils.autoShopItemTier()`
- Throw `IllegalArgumentException` with clear message when the tier value is not a valid integer

## Motivation

Previously, an invalid item name like `sword:tier:abc` would silently resolve to tier `0`, masking data issues and making debugging harder.

## Test plan

Test with an item containing a non-numeric tier segment and confirm a clear exception is thrown.