### PR TITLE
refactor(interop): centralize REST marketplace ID validation in HttpHelper

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
@@ -30,6 +30,15 @@ import net.ccbluex.liquidbounce.features.marketplace.MarketplaceManager
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.netty.http.routing.Routing
 
+
+/**
+ * Extract a required integer path parameter or respond with 403 Forbidden
+ */
+suspend fun ApplicationCall.requireId(parameter: String = "id"): Int {
+    return parameters[parameter]?.toIntOrNull() ?: forbidden("Invalid $parameter")
+}
+
+
 /**
  * GET /api/v1/marketplace
  *
@@ -62,7 +71,7 @@ private fun Routing.getMarketplaceItems() = get {
  * GET /api/v1/marketplace/:id
  */
 private fun Routing.getMarketplaceItem() = get {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
 
     val item = MarketplaceApi.getMarketplaceItem(id)
     call.respond(JsonObject().apply {
@@ -76,7 +85,7 @@ private fun Routing.getMarketplaceItem() = get {
  * GET /api/v1/marketplace/:id/revisions
  */
 private fun Routing.getMarketplaceItemRevisions() = get {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
     val page = call.queryParameters.getOrDefault("page", "1").toInt()
     val limit = call.queryParameters.getOrDefault("limit", "10").toInt()
 
@@ -88,9 +97,8 @@ private fun Routing.getMarketplaceItemRevisions() = get {
  * GET /api/v1/marketplace/:id/revisions/:revisionId
  */
 private fun Routing.getMarketplaceItemRevision() = get("/:revisionId") {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
-    val revisionId = call.parameters["revisionId"]?.toIntOrNull()
-        ?: call.forbidden("Invalid revision ID")
+    val id = call.requireId()
+    val revisionId = call.requireId("revisionId")
 
     val response = MarketplaceApi.getMarketplaceItemRevision(id, revisionId)
     call.respond(response, interopGson)
@@ -100,7 +108,7 @@ private fun Routing.getMarketplaceItemRevision() = get("/:revisionId") {
  * POST /api/v1/marketplace/:id/subscribe
  */
 private fun Routing.subscribeMarketplaceItem() = post("/subscribe") {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
 
     if (MarketplaceManager.isSubscribed(id)) {
         call.forbidden("Already subscribed")
@@ -130,7 +138,7 @@ private fun Routing.subscribeMarketplaceItem() = post("/subscribe") {
  * POST /api/v1/marketplace/:id/unsubscribe
  */
 private fun Routing.unsubscribeMarketplaceItem() = post("/unsubscribe") {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
 
     if (!MarketplaceManager.isSubscribed(id)) {
         call.forbidden("Not subscribed")
@@ -149,7 +157,7 @@ private fun Routing.unsubscribeMarketplaceItem() = post("/unsubscribe") {
  * GET /api/v1/marketplace/:id/reviews
  */
 private fun Routing.getMarketplaceItemReviews() = get {
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
     val page = call.queryParameters.getOrDefault("page", "1").toInt()
     val limit = call.queryParameters.getOrDefault("limit", "10").toInt()
 
@@ -166,7 +174,7 @@ private fun Routing.postMarketplaceItemReview() = post {
         val comment: String
     )
 
-    val id = call.parameters["id"]?.toIntOrNull() ?: call.forbidden("Invalid ID")
+    val id = call.requireId()
     val review = call.body.let { interopGson.fromJson(it, MarketplaceReview::class.java) }
         ?: call.forbidden("Invalid review data")
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
@@ -29,6 +29,7 @@ import net.ccbluex.liquidbounce.features.cosmetic.ClientAccountManager
 import net.ccbluex.liquidbounce.features.marketplace.MarketplaceManager
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.netty.http.routing.Routing
+import net.ccbluex.netty.http.application.ApplicationCall
 
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
@@ -36,7 +36,7 @@ import net.ccbluex.netty.http.application.ApplicationCall
  * Extract a required integer path parameter or respond with 403 Forbidden
  */
 private suspend fun ApplicationCall.requireId(parameter: String = "id"): Int {
-    return parameters[parameter]?.toIntOrNull() ?: forbidden("Invalid $parameter")
+    return parameters[parameter]?.toIntOrNull() ?: forbidden("Invalid $parameter: ${parameters[parameter]}")
 }
 
 /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/MarketplaceFunctions.kt
@@ -35,10 +35,9 @@ import net.ccbluex.netty.http.application.ApplicationCall
 /**
  * Extract a required integer path parameter or respond with 403 Forbidden
  */
-suspend fun ApplicationCall.requireId(parameter: String = "id"): Int {
+private suspend fun ApplicationCall.requireId(parameter: String = "id"): Int {
     return parameters[parameter]?.toIntOrNull() ?: forbidden("Invalid $parameter")
 }
-
 
 /**
  * GET /api/v1/marketplace


### PR DESCRIPTION
This PR centralizes REST marketplace ID validation in `HttpHelper`.

- The `requireId` helper has been moved to `MarketplaceFunctions.kt`
- Manual parameter parsing in marketplace routes has been replaced with the centralized `requireId()` extension
- All commits have been corrected to reflect the proper authorship

---

**Note:** Previous PR #8532 was closed by mistake. This PR replaces it with the same corrected content. Sorry for the confusion.

All related review issues have been fixed (including moving `requireId` back into `MarketplaceFunctions.kt`).
