### PR TITLE
fix(module): send toggle event outside game

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/integration/interop/protocol/rest/v1/client/ModuleFunctions.kt
@@ -26,10 +26,13 @@ import kotlinx.coroutines.withContext
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
 import net.ccbluex.liquidbounce.config.gson.interopGson
+import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.events.ModuleToggleEvent
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.features.module.ModuleManager
 import net.ccbluex.liquidbounce.features.module.ModuleManager.modulesConfig
+import net.ccbluex.liquidbounce.utils.client.inGame
 import net.ccbluex.liquidbounce.utils.client.logger
 import net.ccbluex.liquidbounce.utils.kotlin.Minecraft
 import net.ccbluex.netty.http.application.ApplicationCall
@@ -130,6 +133,9 @@ private data class ModuleRequest(val name: String) {
         withContext(Dispatchers.Minecraft) {
             try {
                 module.enabled = supposedNew
+                if (!inGame) {
+                    EventManager.callEvent(ModuleToggleEvent(module.name, module.hidden, module.enabled))
+                }
                 ConfigSystem.store(modulesConfig)
             } catch (e: Exception) {
                 logger.error("Failed to toggle module ${this@ModuleRequest.name}", e)


### PR DESCRIPTION
# Summary
  Ensures REST module toggles also notify websocket listeners when the client is not in-
  game.

  ## Details
  `ClientModule.onToggled` skips the normal event path outside a world, but the REST
  toggle endpoint can still update the module state there. This sends
  `ModuleToggleEvent` from the REST handler for that case so ClickGUI and other UI
  listeners stay in sync.