### PR TITLE
fix: perspective mod compatibility and improve mixin compatibility

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouseHandler.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMouseHandler.java
@@ -20,7 +20,8 @@
 package net.ccbluex.liquidbounce.injection.mixins.minecraft.client;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.ccbluex.liquidbounce.additions.MouseHandlerAddition;
@@ -108,16 +109,14 @@ public abstract class MixinMouseHandler implements MouseHandlerAddition {
         return original || ModuleZoom.INSTANCE.getRunning();
     }
 
-    @WrapWithCondition(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), require = 1, allow = 1)
-    private boolean modifyMouseRotationInput(LocalPlayer instance, double cursorDeltaX, double cursorDeltaY) {
+    @WrapOperation(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), require = 1, allow = 1)
+    private void modifyMouseRotationInput(LocalPlayer instance, double cursorDeltaX, double cursorDeltaY, Operation<Void> original) {
         final MouseRotationEvent event = new MouseRotationEvent(cursorDeltaX, cursorDeltaY);
         EventManager.INSTANCE.callEvent(event);
 
         if (!event.isCancelled()) {
-            instance.turn(event.getCursorDeltaX(), event.getCursorDeltaY());
+            original.call(instance, event.getCursorDeltaX(), event.getCursorDeltaY());
         }
-
-        return false;
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
@@ -204,8 +204,7 @@ object RotationManager : EventListener {
         val partialTicks = event.partialTicks
 
         if (isRotatingAllowed(activeRotationTarget)
-            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK
-            && mc.options.cameraType.isFirstPerson()) {
+            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK) {
             val playerRotation = playerRotation ?: return@handler
             val currentRotation = currentRotation ?: return@handler
             val timerSpeed = Timer.timerSpeed
@@ -219,8 +218,7 @@ object RotationManager : EventListener {
     private val mouseMovement = handler<MouseRotationEvent> { event ->
         val activeRotationTarget = this.activeRotationTarget ?: return@handler
         if (!isRotatingAllowed(activeRotationTarget) ||
-            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK ||
-            !mc.options.cameraType.isFirstPerson()) {
+            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK) {
             return@handler
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/RotationManager.kt
@@ -204,7 +204,8 @@ object RotationManager : EventListener {
         val partialTicks = event.partialTicks
 
         if (isRotatingAllowed(activeRotationTarget)
-            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK) {
+            && activeRotationTarget.movementCorrection == MovementCorrection.CHANGE_LOOK
+            && mc.options.cameraType.isFirstPerson()) {
             val playerRotation = playerRotation ?: return@handler
             val currentRotation = currentRotation ?: return@handler
             val timerSpeed = Timer.timerSpeed
@@ -218,7 +219,8 @@ object RotationManager : EventListener {
     private val mouseMovement = handler<MouseRotationEvent> { event ->
         val activeRotationTarget = this.activeRotationTarget ?: return@handler
         if (!isRotatingAllowed(activeRotationTarget) ||
-            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK) {
+            activeRotationTarget.movementCorrection != MovementCorrection.CHANGE_LOOK ||
+            !mc.options.cameraType.isFirstPerson()) {
             return@handler
         }
 


### PR DESCRIPTION
Reopening the work from #8487. The branch got deleted by accident on my end, which also closed the PR, so this is a fresh PR rebased on nextgen (26.2).

Same two changes as before:
1. First-person guard in RotationManager. CHANGE_LOOK only fires when cameraType.isFirstPerson(). In F5 the mouse only moves the camera now, which is what Lunar's Freelook and other perspective mods expect. No effect on LiquidBounce's own FreeLook;

2. MixinMouseHandler moved from @WrapWithCondition to @WrapOperation, per the suggestion in the original PR thread to convert to the new mixin extras once 26.2 was in.

Diff is still +9/-8 on the same two files, no new code beyond the rebase.