### PR TITLE
fix(#8440): improve IRC auth error handling with retry mechanism

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/chat/AxochatClient.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/chat/AxochatClient.kt
@@ -283,8 +283,10 @@ class AxochatClient {
                     )
                 }.onFailure { cause ->
                     if (cause is InvalidCredentialsException) {
+                        logger.warn("Authentication to LiquidChat failed - credentials may be expired")
                         EventManager.callEvent(ClientChatStateChange(ClientChatStateChange.State.AUTHENTICATION_FAILED))
                     } else {
+                        logger.error("LiquidChat authentication error", cause)
                         EventManager.callEvent(ClientChatErrorEvent(
                             cause.localizedMessage ?: cause.message ?: cause.javaClass.name
                         ))

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/global/GlobalSettingsClientChat.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/global/GlobalSettingsClientChat.kt
@@ -79,6 +79,13 @@ object GlobalSettingsClientChat : ToggleableValueGroup(
     private val autoTranslate by multiEnumChoice<ClientChatMessageEvent.ChatGroup>("AutoTranslate")
 
     private val chatClient = AxochatClient()
+
+    /**
+     * Tracks authentication retry attempts. Reset on successful login or reconnect.
+     */
+    private var authRetryCount = 0
+    private const val MAX_AUTH_RETRIES = 3
+    private val AUTH_RETRY_DELAYS = longArrayOf(3_000L, 8_000L, 15_000L)
     private val prefix: Component = "".asText()
         .withStyle(ChatFormatting.RESET).withStyle(ChatFormatting.GRAY)
         .append(this.name.asPlainText(ChatFormatting.BLUE))
@@ -169,6 +176,7 @@ object GlobalSettingsClientChat : ToggleableValueGroup(
 
     @Suppress("unused")
     private val sessionChange = suspendHandler<SessionEvent>(behavior = CancelPrevious) {
+        authRetryCount = 0
         chatClient.reconnect()
     }
 
@@ -246,6 +254,7 @@ object GlobalSettingsClientChat : ToggleableValueGroup(
                 }
             }
             ClientChatStateChange.State.LOGGED_IN -> {
+                authRetryCount = 0
                 notification(
                     "LiquidChat",
                     translation("liquidbounce.liquidchat.states.loggedIn"),
@@ -265,7 +274,28 @@ object GlobalSettingsClientChat : ToggleableValueGroup(
                     translation("liquidbounce.liquidchat.authenticationFailed"),
                     NotificationEvent.Severity.ERROR
                 )
-                logger.warn("Failed authentication to LiquidChat")
+                logger.warn("Failed authentication to LiquidChat (attempt ${authRetryCount + 1}/$MAX_AUTH_RETRIES)")
+
+                if (authRetryCount < MAX_AUTH_RETRIES) {
+                    val delayMs = AUTH_RETRY_DELAYS[authRetryCount]
+                    authRetryCount++
+                    logger.info("Retrying authentication in ${delayMs / 1000}s...")
+                    eventListenerScope.launch {
+                        delay(delayMs)
+                        if (chatClient.isConnected && !chatClient.isLoggedIn) {
+                            chatClient.requestMojangLogin()
+                        }
+                    }
+                } else {
+                    chat(
+                        prefix,
+                        "Authentication failed after $MAX_AUTH_RETRIES attempts. ".asText()
+                            .withStyle(ChatFormatting.RED),
+                        "Try restarting the game or re-logging into your account.".asText()
+                            .withStyle(ChatFormatting.GRAY),
+                        metadata = exceptionData
+                    )
+                }
             }
 
             else -> {} // do not bother


### PR DESCRIPTION
## Summary

Might fix #8440 ? — LiquidChat authentication silently failed with "Not authenticated!" even for premium accounts.

## Changes

### AxochatClient.kt
- Added `logger.warn` for `InvalidCredentialsException` (was completely silent before).
- Added `logger.error` with full stacktrace for unexpected auth errors.

### GlobalSettingsClientChat.kt
- **Retry mechanism**: On auth failure, the client now retries `requestMojangLogin()` up to 3 times with exponential backoff (3s, 8s, 15s). This handles transient token expiration without user intervention.
- **User feedback**: Only after all retries are exhausted, a clear chat message is shown explaining the issue and suggesting a game restart.
- **State management**: `authRetryCount` is reset on successful login (`LOGGED_IN` state) and on session change (`SessionEvent`), so a fresh login attempt always starts clean.

## Why retry works

Minecraft auth service (`sessionService.joinServer`) validates the current access token against Mojang servers. Tokens can expire mid-session but get refreshed by the launcher in the background. A retry after a few seconds often succeeds because:
1. The launcher has refreshed the token by then.
2. Mojang auth servers may have had a transient hiccup.

After 3 failures (~26s total), the token is genuinely invalid and user action is required.

## Backoff schedule

| Attempt | Delay | Rationale |
|---------|-------|-----------|
| 1       | 3s    | Quick retry for transient network issues |
| 2       | 8s    | Allow token refresh to propagate |
| 3       | 15s   | Last chance before giving up |

---
*This PR was developed with AI assistance.*
