### PR TITLE
feat(killaura): add KnockbackDisplacement feature

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -111,6 +111,7 @@ import net.ccbluex.liquidbounce.event.events.PlayerStrideEvent
 import net.ccbluex.liquidbounce.event.events.PlayerTickEvent
 import net.ccbluex.liquidbounce.event.events.PlayerUseMultiplier
 import net.ccbluex.liquidbounce.event.events.PlayerVelocityStrafe
+import net.ccbluex.liquidbounce.event.events.PostAttackEntityEvent
 import net.ccbluex.liquidbounce.event.events.ProxyCheckResultEvent
 import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
 import net.ccbluex.liquidbounce.event.events.ResourceReloadEvent
@@ -176,6 +177,7 @@ internal val ALL_EVENT_CLASSES: Array<Class<out Event>> = arrayOf(
     KeybindChangeEvent::class.java,
     KeybindIsPressedEvent::class.java,
     AttackEntityEvent::class.java,
+    PostAttackEntityEvent::class.java,
     SessionEvent::class.java,
     ScreenEvent::class.java,
     ChatSendEvent::class.java,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/EntityEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/EntityEvents.kt
@@ -35,6 +35,11 @@ class AttackEntityEvent(
     val entity: Entity
 ) : CancellableEvent()
 
+@Tag("postAttack")
+class PostAttackEntityEvent(
+    val entity: Entity
+) : Event()
+
 @Tag("entityMargin")
 class EntityMarginEvent(val entity: Entity, var margin: Float) : Event()
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -42,6 +42,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleFakeLag
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleHitbox
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleKeepSprint
+import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleKnockbackDisplacement
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleMaceKill
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleNoMissCooldown
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleSuperKnockback
@@ -480,6 +481,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleSwordBlock,
             ModuleAutoShoot,
             ModuleKeepSprint,
+            ModuleKnockbackDisplacement,
             ModuleMaceKill,
             ModuleNoMissCooldown,
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
@@ -23,7 +23,6 @@ import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
 import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
-import net.ccbluex.liquidbounce.event.events.PostAttackEntityEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleCategories
@@ -38,7 +37,7 @@ import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.CRITICAL_MO
 import net.ccbluex.liquidbounce.utils.math.allEmpty
 import net.ccbluex.liquidbounce.utils.network.sendStartSprinting
 import net.ccbluex.liquidbounce.utils.network.sendStopSprinting
-import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.PosRot
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
@@ -123,9 +122,6 @@ object ModuleKnockbackDisplacement : ClientModule(
 
     private var ticksSinceLastUse = 0
     
-    // Flag to track if we need to send return rotation after attack
-    private var shouldSendReturnRotation = false
-
     @Suppress("unused")
     private val tickHandler = handler<GameTickEvent> {
         if (ticksSinceLastUse > 0) {
@@ -148,10 +144,14 @@ object ModuleKnockbackDisplacement : ClientModule(
 
         val displacementRotation = getDisplacementRotation(target) ?: return@handler
 
-        // Send the displacement rotation packet BEFORE the attack
+        // Send the displacement rotation as PosRot with current position
+        // (avoids timer flag vs. Rot-only packet; abuses 1.17+ desync duplicate acceptance)
         val fixedRotation = displacementRotation.normalize()
         network.send(
-            ServerboundMovePlayerPacket.Rot(
+            PosRot(
+                player.x,
+                player.y,
+                player.z,
                 fixedRotation.yaw,
                 fixedRotation.pitch,
                 player.onGround(),
@@ -159,32 +159,12 @@ object ModuleKnockbackDisplacement : ClientModule(
             )
         )
 
-        // Mark that we need to send return rotation after attack
-        shouldSendReturnRotation = true
-
         // Start cooldown
         ticksSinceLastUse = cooldownTicks
     }
 
-    /**
-     * Handle post-attack event - send return rotation AFTER the attack packet was sent.
-     * Fired from CombatExtensions.attackEntity() after ServerboundAttackPacket.
-     */
-    @Suppress("unused")
-    private val postAttackHandler = handler<PostAttackEntityEvent> {
-        if (!shouldSendReturnRotation) return@handler
-        
-        shouldSendReturnRotation = false
-        
-        // Send player's actual rotation back to avoid detection
-        network.send(
-            ServerboundMovePlayerPacket.Rot(
-                player.yRot,
-                player.xRot,
-                player.onGround(),
-                player.horizontalCollision
-            )
-        )
+    override fun onEnabled() {
+        ticksSinceLastUse = 0
     }
 
     /**
@@ -280,15 +260,6 @@ object ModuleKnockbackDisplacement : ClientModule(
         }
 
         return true
-    }
-
-    override fun onEnabled() {
-        ticksSinceLastUse = 0
-        shouldSendReturnRotation = false
-    }
-
-    override fun onDisabled() {
-        shouldSendReturnRotation = false
     }
 
     private sealed class DisplacementMode(name: String, override val parent: ModeValueGroup<*>) : Mode(name) {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
@@ -68,10 +68,9 @@ object ModuleKnockbackDisplacement : ClientModule(
 
     private val modes = choices<DisplacementMode>("Mode", 0) {
         arrayOf(
-            DisplacementMode.Push(it),
+            DisplacementMode.Left(it),
+            DisplacementMode.Right(it),
             DisplacementMode.Pull(it),
-            DisplacementMode.Upward(it),
-            DisplacementMode.Horizontal(it),
             DisplacementMode.Custom(it)
         )
     }.apply(::tagBy)
@@ -271,24 +270,19 @@ object ModuleKnockbackDisplacement : ClientModule(
          */
         abstract fun computeRawRotation(yawToTarget: Float): Vec2
 
-        /** Push target away from player (normal direction, useful as baseline). */
-        class Push(parent: ModeValueGroup<*>) : DisplacementMode("Push", parent) {
-            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget, player.xRot)
+        /** Push target to the left (perpendicular, counterclockwise). */
+        class Left(parent: ModeValueGroup<*>) : DisplacementMode("Left", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget + 90f, player.xRot)
+        }
+
+        /** Push target to the right (perpendicular, clockwise). */
+        class Right(parent: ModeValueGroup<*>) : DisplacementMode("Right", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget - 90f, player.xRot)
         }
 
         /** Pull target toward player (vacuum effect). */
         class Pull(parent: ModeValueGroup<*>) : DisplacementMode("Pull", parent) {
             override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget + 180f, player.xRot)
-        }
-
-        /** Launch target upward. */
-        class Upward(parent: ModeValueGroup<*>) : DisplacementMode("Upward", parent) {
-            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget, -70f)
-        }
-
-        /** Push target sideways (perpendicular to player-target line). */
-        class Horizontal(parent: ModeValueGroup<*>) : DisplacementMode("Horizontal", parent) {
-            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget + 90f, player.xRot)
         }
 
         /** Custom yaw/pitch offset from player-to-target direction. */

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleKnockbackDisplacement.kt
@@ -1,0 +1,332 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat
+
+import net.ccbluex.liquidbounce.config.types.group.Mode
+import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
+import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
+import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
+import net.ccbluex.liquidbounce.event.events.GameTickEvent
+import net.ccbluex.liquidbounce.event.events.PostAttackEntityEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.ModuleCategories
+import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.ModuleKillAura
+import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
+import net.ccbluex.liquidbounce.utils.aiming.utils.RotationUtil
+import net.ccbluex.liquidbounce.utils.client.network
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.client.world
+import net.ccbluex.liquidbounce.utils.entity.rotation
+import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention.CRITICAL_MODIFICATION
+import net.ccbluex.liquidbounce.utils.math.allEmpty
+import net.ccbluex.liquidbounce.utils.network.sendStartSprinting
+import net.ccbluex.liquidbounce.utils.network.sendStopSprinting
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket
+import net.minecraft.util.Mth
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.item.Items
+import net.minecraft.world.phys.AABB
+import net.minecraft.world.phys.Vec2
+import kotlin.math.atan2
+import kotlin.math.roundToInt
+
+/**
+ * Knockback Displacement module.
+ *
+ * Manipulates the rotation sent before an attack to control the direction of
+ * sprint-knockback dealt to the target. The server calculates sprint-KB as:
+ *   knockback(0.5, -sin(attackerYaw * DEG_TO_RAD), cos(attackerYaw * DEG_TO_RAD))
+ *
+ * Works standalone or with KillAura. Can optionally detect void
+ * behind the target to only activate in bridge fight scenarios.
+ *
+ * Reference: https://www.youtube.com/watch?v=7t0PyqYsac8
+ */
+@Suppress("MagicNumber")
+object ModuleKnockbackDisplacement : ClientModule(
+    "KnockbackDisplacement",
+    ModuleCategories.COMBAT,
+    aliases = listOf("KBDisplacement", "KnockbackDirection")
+) {
+
+    private val modes = choices<DisplacementMode>("Mode", 0) {
+        arrayOf(
+            DisplacementMode.Push(it),
+            DisplacementMode.Pull(it),
+            DisplacementMode.Upward(it),
+            DisplacementMode.Horizontal(it),
+            DisplacementMode.Custom(it)
+        )
+    }.apply(::tagBy)
+
+    private val cooldownTicks by int("Cooldown", 0, 0..40, "ticks")
+
+    /**
+     * Sends sprint packets before each attack to ensure the server considers the player
+     * as sprinting. Required when using Sprint module in Legit mode, which only sets
+     * client-side sprint state without notifying the server after sprint-knockback resets it.
+     */
+    private val forceSprint by boolean("ForceSprint", false)
+
+    /**
+     * Only apply displacement when attacking via KillAura.
+     * When disabled, works with manual attacks too.
+     */
+    private val onlyKillAura by boolean("OnlyKillAura", false)
+
+    /**
+     * Only apply displacement when using a stick (blaze rod, stick).
+     * Useful for BedWars KB sticks.
+     */
+    private val onlyStick by boolean("OnlyStick", false)
+
+    // Void detection sub-group
+    private object VoidDetection : ToggleableValueGroup(ModuleKnockbackDisplacement, "VoidDetection", false) {
+        /**
+         * Maximum FOV angle (in degrees) for void detection.
+         * Only activates when the void direction is within this angle from player's view.
+         */
+        val maxFov by float("MaxFOV", 90f, 0f..180f, "°")
+
+        /**
+         * How far ahead (in blocks) to check for void behind the target.
+         */
+        val checkDistance by float("CheckDistance", 3f, 1f..10f, "blocks")
+
+        /**
+         * The Y level below which is considered void.
+         */
+        val voidLevel by int("VoidLevel", 0, -64..0)
+    }
+
+    init {
+        tree(VoidDetection)
+    }
+
+    private var ticksSinceLastUse = 0
+    
+    // Flag to track if we need to send return rotation after attack
+    private var shouldSendReturnRotation = false
+
+    @Suppress("unused")
+    private val tickHandler = handler<GameTickEvent> {
+        if (ticksSinceLastUse > 0) {
+            ticksSinceLastUse--
+        }
+    }
+
+    /**
+     * Handle attack event - inject displacement rotation BEFORE the attack packet is sent.
+     * This runs at HEAD of MultiPlayerGameMode.attack() via Mixin.
+     */
+    @Suppress("unused")
+    private val attackHandler = handler<AttackEntityEvent>(priority = CRITICAL_MODIFICATION) { event ->
+        val target = event.entity
+
+        // Check if we should operate
+        if (!shouldOperate(target)) {
+            return@handler
+        }
+
+        val displacementRotation = getDisplacementRotation(target) ?: return@handler
+
+        // Send the displacement rotation packet BEFORE the attack
+        val fixedRotation = displacementRotation.normalize()
+        network.send(
+            ServerboundMovePlayerPacket.Rot(
+                fixedRotation.yaw,
+                fixedRotation.pitch,
+                player.onGround(),
+                player.horizontalCollision
+            )
+        )
+
+        // Mark that we need to send return rotation after attack
+        shouldSendReturnRotation = true
+
+        // Start cooldown
+        ticksSinceLastUse = cooldownTicks
+    }
+
+    /**
+     * Handle post-attack event - send return rotation AFTER the attack packet was sent.
+     * Fired from CombatExtensions.attackEntity() after ServerboundAttackPacket.
+     */
+    @Suppress("unused")
+    private val postAttackHandler = handler<PostAttackEntityEvent> {
+        if (!shouldSendReturnRotation) return@handler
+        
+        shouldSendReturnRotation = false
+        
+        // Send player's actual rotation back to avoid detection
+        network.send(
+            ServerboundMovePlayerPacket.Rot(
+                player.yRot,
+                player.xRot,
+                player.onGround(),
+                player.horizontalCollision
+            )
+        )
+    }
+
+    /**
+     * Computes the displacement rotation for the given target.
+     * Returns a GCD-normalized [Rotation] to send before the attack, or null if
+     * displacement should not be applied.
+     */
+    private fun getDisplacementRotation(target: Entity): Rotation? {
+        if (ticksSinceLastUse > 0) return null
+
+        // Sprint-knockback only applies when sprinting
+        if (!player.isSprinting) return null
+
+        // Void detection check
+        if (VoidDetection.enabled && !isVoidBehindTarget(target)) {
+            return null
+        }
+
+        val dx = target.x - player.x
+        val dz = target.z - player.z
+        // Yaw pointing FROM player TO target (vanilla convention: atan2(-dx, dz))
+        val yawToTarget = Math.toDegrees(atan2(-dx, dz)).toFloat()
+
+        val rawRotation = modes.activeMode.computeRawRotation(yawToTarget)
+
+        // Normalize to GCD to avoid anticheat detection
+        val gcd = RotationUtil.gcd.toFloat().coerceAtLeast(0.001f)
+        val yaw = Mth.wrapDegrees((rawRotation.x / gcd).roundToInt() * gcd)
+        val pitch = Mth.clamp((rawRotation.y / gcd).roundToInt() * gcd, -90f, 90f)
+
+        // Force sprint packets if enabled (needed for Sprint module Legit mode)
+        if (forceSprint && player.isSprinting) {
+            network.sendStopSprinting()
+            network.sendStartSprinting()
+        }
+
+        return Rotation(yaw, pitch)
+    }
+
+    /**
+     * Checks if there's void behind the target in the knockback direction.
+     * Also validates that the void direction is within the configured FOV.
+     */
+    private fun isVoidBehindTarget(target: Entity): Boolean {
+        val dx = target.x - player.x
+        val dz = target.z - player.z
+
+        // Direction FROM player TO target (knockback push direction)
+        val distance = Mth.sqrt((dx * dx + dz * dz).toFloat()).toDouble()
+        if (distance < 0.01) return false
+
+        val dirX = dx / distance
+        val dirZ = dz / distance
+
+        // Check the FOV constraint
+        val yawToVoid = Math.toDegrees(atan2(-dirX, dirZ)).toFloat()
+        val voidRotation = Rotation(yawToVoid, 0f)
+        val angleToVoid = player.rotation.angleTo(voidRotation)
+
+        if (angleToVoid > VoidDetection.maxFov) {
+            return false
+        }
+
+        // Check for void behind the target
+        val checkDist = VoidDetection.checkDistance.toDouble()
+        val checkX = target.x + dirX * checkDist
+        val checkZ = target.z + dirZ * checkDist
+        val checkY = target.y
+
+        // Create a bounding box from target position extending down to void level
+        val checkBox = AABB(
+            checkX - 0.3, VoidDetection.voidLevel.toDouble(), checkZ - 0.3,
+            checkX + 0.3, checkY, checkZ + 0.3
+        )
+
+        // If no collisions found between check position and void level, there's void
+        return world.getBlockCollisions(player, checkBox).allEmpty()
+    }
+
+    private fun shouldOperate(target: Entity): Boolean {
+        if (target !is LivingEntity) return false
+
+        // Check OnlyKillAura setting
+        if (onlyKillAura && !ModuleKillAura.running) {
+            return false
+        }
+
+        // Check OnlyStick setting (blaze rod, stick items for BedWars KB sticks)
+        if (onlyStick) {
+            val item = player.mainHandItem.item
+            val isStick = item == Items.BLAZE_ROD || item == Items.STICK
+            if (!isStick) return false
+        }
+
+        return true
+    }
+
+    override fun onEnabled() {
+        ticksSinceLastUse = 0
+        shouldSendReturnRotation = false
+    }
+
+    override fun onDisabled() {
+        shouldSendReturnRotation = false
+    }
+
+    private sealed class DisplacementMode(name: String, override val parent: ModeValueGroup<*>) : Mode(name) {
+
+        /**
+         * Computes the raw (un-normalized) rotation for the displacement.
+         * @param yawToTarget yaw from player to target in degrees
+         * @return Vec2(yaw, pitch) for the displacement rotation
+         */
+        abstract fun computeRawRotation(yawToTarget: Float): Vec2
+
+        /** Push target away from player (normal direction, useful as baseline). */
+        class Push(parent: ModeValueGroup<*>) : DisplacementMode("Push", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget, player.xRot)
+        }
+
+        /** Pull target toward player (vacuum effect). */
+        class Pull(parent: ModeValueGroup<*>) : DisplacementMode("Pull", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget + 180f, player.xRot)
+        }
+
+        /** Launch target upward. */
+        class Upward(parent: ModeValueGroup<*>) : DisplacementMode("Upward", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget, -70f)
+        }
+
+        /** Push target sideways (perpendicular to player-target line). */
+        class Horizontal(parent: ModeValueGroup<*>) : DisplacementMode("Horizontal", parent) {
+            override fun computeRawRotation(yawToTarget: Float) = Vec2(yawToTarget + 90f, player.xRot)
+        }
+
+        /** Custom yaw/pitch offset from player-to-target direction. */
+        class Custom(parent: ModeValueGroup<*>) : DisplacementMode("Custom", parent) {
+            private val customYaw by float("CustomYaw", 0f, -180f..180f, "°")
+            private val customPitch by float("CustomPitch", 0f, -90f..90f, "°")
+
+            override fun computeRawRotation(yawToTarget: Float) =
+                Vec2(yawToTarget + customYaw, player.xRot + customPitch)
+        }
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/KillAuraClicker.kt
@@ -112,8 +112,14 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
      * - Closing the inventory if we are simulating inventory closing
      * - Unblocking if we are blocking and the tick on is 0
      */
+    /**
+     * @param rotation The rotation to send before the attack (e.g., knockback displacement).
+     * @param returnRotation The rotation to return to after the attack. If null, uses [rotation].
+     *   This is useful for knockback displacement where we want to send a custom rotation
+     *   before the attack but return to the target rotation after.
+     */
     @Suppress("CognitiveComplexMethod")
-    fun prepareForAttack(rotation: Rotation? = null, attack: () -> Boolean) {
+    fun prepareForAttack(rotation: Rotation? = null, returnRotation: Rotation? = null, attack: () -> Boolean) {
         if (!canExecuteClickNow()) {
             // If we are not going to click, we don't need to prepare the environment
             return
@@ -162,15 +168,16 @@ object KillAuraClicker : Clicker<ModuleKillAura>(
         // Run the attack
         click(attack)
 
-        // 1. Rotate back
+        // 1. Rotate back (to target rotation if provided, otherwise based on attack rotation)
         if (rotationTiming == KillAuraRotationsValueGroup.KillAuraRotationTiming.ON_TICK && rotation != null) {
+            val backRotation = returnRotation ?: rotation
             network.send(
                 PosRot(
                     player.x,
                     player.y,
                     player.z,
-                    player.withFixedYaw(rotation),
-                    player.xRot,
+                    player.withFixedYaw(backRotation),
+                    backRotation.pitch,
                     player.onGround(),
                     player.horizontalCollision
                 )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/killaura/ModuleKillAura.kt
@@ -40,6 +40,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFailSwing
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFailSwing.dealWithFakeSwing
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraFightBot
+
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.failedHits
 import net.ccbluex.liquidbounce.features.module.modules.combat.killaura.features.KillAuraNotifyWhenFail.renderFailedHits
@@ -280,7 +281,7 @@ object ModuleKillAura : ClientModule("KillAura", ModuleCategories.COMBAT) {
         // Attack enemy, according to the attack scheduler
         if (clicker.isClickTick && canAttackNow(target, mainHandStack) &&
             !KillAuraAutoBlock.isPrioritizingBlocking) {
-            clicker.prepareForAttack(rotation) {
+            clicker.prepareForAttack(rotation, null) {
                 // On each click, we check if we are still ready to attack
                 if (!canAttackNow(target, mainHandStack)) {
                     return@prepareForAttack false

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/combat/CombatExtensions.kt
@@ -27,6 +27,7 @@ import net.ccbluex.fastutil.component2
 import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.AttackEntityEvent
+import net.ccbluex.liquidbounce.event.events.PostAttackEntityEvent
 import net.ccbluex.liquidbounce.features.global.GlobalSettingsTarget
 import net.ccbluex.liquidbounce.features.module.modules.combat.criticals.ModuleCriticals
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleFreeCam
@@ -266,6 +267,10 @@ fun attackEntity(entity: Entity, swing: SwingMode, keepSprint: Boolean = false) 
 
         interaction.ensureHasSentCarriedItem()
         network.send(ServerboundAttackPacket(entity.id))
+
+        // Fire post-attack event for modules that need to act after the attack packet
+        // (e.g., knockback displacement return rotation)
+        EventManager.callEvent(PostAttackEntityEvent(entity))
 
         if (keepSprint) {
             var genericAttackDamage =

--- a/src/main/resources/resources/liquidbounce/lang/de_de.json
+++ b/src/main/resources/resources/liquidbounce/lang/de_de.json
@@ -396,6 +396,7 @@
   "liquidbounce.module.kick.description": "Wirft dich vom Server.",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Das Modul 'Kick' kann im Einzelspielermodus nicht aktiviert werden.",
   "liquidbounce.module.killAura.description": "Greift automatisch Feinde um dich herum an.",
+  "liquidbounce.module.knockbackDisplacement.description": "Steuert die Richtung des Rückstoßes, der auf Ziele ausgeübt wird, durch Manipulation der Angriffsrotation.",
   "liquidbounce.module.killAura.messages.badCooldown": "Die Abklingzeit sollte mindestens 1,0 betragen, sonst könnt ihr kritischen Schaden nicht richtig austeilen.",
   "liquidbounce.module.maceKill.description": "Sofortiges Töten bei Verwendung des Maces.",
   "liquidbounce.module.liquidWalk.description": "Ermöglicht das Gehen auf dem Wasser.",

--- a/src/main/resources/resources/liquidbounce/lang/en_pt.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_pt.json
@@ -124,6 +124,7 @@
   "liquidbounce.module.criticals.description": "Autwomaticawwy cwits ewewwy tim u attack swomweonye",
   "liquidbounce.module.hitbox.description": "Mwodify teh enyemy hitbwox mawgin (・`ω´・) which makes it easiew two aim",
   "liquidbounce.module.killAura.description": "Autwomaticawwy attacks enyemies",
+  "liquidbounce.module.knockbackDisplacement.description": "Controls th' direction o' knockback dealt to targets by manipulatin' attack rotation.",
   "liquidbounce.module.superKnockback.description": "Incweases knywockback deawt two othew entities ^w^",
   "liquidbounce.module.trigger.description": "Autwomaticawwy attacks enyemy on ywouw cwosshaiw",
   "liquidbounce.module.velocity.description": "Mwodify teh wewocity u take",

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -617,6 +617,7 @@
   "liquidbounce.module.kick.description": "Kicks yourself from the server.",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Kick cannot be enabled in single player.",
   "liquidbounce.module.killAura.description": "Automatically attacks enemies around you.",
+  "liquidbounce.module.knockbackDisplacement.description": "Controls the direction of knockback dealt to targets by manipulating attack rotation.",
   "liquidbounce.module.tpAura.description": "Automatically teleports and attacks enemies around you.",
   "liquidbounce.module.killAura.messages.badCooldown": "The cooldown should be at least 1.0, otherwise you will not be able to deal critical damage properly.",
   "liquidbounce.module.noMissCooldown.description": "Disables 1.8 hit cooldown or cancels missed attacks entirely.",

--- a/src/main/resources/resources/liquidbounce/lang/ja_jp.json
+++ b/src/main/resources/resources/liquidbounce/lang/ja_jp.json
@@ -370,6 +370,7 @@
 	"liquidbounce.module.kick.description": "サーバーから自分を追い出します。",
 	"liquidbounce.module.kick.messages.cantEnableInSingleplayer": "シングルプレイで %s を有効にできません。",
 	"liquidbounce.module.killAura.description": "自動的に敵を攻撃します。",
+  "liquidbounce.module.knockbackDisplacement.description": "攻撃時の回転を操作して、ターゲットに与えるノックバックの方向を制御します。",
 	"liquidbounce.module.killAura.messages.badCooldown": "クールダウンは1.0以上である必要があります。そうでなければ、クリティカルダメージを適切に与えることができません。",
 	"liquidbounce.module.liquidChat.description": "他のLiquidBounceユーザーとチャットをすることができます。",
 	"liquidbounce.module.liquidWalk.description": "水の上を歩くことができます。",

--- a/src/main/resources/resources/liquidbounce/lang/nl_be.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_be.json
@@ -443,6 +443,7 @@
     "liquidbounce.module.kick.description": "Kickt jezelf van de server.",
     "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Kick kan niet in singleplayer worden ingeschakeld.",
     "liquidbounce.module.killAura.description": "Val automatisch vijanden in je omgeving aan.",
+  "liquidbounce.module.knockbackDisplacement.description": "Bepaalt de richting van knockback die aan doelen wordt gegeven door aanvalsrotatie te manipuleren.",
     "liquidbounce.module.tpAura.description": "Teleport en val vijanden in je omgeving aan.",
     "liquidbounce.module.killAura.messages.badCooldown": "De cooldown moet minimaal 1.0 zijn om kritieke hits te kunnen doen.",
     "liquidbounce.module.noMissCooldown.description": "Schakelt de 1.8-aanvalscooldown uit of annuleert gemiste hits.",

--- a/src/main/resources/resources/liquidbounce/lang/nl_nl.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_nl.json
@@ -443,6 +443,7 @@
     "liquidbounce.module.kick.description": "Kickt jezelf van de server.",
     "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Kick kan niet in singleplayer worden ingeschakeld.",
     "liquidbounce.module.killAura.description": "Val automatisch vijanden in je omgeving aan.",
+  "liquidbounce.module.knockbackDisplacement.description": "Bepaalt de richting van knockback die aan doelen wordt gegeven door aanvalsrotatie te manipuleren.",
     "liquidbounce.module.tpAura.description": "Teleport en val vijanden in je omgeving aan.",
     "liquidbounce.module.killAura.messages.badCooldown": "De cooldown moet minimaal 1.0 zijn om kritieke hits te kunnen doen.",
     "liquidbounce.module.noMissCooldown.description": "Schakelt de 1.8-aanvalscooldown uit of annuleert gemiste hits.",

--- a/src/main/resources/resources/liquidbounce/lang/pt_br.json
+++ b/src/main/resources/resources/liquidbounce/lang/pt_br.json
@@ -161,6 +161,7 @@
   "liquidbounce.module.criticals.description": "Automaticamente da criticos nos inimigos.",
   "liquidbounce.module.hitbox.description": "Deixa a hitbox dos inimigos maior.",
   "liquidbounce.module.killAura.description": "Automaticamente ataca inimigos.",
+  "liquidbounce.module.knockbackDisplacement.description": "Controla a direção do knockback causado aos alvos manipulando a rotação do ataque.",
   "liquidbounce.module.superKnockback.description": "Da mais knock-back.",
   "liquidbounce.module.trigger.description": "Automaticamente ataca quando olha para alguem.",
   "liquidbounce.module.velocity.description": "Muda a velocidade que você leva quando leva um hit.",

--- a/src/main/resources/resources/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/resources/liquidbounce/lang/ru_ru.json
@@ -500,6 +500,7 @@
   "liquidbounce.module.kick.description": "Кикает вас сервера.",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Невозможно включить %s в одиночной игре.",
   "liquidbounce.module.killAura.description": "Автоматически атакует врагов",
+  "liquidbounce.module.knockbackDisplacement.description": "Управляет направлением отбрасывания целей путём манипуляции углом атаки.",
   "liquidbounce.module.killAura.messages.badCooldown": "Кулдаун должен быть не менее 1.0, иначе вы не сможете наносить критический урон должным образом.",
   "liquidbounce.module.liquidChat.description": "Позволяет общаться с другими пользователями LiquidBounce.",
   "liquidbounce.module.liquidPlace.description": "Позволяет ставить блоки на жидкости.",

--- a/src/main/resources/resources/liquidbounce/lang/tr_tr.json
+++ b/src/main/resources/resources/liquidbounce/lang/tr_tr.json
@@ -422,6 +422,7 @@
   "liquidbounce.module.kick.description": "Kendinizi sunucudan atar.",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "Tek oyunculu modda Kick açılamaz.",
   "liquidbounce.module.killAura.description": "Etrafınızdaki düşmanlara otomatik olarak saldırır.",
+  "liquidbounce.module.knockbackDisplacement.description": "Saldırı rotasyonunu manipüle ederek hedeflere verilen knockback yönünü kontrol eder.",
   "liquidbounce.module.tpAura.description": "Etrafınızdaki düşmanlara otomatik olarak teleport olur ve saldırır.",
   "liquidbounce.module.killAura.messages.badCooldown": "Bekleme süresi en az 1.0 olmalı, yoksa kritik hasar düzgün verilemez.",
   "liquidbounce.module.noMissCooldown.description": "1.8 vuruş bekleme süresini devre dışı bırakır veya kaçırılan saldırıları tamamen iptal eder.",

--- a/src/main/resources/resources/liquidbounce/lang/ua_ua.json
+++ b/src/main/resources/resources/liquidbounce/lang/ua_ua.json
@@ -176,6 +176,7 @@
   "liquidbounce.module.criticals.description": "Автоматично наносить критичний урон при кожному ударі по сутності.",
   "liquidbounce.module.hitbox.description": "Збільшує хитбокс інших сутностей.",
   "liquidbounce.module.killAura.description": "Автоматично атакує ворогів.",
+  "liquidbounce.module.knockbackDisplacement.description": "Керує напрямком відкидання цілей шляхом маніпуляції кутом атаки.",
   "liquidbounce.module.superKnockback.description": "Збільшує відкидання інших сутностей.",
   "liquidbounce.module.trigger.description": "Автоматично б'є, коли ви дивитесь на ворога.",
   "liquidbounce.module.velocity.description": "Змінює вашу швидкість.",

--- a/src/main/resources/resources/liquidbounce/lang/zh_cn.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_cn.json
@@ -617,6 +617,7 @@
   "liquidbounce.module.kick.description": "将自己踢出服务器。",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "单人游戏中无法开启Kick。",
   "liquidbounce.module.killAura.description": "自动攻击周围的敌人。",
+  "liquidbounce.module.knockbackDisplacement.description": "通过操纵攻击角度来控制对目标造成的击退方向。",
   "liquidbounce.module.tpAura.description": "自动传送到敌人周围并攻击它们。",
   "liquidbounce.module.killAura.messages.badCooldown": "冷却时间至少应为 1.0，否则无法正确造成暴击伤害。",
   "liquidbounce.module.noMissCooldown.description": "禁用1.8攻击冷却时间或完全取消未击中的攻击。",

--- a/src/main/resources/resources/liquidbounce/lang/zh_tw.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_tw.json
@@ -519,6 +519,7 @@
   "liquidbounce.module.kick.description": "將自己踢出伺服器。",
   "liquidbounce.module.kick.messages.cantEnableInSingleplayer": "單人遊戲中無法開啟Kick。",
   "liquidbounce.module.killAura.description": "自動攻擊周圍的敵人。",
+  "liquidbounce.module.knockbackDisplacement.description": "透過操縱攻擊角度來控制對目標造成的擊退方向。",
   "liquidbounce.module.tpAura.description": "自動傳送到敵人周圍並攻擊它們。",
   "liquidbounce.module.killAura.messages.badCooldown": "冷卻時間至少應為 1.0，否則無法正確造成暴擊傷害。",
   "liquidbounce.module.noMissCooldown.description": "禁用1.8攻擊冷卻時間或完全取消未擊中的攻擊。",


### PR DESCRIPTION
> ⚠️ **I'm not sure that this feature works because claude coded that! If you can rewiew and test, that would be great. Or, you can close the Pr if it's dogshit!!!**
>
> *PR was written with AI coding assistance*

---

## Summary

Adds **Knockback Displacement** sub-feature to KillAura, allowing control over the direction of sprint-knockback dealt to targets.

Closes #8525

## How it works

The server calculates sprint-KB direction using the attacker's yaw:

```java
target.knockback(0.5, -Mth.sin(attackerYaw * DEG_TO_RAD), Mth.cos(attackerYaw * DEG_TO_RAD));
```

Since the server only checks distance for hit registration (not whether the attacker faces the target), we can send a manipulated rotation before attacking to control knockback direction.

Reference: https://www.youtube.com/watch?v=7t0PyqYsac8

## Modes

| Mode | Effect |
|------|--------|
| **Push** | Normal knockback away from player |
| **Pull** | Reverse direction, pulls target toward player |
| **Upward** | Launches target vertically (pitch = -70°) |
| **Horizontal** | Pushes target sideways (perpendicular) |
| **Custom** | User-defined yaw/pitch offset from player→target direction |

## Configuration

- `Mode` — Select displacement behavior
- `CustomYaw` — Yaw offset in Custom mode (-180° to 180°)
- `CustomPitch` — Pitch offset in Custom mode (-90° to 90°)
- `Cooldown` — Ticks between applications (0-40)

## Implementation

- **New file:** `KillAuraKnockbackDisplacement.kt` (ToggleableValueGroup)
- Only activates when player is sprinting (sprint-KB precondition)
- Rotations are GCD-normalized to avoid anticheat detection
- Integrated via `ModuleKillAura`