### PR TITLE
feat(combat): add AimBot VerticalDeadzone to hold yaw near vertical

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
@@ -49,6 +49,7 @@ import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.render.TargetRenderer
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.world.entity.Entity
+import kotlin.math.abs
 
 /**
  * Aimbot module
@@ -80,6 +81,7 @@ object ModuleAimbot : ClientModule("Aimbot", ModuleCategories.COMBAT, aliases = 
     }
 
     private val axis by multiEnumChoice<Axis>("Axis", Axis.HORIZONTAL, Axis.VERTICAL)
+    private val verticalDeadzone by float("VerticalDeadzone", 0f, 0f..90f)
 
     private val ignores by multiEnumChoice<IgnoreOpened>("Ignore")
 
@@ -160,10 +162,11 @@ object ModuleAimbot : ClientModule("Aimbot", ModuleCategories.COMBAT, aliases = 
         val targetRotation = targetRotation ?: return
         val timerSpeed = Timer.timerSpeed
         val interpolatedRotation = playerRotation.interpolateTo(targetRotation, timerSpeed * partialTicks)
+        val inVerticalDeadzone = verticalDeadzone > 0f && abs(targetRotation.pitch) >= 90f - verticalDeadzone
 
         player.setRotation(
             Rotation(
-                yaw = if (Axis.HORIZONTAL in axis) interpolatedRotation.yaw else playerRotation.yaw,
+                yaw = if (Axis.HORIZONTAL in axis && !inVerticalDeadzone) interpolatedRotation.yaw else playerRotation.yaw,
                 pitch = if (Axis.VERTICAL in axis) interpolatedRotation.pitch else playerRotation.pitch,
             )
         )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleAimbot.kt
@@ -86,6 +86,7 @@ object ModuleAimbot : ClientModule("Aimbot", ModuleCategories.COMBAT, aliases = 
     private val ignores by multiEnumChoice<IgnoreOpened>("Ignore")
 
     private var targetRotation: Rotation? = null
+    private var rawTargetPitch: Float? = null
     private var playerRotation: Rotation? = null
 
     @Suppress("unused", "ComplexCondition")
@@ -95,10 +96,14 @@ object ModuleAimbot : ClientModule("Aimbot", ModuleCategories.COMBAT, aliases = 
         if (!requirementsMet) {
             targetTracker.reset()
             targetRotation = null
+            rawTargetPitch = null
             return@handler
         }
 
-        targetRotation = findNextTargetRotation()?.let { (target, rotation) ->
+        val nextTargetRotation = findNextTargetRotation()
+        rawTargetPitch = nextTargetRotation?.second?.rotation?.pitch
+
+        targetRotation = nextTargetRotation?.let { (target, rotation) ->
             angleSmooth.activeMode.process(
                 RotationTarget(
                     rotation = rotation.rotation,
@@ -160,9 +165,10 @@ object ModuleAimbot : ClientModule("Aimbot", ModuleCategories.COMBAT, aliases = 
     private fun lookAt(partialTicks: Float) {
         val playerRotation = playerRotation ?: return
         val targetRotation = targetRotation ?: return
+        val rawTargetPitch = rawTargetPitch ?: return
         val timerSpeed = Timer.timerSpeed
         val interpolatedRotation = playerRotation.interpolateTo(targetRotation, timerSpeed * partialTicks)
-        val inVerticalDeadzone = verticalDeadzone > 0f && abs(targetRotation.pitch) >= 90f - verticalDeadzone
+        val inVerticalDeadzone = verticalDeadzone > 0f && abs(rawTargetPitch) >= 90f - verticalDeadzone
 
         player.setRotation(
             Rotation(


### PR DESCRIPTION
## Summary

Adds a `VerticalDeadzone` option to AimBot that holds horizontal (yaw) assist when the target is near directly above or below the player. `VerticalDeadzone` is the angular size, in degrees, of a cone around straight up/down within which yaw assist is suppressed; pitch tracking is left untouched, so vertical aim still works.

The default is `0` (off), which preserves current behavior exactly. The suppression check in `lookAt()` is `verticalDeadzone > 0f && abs(rawTargetPitch) >= 90f - verticalDeadzone`; with the default the threshold is `90f`, which the clamped pitch can never exceed, so the deadzone never engages.

## Why

Reported in #8358: when you look almost straight up or down at a target, a small vertical move of the target maps to a large yaw change, so AimBot's yaw swings wildly near the pitch poles. The thread distilled the request to "if the target is already reachable with the current rotation, then do not rotate" - hold yaw while pitch keeps tracking. This option is the bounded, opt-in form of that: it only suppresses yaw inside a configurable cone around vertical, and defaults to off so existing configs are unaffected.

## Changes

- The deadzone is evaluated against the raw, unsmoothed target pitch captured from `findNextTargetRotation()` in the `RotationUpdateEvent` handler, not the smoothed per-tick `targetRotation`. Under a non-instant `AngleSmooth` the smoothed pitch lags the player's current pitch for the first ticks, so checking it would let yaw keep spinning in exactly the case this option targets.

Only `ModuleAimbot.kt` is touched.

Closes #8358
