### PR TITLE
fix(combat): allow targeting friends when Players is disabled

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
@@ -110,7 +110,7 @@ private fun Set<Targets>.shouldAttack(entity: Entity): Boolean {
 
     return when {
         info.isFriend && Targets.FRIENDS !in this -> false
-        info.classification === EntityTargetClassification.TARGET -> isInteresting(entity)
+        info.classification === EntityTargetClassification.TARGET -> isInteresting(entity, info)
         else -> false
     }
 }
@@ -125,7 +125,7 @@ private fun Set<Targets>.shouldShow(entity: Entity): Boolean {
 
     return when {
         info.isFriend && Targets.FRIENDS !in this -> false
-        info.classification !== EntityTargetClassification.IGNORED -> isInteresting(entity)
+        info.classification !== EntityTargetClassification.IGNORED -> isInteresting(entity, info)
         else -> false
     }
 }
@@ -134,7 +134,7 @@ private fun Set<Targets>.shouldShow(entity: Entity): Boolean {
  * Check if an entity is considered a target
  */
 @Suppress("CyclomaticComplexMethod", "ReturnCount")
-private fun Set<Targets>.isInteresting(suspect: Entity): Boolean {
+private fun Set<Targets>.isInteresting(suspect: Entity, info: EntityTargetingInfo): Boolean {
     // Check if the enemy is living and not dead (or ignore being dead)
     if (suspect !is LivingEntity || !(Targets.DEAD in this || suspect.isAlive)) {
         return false
@@ -146,7 +146,6 @@ private fun Set<Targets>.isInteresting(suspect: Entity): Boolean {
     }
 
     // Check if enemy is a player and should be considered as a target
-    val info = EntityTaggingManager.getTag(suspect).targetingInfo
     return when (suspect) {
         is Player -> when {
             suspect === mc.player -> false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
@@ -146,12 +146,14 @@ private fun Set<Targets>.isInteresting(suspect: Entity): Boolean {
     }
 
     // Check if enemy is a player and should be considered as a target
+    val info = EntityTaggingManager.getTag(suspect).targetingInfo
     return when (suspect) {
         is Player -> when {
             suspect === mc.player -> false
             // Check if enemy is sleeping (or ignore being sleeping)
             suspect.isSleeping && Targets.SLEEPING !in this -> false
-            else -> Targets.PLAYERS in this
+            // Allow targeting friends even when Players is disabled, as long as Friends is enabled
+            else -> Targets.PLAYERS in this || (info.isFriend && Targets.FRIENDS in this)
         }
         is WaterAnimal -> Targets.WATER_CREATURE in this
         is AgeableMob, is Bat, is Allay -> Targets.PASSIVE in this


### PR DESCRIPTION
## Summary
Fixes #8518

Friends could never be targeted by combat modules (KillAura, AimAssist, etc.) if the `Players` target option was disabled, even when `Friends` was explicitly enabled in Global Settings > Targets.

## Root cause
In `CombatExtensions.kt`, the `shouldAttack()` function correctly allowed friends through when `Targets.FRIENDS` was in the set (line 112 only blocks friends when FRIENDS is *not* selected). However, it then delegated to `isInteresting()` which, for `Player` entities, *only* checked `Targets.PLAYERS in this` — meaning friends (who are players) were rejected.

## Fix
Added a secondary check in `isInteresting()` for the Player branch:
```kotlin
else -> Targets.PLAYERS in this || (info.isFriend && Targets.FRIENDS in this)
```

This allows friends to be targeted when:
- `Friends` is enabled in Targets, OR
- `Players` is enabled (existing behavior)

## Impact
- KillAura, AimAssist, and any module using `shouldBeAttacked()` can now target friends-only when configured
- ESP and any module using `shouldBeShown()` also benefits (same `isInteresting()` path)
- No behavior change when `Players` is already enabled

---
*This PR was created with AI assistance.*