### PR TITLE
fix(eagle): clamp pitch for NoPitchLimit compatibility

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/ModuleEagle.kt
@@ -99,7 +99,7 @@ object ModuleEagle : ClientModule(
             get() = enabled && Condition.SNEAK in conditions
 
         fun shouldSneak(event: MovementInputEvent) =
-            !enabled || player.xRot in pitch && conditions.matchesAll(event)
+            !enabled || player.xRot.coerceIn(-90f, 90f) in pitch && conditions.matchesAll(event)
 
         @Suppress("unused")
         private enum class Condition(override val tag: String) : Tagged, Predicate<MovementInputEvent> {


### PR DESCRIPTION
## Summary
Fixes #8189

Eagle module fails to activate when NoPitchLimit is enabled with `ServerSide=false`, because the player's pitch exceeds the expected ±90° range.

## Root cause
In `ModuleEagle.Conditional.shouldSneak()`, the pitch check:
```kotlin
player.xRot in pitch
```
compares the raw `xRot` value against the configured pitch range (default `-90..90`). When NoPitchLimit allows rotations beyond ±90° (e.g. looking at -120°), this check always fails, preventing Eagle from sneaking at edges.

## Fix
Clamp the pitch value before comparison:
```kotlin
player.xRot.coerceIn(-90f, 90f) in pitch
```

This way, any pitch beyond the normal range is treated as if it were at the boundary (which is the logical equivalent for "looking down/up"), allowing Eagle to function normally.

## Impact
- Eagle now works with NoPitchLimit enabled (both ServerSide modes)
- No behavior change when NoPitchLimit is disabled (pitch is always in [-90, 90] normally)

---
*This PR was created with AI assistance.*