### PR TITLE
feat(Trajectories): different color of types, adjustable width

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ValueGroup.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/types/group/ValueGroup.kt
@@ -566,11 +566,20 @@ open class ValueGroup(
         this@ValueGroup.inner.add(this)
     }
 
-    inline fun <reified T> enumChoice(name: String, default: T): ChoiceListValue<T>
-        where T : Enum<T>, T : Tagged = enumChoice(name, default, enumSetAllOf())
+    inline fun <reified T> enumChoice(
+        name: String,
+        default: T,
+        aliases: List<String> = emptyList(),
+    ): ChoiceListValue<T> where T : Enum<T>, T : Tagged = enumChoice(name, default, enumSetAllOf(), aliases)
 
-    fun <T : Tagged> enumChoice(name: String, default: T, choices: Set<T>): ChoiceListValue<T> =
-        ChoiceListValue(name, defaultValue = default, choices = choices).apply { this@ValueGroup.inner.add(this) }
+    fun <T : Tagged> enumChoice(
+        name: String,
+        default: T,
+        choices: Set<T>,
+        aliases: List<String> = emptyList(),
+    ): ChoiceListValue<T> = ChoiceListValue(name, defaultValue = default, choices = choices, aliases = aliases).apply {
+        this@ValueGroup.inner.add(this)
+    }
 
     protected fun <T : Mode> modes(
         eventListener: EventListener,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/blink/BlinkManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/blink/BlinkManager.kt
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.features.blink
 import com.google.common.collect.Queues
 import net.ccbluex.fastutil.filterIsInstance
 import net.ccbluex.fastutil.forEachIsInstance
-import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.group.ValueGroup
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
@@ -41,8 +40,8 @@ import net.ccbluex.liquidbounce.features.blink.esp.BlinkEspNone
 import net.ccbluex.liquidbounce.features.blink.esp.BlinkEspWireframe
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
-import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.network.handlePacket
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -211,7 +210,7 @@ object BlinkManager : EventListener, ValueGroup("BlinkManager") {
             renderEnvironmentForWorld(matrixStack) {
                 drawLineStrip(
                     argb = lineColor.argb,
-                    positions = positions.mapToArray { vec3d -> Vec3f(relativeToCamera(vec3d)) },
+                    positions = MutableVertexList(positions.size).addAllRelativeToCamera(positions, camera),
                 )
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/ModuleTickBase.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.combat
 
-import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
@@ -35,10 +34,10 @@ import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debug
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.utils.combat.findEnemy
 import net.ccbluex.liquidbounce.utils.entity.PlayerSimulationCache
 import net.ccbluex.liquidbounce.utils.math.sq
-import net.ccbluex.liquidbounce.utils.math.toVec3f
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
 import net.minecraft.world.phys.Vec3
 import kotlin.math.min
@@ -230,9 +229,8 @@ internal object ModuleTickBase : ClientModule("TickBase", ModuleCategories.COMBA
         renderEnvironmentForWorld(event.matrixStack) {
             drawLineStrip(
                 argb = lineColor.argb,
-                positions = tickBuffer.mapToArray { tick ->
-                    relativeToCamera(tick.position).toVec3f()
-                }
+                positions = MutableVertexList(tickBuffer.size)
+                    .addAllRelativeToCamera(tickBuffer, camera) { it.position }
             )
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/tpaura/modes/AStarMode.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.ccbluex.fastutil.WeightedSortedList
-import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.WorldRenderEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -39,6 +38,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.tpaura.TpAuraMode
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.utils.block.AStarPathBuilder
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
@@ -47,7 +47,6 @@ import net.ccbluex.liquidbounce.utils.math.bottomCenter
 import net.ccbluex.liquidbounce.utils.math.center
 import net.ccbluex.liquidbounce.utils.math.set
 import net.ccbluex.liquidbounce.utils.math.sq
-import net.ccbluex.liquidbounce.utils.math.toVec3f
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Vec3i
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
@@ -132,9 +131,8 @@ object AStarMode : TpAuraMode("AStar"), AStarPathBuilder {
         renderEnvironmentForWorld(matrixStack) {
             drawLineStrip(
                 argb = Color4b.WHITE.argb,
-                positions = path.mapToArray {
-                    relativeToCamera(it.center).toVec3f()
-                }
+                positions = MutableVertexList(path.size)
+                    .addAllRelativeToCamera(path, camera) { it.center }
             )
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoPearl.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/misc/ModuleAutoPearl.kt
@@ -209,7 +209,7 @@ object ModuleAutoPearl : ClientModule(
         destination: Vec3
     ): Boolean {
         val simulatedDestination = TrajectoryInfoRenderer.getHypotheticalTrajectory(
-            owner = player,
+            simulationOwner = player,
             trajectoryInfo = TrajectoryInfo.GENERIC,
             trajectoryType = TrajectoryType.EnderPearl,
             rotation = angles
@@ -226,7 +226,8 @@ object ModuleAutoPearl : ClientModule(
         renderOffset: Vec3 = Vec3.ZERO
     ): HitResult? =
         TrajectoryInfoRenderer(
-            owner = owner,
+            simulationOwner = owner,
+            displayOwner = owner,
             icon = Items.ENDER_PEARL.defaultInstance,
             velocity = velocity,
             pos = pos,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleFreeze.kt
@@ -18,7 +18,6 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.movement
 
-import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.liquidbounce.config.types.group.Mode
 import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
 import net.ccbluex.liquidbounce.event.events.BlinkPacketEvent
@@ -35,6 +34,7 @@ import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleEasyPearl
 import net.ccbluex.liquidbounce.render.drawLineStrip
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.network.sendPacketSilently
@@ -42,7 +42,6 @@ import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayer
 import net.ccbluex.liquidbounce.utils.entity.SimulatedPlayerCache
 import net.ccbluex.liquidbounce.utils.input.InputTracker.isPressedOnAny
 import net.ccbluex.liquidbounce.utils.kotlin.EventPriorityConvention
-import net.ccbluex.liquidbounce.utils.math.toVec3f
 import net.ccbluex.liquidbounce.utils.movement.DirectionalInput
 import net.minecraft.network.protocol.common.ServerboundPongPacket
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
@@ -139,7 +138,8 @@ object ModuleFreeze : ClientModule("Freeze", ModuleCategories.MOVEMENT, disableO
         renderEnvironmentForWorld(event.matrixStack) {
             drawLineStrip(
                 argb = Color4b(0x00, 0x80, 0xFF, 0xFF).argb,
-                positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3f() },
+                positions = MutableVertexList(cachedPositions.size)
+                    .addAllRelativeToCamera(cachedPositions, camera) { it.pos },
             )
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleDebug.kt
@@ -20,7 +20,6 @@ package net.ccbluex.liquidbounce.features.module.modules.render
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import net.ccbluex.fastutil.forEachFloat
-import net.ccbluex.fastutil.mapToArray
 import net.ccbluex.fastutil.step
 import net.ccbluex.liquidbounce.config.types.CurveValue.Axis.Companion.axis
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
@@ -41,6 +40,7 @@ import net.ccbluex.liquidbounce.render.drawQuad
 import net.ccbluex.liquidbounce.render.drawTriangle
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.renderEnvironmentForWorld
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.utils.text.asPlainText
 import net.ccbluex.liquidbounce.utils.text.textOf
 import net.ccbluex.liquidbounce.utils.math.vector2f
@@ -91,7 +91,8 @@ object ModuleDebug : ClientModule("Debug", ModuleCategories.RENDER) {
             renderEnvironmentForWorld(event.matrixStack) {
                 drawLineStrip(
                     Color4b.BLUE.argb,
-                    positions = cachedPositions.mapToArray { relativeToCamera(it.pos).toVec3f() },
+                    positions = MutableVertexList(cachedPositions.size)
+                        .addAllRelativeToCamera(cachedPositions, camera) { it.pos },
                 )
             }
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTNTTimer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/ModuleTNTTimer.kt
@@ -22,7 +22,6 @@ import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 import net.ccbluex.fastutil.filterIsInstanceTo
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
-import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.computedOn
 import net.ccbluex.liquidbounce.event.events.GameTickEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
@@ -38,8 +37,6 @@ import net.ccbluex.liquidbounce.utils.text.textOf
 import net.minecraft.network.chat.Style
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.item.PrimedTnt
-import java.text.DecimalFormat
-import java.util.function.IntFunction
 import kotlin.math.sin
 
 /**
@@ -61,18 +58,6 @@ object ModuleTNTTimer : ClientModule("TNTTimer", ModuleCategories.RENDER) {
         val ownerName by boolean("OwnerName", true)
         val timeUnit by enumChoice("TimeUnit", TimeUnit.TICKS)
 
-        enum class TimeUnit(override val tag: String): Tagged, IntFunction<String> {
-            TICKS("Ticks"),
-            SECONDS("Seconds");
-
-            override fun apply(t: Int): String = when (this) {
-                TICKS -> t.toString()
-                SECONDS -> SECONDS_FORMAT.format(t * 0.05)
-            }
-        }
-
-        private val SECONDS_FORMAT = DecimalFormat("0.00s")
-
         @Suppress("unused")
         private val render2DHandler = handler<OverlayRenderEvent> { event ->
             for (tnt in tntEntities) {
@@ -83,7 +68,7 @@ object ModuleTNTTimer : ClientModule("TNTTimer", ModuleCategories.RENDER) {
                 // Yellow #ffff00 -> Red #ff0000
                 val color = Color4b(255, Mth.floor(255F * tnt.fuse / DEFAULT_FUSE).coerceAtMost(255), 0)
 
-                var text = timeUnit.apply(tnt.fuse).asPlainText(Style.EMPTY + color)
+                var text = timeUnit.format(tnt.fuse).asPlainText(Style.EMPTY + color)
 
                 if (ownerName) {
                     tnt.owner?.name?.let {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/TimeUnit.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/TimeUnit.kt
@@ -1,0 +1,37 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.render
+
+import net.ccbluex.liquidbounce.config.types.list.Tagged
+import java.text.DecimalFormat
+
+enum class TimeUnit(
+    override val tag: String,
+) : Tagged {
+    TICKS("Ticks") {
+        override fun format(ticks: Int): String = ticks.toString()
+    },
+    SECONDS("Seconds") {
+        private val format = DecimalFormat("0.#s")
+        override fun format(ticks: Int): String = format.format(ticks * 0.05)
+    };
+
+    abstract fun format(ticks: Int): String
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -32,6 +32,8 @@ import net.ccbluex.liquidbounce.utils.aiming.RotationManager
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.entity.handItems
 import net.ccbluex.liquidbounce.utils.entity.rotation
+import net.ccbluex.liquidbounce.utils.math.dot
+import net.ccbluex.liquidbounce.utils.math.sq
 import net.ccbluex.liquidbounce.utils.render.trajectory.EntityTrajectoryResolver
 import net.ccbluex.liquidbounce.utils.render.trajectory.HeldItemTrajectoryResolver
 import net.ccbluex.liquidbounce.utils.render.trajectory.TrajectoryInfoRenderer
@@ -83,14 +85,15 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
     val renderHandler = handler<WorldRenderEvent> { event ->
         simulationResults.clear()
         renderEnvironmentForWorld(event.matrixStack) {
-            val viewPos = player.eyePosition
-            val viewDirection = player.rotation.directionVector
-            val maxRenderDistanceSq = maxRenderDistance * maxRenderDistance.toDouble()
+            val viewPos = camera.position()
+            val viewDirection = camera.forwardVector()
+            val maxRenderDistanceSq = maxRenderDistance.sq().toDouble()
 
             for (entity in world.entitiesForRendering()) {
                 val delta = entity.position().subtract(viewPos)
-                if (delta.lengthSqr() > maxRenderDistanceSq ||
-                    cullBehindPlayer && delta.dot(viewDirection) < 0.0 && delta.lengthSqr() > 9.0) {
+                val deltaLengthSq = delta.lengthSqr()
+                if (deltaLengthSq > maxRenderDistanceSq ||
+                    cullBehindPlayer && delta.dot(viewDirection) < 0.0 && deltaLengthSq > 9.0) {
                     continue
                 }
 
@@ -138,10 +141,11 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                 for (otherPlayer in world.players()) {
                     if (otherPlayer !== player) {
                         val delta = otherPlayer.eyePosition.subtract(viewPos)
-                        if (delta.lengthSqr() > maxRenderDistanceSq) {
+                        val deltaLengthSq = delta.lengthSqr()
+                        if (deltaLengthSq > maxRenderDistanceSq) {
                             continue
                         }
-                        if (cullBehindPlayer && delta.dot(viewDirection) < 0.0 && delta.lengthSqr() > 9.0) {
+                        if (cullBehindPlayer && delta.dot(viewDirection) < 0.0 && deltaLengthSq > 9.0) {
                             continue
                         }
                     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -53,6 +53,8 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
     private val maxRenderDistance by int("MaxRenderDistance", 96, 16..512, "m")
     private val cullBehindPlayer by boolean("CullBehindPlayer", false)
     private val showMultiShot by boolean("ShowMultiShot", true)
+    private val lineWidth by float("LineWidth", 1f, 1f..16f)
+    private val activeLineWidth by float("ActiveLineWidth", 2f, 1f..16f)
 
     private val trajectoryTypes by multiEnumChoice("TrajectoryTypes", TrajectoryType.entries, canBeNone = false)
 
@@ -128,6 +130,7 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                     trajectoryColor = color,
                     blockHitColor = color,
                     entityHitColor = color,
+                    lineWidth = activeLineWidth,
                 )
             }
 
@@ -220,6 +223,7 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                 ),
                 blockHitColor = Color4b(0, 160, 255, 150),
                 entityHitColor = Color4b.RED.alpha(100),
+                lineWidth = lineWidth,
             )
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -100,8 +100,10 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
 
                 if (trajectoryType !in trajectoryTypes) continue
 
+                val displayOwner = (entity as? TraceableEntity)?.owner
                 val trajectoryRenderer = TrajectoryInfoRenderer(
-                    owner = (entity as? TraceableEntity)?.owner ?: entity,
+                    simulationOwner = displayOwner ?: entity,
+                    displayOwner = displayOwner,
                     icon = TrajectoryDisplayResolver.resolveEntityIcon(
                         entity, activeTrajectoryArrow, activeTrajectoryOther
                     ),
@@ -196,7 +198,7 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
             )
 
             val renderer = TrajectoryInfoRenderer.getHypotheticalTrajectory(
-                owner = otherPlayer,
+                simulationOwner = otherPlayer,
                 icon = if (shotDescriptor.icon.isEmpty) stack else shotDescriptor.icon,
                 trajectoryInfo = shotDescriptor.trajectoryInfo,
                 trajectoryType = shotDescriptor.trajectoryType,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/ModuleTrajectories.kt
@@ -101,12 +101,13 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                 if (trajectoryType !in trajectoryTypes) continue
 
                 val displayOwner = (entity as? TraceableEntity)?.owner
+                val icon = TrajectoryDisplayResolver.resolveEntityIcon(
+                    entity, activeTrajectoryArrow, activeTrajectoryOther
+                )
                 val trajectoryRenderer = TrajectoryInfoRenderer(
                     simulationOwner = displayOwner ?: entity,
                     displayOwner = displayOwner,
-                    icon = TrajectoryDisplayResolver.resolveEntityIcon(
-                        entity, activeTrajectoryArrow, activeTrajectoryOther
-                    ),
+                    icon = icon,
                     velocity = entity.deltaMovement,
                     pos = entity.position(),
                     trajectoryInfo = trajectoryInfo,
@@ -115,7 +116,11 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
                     renderOffset = Vec3.ZERO,
                 )
 
-                val color = TrajectoryDisplayResolver.resolveEntityColor(entity)
+                val color = TrajectoryDisplayResolver.resolveTrajectoryColor(
+                    trajectoryType = trajectoryType,
+                    colorSource = icon,
+                    entity = entity,
+                )
 
                 simulationResults += trajectoryRenderer to trajectoryRenderer.drawTrajectoryForProjectile(
                     maxSimulatedTicks,
@@ -209,7 +214,10 @@ object ModuleTrajectories : ClientModule("Trajectories", ModuleCategories.RENDER
             simulationResults += renderer to renderer.drawTrajectoryForProjectile(
                 maxSimulatedTicks,
                 partialTicks,
-                trajectoryColor = Color4b.WHITE,
+                trajectoryColor = TrajectoryDisplayResolver.resolveTrajectoryColor(
+                    trajectoryType = shotDescriptor.trajectoryType,
+                    colorSource = shotDescriptor.colorSource,
+                ),
                 blockHitColor = Color4b(0, 160, 255, 150),
                 entityHitColor = Color4b.RED.alpha(100),
             )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/TrajectoryDetailedInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/TrajectoryDetailedInfoRenderer.kt
@@ -23,6 +23,7 @@ import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
 import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.features.module.modules.render.TimeUnit
 import net.ccbluex.liquidbounce.render.FontManager
 import net.ccbluex.liquidbounce.render.engine.font.HorizontalAnchor
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
@@ -33,20 +34,18 @@ import net.ccbluex.liquidbounce.utils.math.toFixed
 import net.ccbluex.liquidbounce.utils.render.WorldToScreen
 import net.ccbluex.liquidbounce.utils.render.trajectory.TrajectoryInfoRenderer
 import net.minecraft.world.phys.Vec3
-import java.text.DecimalFormat
-import java.util.function.BiFunction
 
 object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories, "ShowDetailedInfo", false) {
     private val showAt by enumChoice("ShowAt", ShowAt.ENTITY)
 
     private enum class ShowAt(
         override val tag: String,
-    ) : Tagged, BiFunction<TrajectoryInfoRenderer, TrajectoryInfoRenderer.SimulationResult, Vec3> {
+    ) : Tagged {
         OWNER("Owner"),
         ENTITY("Entity"),
         LANDING("Landing");
 
-        override fun apply(
+        fun apply(
             renderer: TrajectoryInfoRenderer,
             result: TrajectoryInfoRenderer.SimulationResult,
         ): Vec3 = when (this) {
@@ -59,22 +58,8 @@ object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories,
     private val item by boolean("Item", true)
     private val ownerName by boolean("OwnerName", true)
     private val distance by boolean("Distance", true)
-    private val durationUnit by enumChoice("DurationUnit", DurationUnit.TICKS)
+    private val timeUnit by enumChoice("TimeUnit", TimeUnit.TICKS, aliases = listOf("DurationUnit"))
     private val color by color("Color", Color4b.WHITE)
-
-    private enum class DurationUnit(
-        override val tag: String,
-    ) : Tagged {
-        TICKS("Ticks") {
-            override fun format(ticks: Int): String = ticks.toString()
-        },
-        SECONDS("Seconds") {
-            private val formatter = DecimalFormat("0.#s")
-            override fun format(ticks: Int): String = formatter.format(ticks * 0.05)
-        };
-
-        abstract fun format(ticks: Int): String
-    }
 
     private val scale by float("Scale", 1F, 0.25F..4F)
     private val renderOffset by vec3d("RenderOffset", useLocateButton = false)
@@ -110,7 +95,7 @@ object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories,
                 pose().scale(scale)
 
                 val texts = buildList {
-                    add(durationUnit.format(result.positions.size).asPlainText())
+                    add(timeUnit.format(result.positions.size).asPlainText())
                     if (distance && result.positions.isNotEmpty()) {
                         add("Dist: ${player.position().distanceTo(result.positions.last()).toFixed(1)}m".asPlainText())
                     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/TrajectoryDetailedInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/render/trajectories/TrajectoryDetailedInfoRenderer.kt
@@ -49,10 +49,10 @@ object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories,
             renderer: TrajectoryInfoRenderer,
             result: TrajectoryInfoRenderer.SimulationResult,
         ): Vec3 = when (this) {
-            OWNER -> renderer.owner.position()
+            OWNER -> renderer.simulationOwner.position()
             ENTITY -> result.positions.firstOrNull()
             LANDING -> result.positions.lastOrNull()
-        } ?: renderer.owner.position()
+        } ?: renderer.simulationOwner.position()
     }
 
     private val item by boolean("Item", true)
@@ -74,7 +74,7 @@ object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories,
             ModuleTrajectories.simulationResults.forEachIndexed { index, (renderer, result) ->
                 val screenPos =
                     when {
-                        showAt === ShowAt.OWNER && renderer.owner === player -> when (renderer.type) {
+                        showAt === ShowAt.OWNER && renderer.simulationOwner === player -> when (renderer.type) {
                             // If this renderer is created by player holding items and showAt is OWNER,
                             // then show at the landing position
                             TrajectoryInfoRenderer.Type.HYPOTHETICAL ->
@@ -99,8 +99,9 @@ object TrajectoryDetailedInfoRenderer : ToggleableValueGroup(ModuleTrajectories,
                     if (distance && result.positions.isNotEmpty()) {
                         add("Dist: ${player.position().distanceTo(result.positions.last()).toFixed(1)}m".asPlainText())
                     }
-                    if (ownerName && renderer.owner !== player) {
-                        add(textOf("Owner: ".asPlainText(), renderer.owner.displayName))
+                    val displayOwner = renderer.displayOwner
+                    if (ownerName && displayOwner != null && displayOwner !== player) {
+                        add(textOf("Owner: ".asPlainText(), displayOwner.displayName))
                     }
                 }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -224,6 +224,31 @@ fun WorldRenderEnvironment.drawLinesWithWidth(argb: Int, width: Float, vararg po
     }
 }
 
+fun WorldRenderEnvironment.drawLinesWithWidth(argb: Int, width: Float, positions: VertexList) {
+    if (positions.size == 0) return
+    require(positions.size and 1 == 0)
+
+    val p1 = Vector3f()
+    val p2 = Vector3f()
+    val norm1 = Vector3f()
+    drawCustomMesh(pipeline = ClientRenderPipelines.LinesWithWidth) { pose ->
+        for (i in 0 until positions.size step 2) {
+            positions.vec(i, p1)
+            positions.vec(i + 1, p2)
+            val norm1 = p1.sub(p2, norm1).normalize()
+
+            addVertex(pose, p1)
+                .setColor(argb)
+                .setNormal(pose, norm1)
+                .setLineWidth(width)
+            addVertex(pose, p2)
+                .setColor(argb)
+                .setNormal(pose, norm1.negate())
+                .setLineWidth(width)
+        }
+    }
+}
+
 /**
  * Function to draw lines using the specified [positions] vectors.
  *

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/RenderShortcuts.kt
@@ -30,6 +30,8 @@ import net.ccbluex.fastutil.objectObjectMapOf
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.ccbluex.liquidbounce.render.utils.DistanceFadeUniformValueGroup
+import net.ccbluex.liquidbounce.render.utils.VertexList
+import net.ccbluex.liquidbounce.render.utils.forEachVertex
 import net.ccbluex.liquidbounce.render.utils.UnitCircle
 import net.ccbluex.liquidbounce.utils.client.gpuDevice
 import net.ccbluex.liquidbounce.utils.client.mc
@@ -238,6 +240,17 @@ fun WorldRenderEnvironment.drawLines(argb: Int, vararg positions: Vec3f) {
     }
 }
 
+fun WorldRenderEnvironment.drawLines(argb: Int, positions: VertexList) {
+    if (positions.size == 0) return
+    require(positions.size and 1 == 0)
+
+    drawCustomMesh(pipeline = ClientRenderPipelines.Lines) { pose ->
+        positions.forEachVertex { x, y, z ->
+            addVertex(pose, x, y, z).setColor(argb)
+        }
+    }
+}
+
 /**
  * Function to draw a line strip using the specified [positions] vectors.
  *
@@ -253,22 +266,12 @@ fun WorldRenderEnvironment.drawLineStrip(argb: Int, vararg positions: Vec3f) {
     }
 }
 
-/**
- * Function to draw a 'line strip' using the specified [positions] vectors,
- * actual pipeline is [ClientRenderPipelines.Lines].
- *
- * @param positions The vectors representing the line strip, the size should be even.
- */
-fun WorldRenderEnvironment.drawLineStripAsLines(argb: Int, positions: Collection<Vec3>) {
-    if (positions.isEmpty()) return
-    require(positions.size and 1 == 0)
+fun WorldRenderEnvironment.drawLineStrip(argb: Int, positions: VertexList) {
+    if (positions.size == 0) return
 
-    drawCustomMesh(ClientRenderPipelines.Lines) { pose ->
-        positions.forEachIndexed { index, pos ->
-            if (index != 0 && index != positions.size - 1) {
-                addVertex(pose, pos).setColor(argb)
-            }
-            addVertex(pose, pos).setColor(argb)
+    drawCustomMesh(pipeline = ClientRenderPipelines.LineStrip) { pose ->
+        positions.forEachVertex { x, y, z ->
+            addVertex(pose, x, y, z).setColor(argb)
         }
     }
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/utils/VertexList.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/utils/VertexList.kt
@@ -1,0 +1,150 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.render.utils
+
+import it.unimi.dsi.fastutil.floats.FloatArrayList
+import net.ccbluex.liquidbounce.render.engine.type.Vec3f
+import net.minecraft.client.Camera
+import net.minecraft.world.phys.Vec3
+
+interface VertexList {
+
+    val size: Int
+
+    fun x(index: Int): Float
+
+    fun y(index: Int): Float
+
+    fun z(index: Int): Float
+}
+
+inline fun VertexList.forEachVertex(action: (x: Float, y: Float, z: Float) -> Unit) {
+    for (index in 0 until size) {
+        action(x(index), y(index), z(index))
+    }
+}
+
+fun VertexList.lineStripAsLines(): VertexList = LineStripAsLinesVertexView(this)
+
+class MutableVertexList(initialVertexCapacity: Int = 0) : VertexList {
+
+    private val values = FloatArrayList(initialVertexCapacity * ELEMENTS_PER_VERTEX)
+
+    override val size: Int
+        get() = values.size / ELEMENTS_PER_VERTEX
+
+    override fun x(index: Int): Float = values.getFloat(index.toValueIndex())
+
+    override fun y(index: Int): Float = values.getFloat(index.toValueIndex() + 1)
+
+    override fun z(index: Int): Float = values.getFloat(index.toValueIndex() + 2)
+
+    fun add(x: Float, y: Float, z: Float): MutableVertexList {
+        values.add(x)
+        values.add(y)
+        values.add(z)
+        return this
+    }
+
+    fun add(vec: Vec3f): MutableVertexList = add(vec.x, vec.y, vec.z)
+
+    fun add(vec: Vec3): MutableVertexList = add(vec.x.toFloat(), vec.y.toFloat(), vec.z.toFloat())
+
+    fun addAll(vertices: Iterable<Vec3>): MutableVertexList {
+        vertices.forEach(this::add)
+        return this
+    }
+
+    fun addRelative(vec: Vec3, origin: Vec3): MutableVertexList = add(
+        (vec.x - origin.x).toFloat(),
+        (vec.y - origin.y).toFloat(),
+        (vec.z - origin.z).toFloat(),
+    )
+
+    fun addAllRelative(vertices: Iterable<Vec3>, origin: Vec3): MutableVertexList {
+        vertices.forEach { addRelative(it, origin) }
+        return this
+    }
+
+    fun addRelativeToCamera(vec: Vec3, camera: Camera): MutableVertexList {
+        val cameraPos = camera.position()
+        return addRelative(vec, cameraPos)
+    }
+
+    fun addAllRelativeToCamera(vertices: Iterable<Vec3>, camera: Camera): MutableVertexList {
+        vertices.forEach { addRelativeToCamera(it, camera) }
+        return this
+    }
+
+    inline fun <T> addAll(vertices: Iterable<T>, vertexMapper: (T) -> Vec3): MutableVertexList {
+        vertices.forEach { add(vertexMapper(it)) }
+        return this
+    }
+
+    inline fun <T> addAllRelative(
+        vertices: Iterable<T>,
+        origin: Vec3,
+        vertexMapper: (T) -> Vec3,
+    ): MutableVertexList {
+        vertices.forEach { addRelative(vertexMapper(it), origin) }
+        return this
+    }
+
+    inline fun <T> addAllRelativeToCamera(
+        vertices: Iterable<T>,
+        camera: Camera,
+        vertexMapper: (T) -> Vec3,
+    ): MutableVertexList {
+        vertices.forEach { addRelativeToCamera(vertexMapper(it), camera) }
+        return this
+    }
+
+    private fun Int.toValueIndex(): Int {
+        if (this !in 0 until size) {
+            throw IndexOutOfBoundsException("Index $this out of bounds [0, $size)")
+        }
+
+        return this * ELEMENTS_PER_VERTEX
+    }
+
+    private companion object {
+        const val ELEMENTS_PER_VERTEX = 3
+    }
+}
+
+private class LineStripAsLinesVertexView(private val source: VertexList) : VertexList {
+
+    override val size: Int
+        get() = if (source.size < 2) 0 else (source.size - 1) shl 1
+
+    override fun x(index: Int): Float = source.x(index.toSourceIndex())
+
+    override fun y(index: Int): Float = source.y(index.toSourceIndex())
+
+    override fun z(index: Int): Float = source.z(index.toSourceIndex())
+
+    private fun Int.toSourceIndex(): Int {
+        if (this !in 0 until size) {
+            throw IndexOutOfBoundsException("Index $this out of bounds [0, $size)")
+        }
+
+        return (this shr 1) + (this and 1)
+    }
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/utils/VertexList.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/utils/VertexList.kt
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.floats.FloatArrayList
 import net.ccbluex.liquidbounce.render.engine.type.Vec3f
 import net.minecraft.client.Camera
 import net.minecraft.world.phys.Vec3
+import org.joml.Vector3f
 
 interface VertexList {
 
@@ -33,6 +34,9 @@ interface VertexList {
     fun y(index: Int): Float
 
     fun z(index: Int): Float
+
+    fun vec(index: Int, dest: Vector3f = Vector3f()): Vector3f =
+        dest.set(x(index), y(index), z(index))
 }
 
 inline fun VertexList.forEachVertex(action: (x: Float, y: Float, z: Float) -> Unit) {
@@ -43,6 +47,7 @@ inline fun VertexList.forEachVertex(action: (x: Float, y: Float, z: Float) -> Un
 
 fun VertexList.lineStripAsLines(): VertexList = LineStripAsLinesVertexView(this)
 
+@Suppress("TooManyFunctions")
 class MutableVertexList(initialVertexCapacity: Int = 0) : VertexList {
 
     private val values = FloatArrayList(initialVertexCapacity * ELEMENTS_PER_VERTEX)

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/projectiles/SituationalProjectileAngleCalculator.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/aiming/projectiles/SituationalProjectileAngleCalculator.kt
@@ -90,7 +90,7 @@ object SituationalProjectileAngleCalculator: ProjectileAngleCalculator {
                 .calculateAngleFor(projectileInfo, sourcePos, targetPosFunction, targetShape) ?: return null
 
             val renderer = TrajectoryInfoRenderer.getHypotheticalTrajectory(
-                owner = player,
+                simulationOwner = player,
                 trajectoryInfo = projectileInfo,
                 rotation = rotation,
                 trajectoryType = resolveTrajectoryType(projectileInfo),

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/math/MinecraftVectorExtensions.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/math/MinecraftVectorExtensions.kt
@@ -127,6 +127,8 @@ inline operator fun Vec3.times(scalar: Double): Vec3 = scale(scalar)
 
 inline fun Vec3.dot(x: Double, y: Double, z: Double): Double = this.x * x + this.y * y + this.z * z
 
+inline fun Vec3.dot(v: Vector3fc): Double = this.x * v.x() + this.y * v.y() + this.z * v.z()
+
 /**
  * `this.normalize().scale(newLength)`
  *

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/HeldItemTrajectoryResolver.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/HeldItemTrajectoryResolver.kt
@@ -20,6 +20,7 @@
 package net.ccbluex.liquidbounce.utils.render.trajectory
 
 import net.ccbluex.liquidbounce.utils.item.getEnchantment
+import net.minecraft.core.component.DataComponentGetter
 import net.minecraft.core.component.DataComponents
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.BowItem
@@ -67,7 +68,11 @@ object HeldItemTrajectoryResolver {
                 }
 
                 val trajectoryInfo = TrajectoryInfo.bowWithUsageDuration(useTime) ?: return null
-                singleShot(stack, TrajectoryDescriptor(trajectoryInfo, TrajectoryType.Arrow))
+                singleShot(
+                    icon = stack,
+                    trajectoryDescriptor = TrajectoryDescriptor(trajectoryInfo, TrajectoryType.Arrow),
+                    colorSource = player.getProjectile(stack),
+                )
             }
             is CrossbowItem -> {
                 val chargedProjectiles = stack[DataComponents.CHARGED_PROJECTILES]
@@ -79,6 +84,7 @@ object HeldItemTrajectoryResolver {
                     isMultiShot -> 3
                     else -> 1
                 }.coerceAtLeast(1)
+                val chargedProjectile: DataComponentGetter = chargedProjectiles?.items?.firstOrNull() ?: ItemStack.EMPTY
 
                 val trajectoryDescriptor = if (isCrossbowFirework(chargedProjectiles)) {
                     TrajectoryDescriptor.FIREWORK_ROCKET
@@ -89,7 +95,8 @@ object HeldItemTrajectoryResolver {
                 getShotYawOffsets(shotCount).map { yawOffsetDegrees ->
                     trajectoryDescriptor.toShotDescriptor(
                         yawOffsetDegrees = yawOffsetDegrees,
-                        icon = stack
+                        icon = stack,
+                        colorSource = chargedProjectile,
                     )
                 }
             }
@@ -122,10 +129,11 @@ object HeldItemTrajectoryResolver {
     }
 
     private fun singleShot(
-        stack: ItemStack,
+        icon: ItemStack,
         trajectoryDescriptor: TrajectoryDescriptor,
+        colorSource: ItemStack = icon,
     ): List<TrajectoryShotDescriptor> {
-        return listOf(trajectoryDescriptor.toShotDescriptor(icon = stack))
+        return listOf(trajectoryDescriptor.toShotDescriptor(icon = icon, colorSource = colorSource))
     }
 
     /**

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryDescriptors.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryDescriptors.kt
@@ -19,6 +19,7 @@
 
 package net.ccbluex.liquidbounce.utils.render.trajectory
 
+import net.minecraft.core.component.DataComponentGetter
 import net.minecraft.world.item.ItemStack
 
 @JvmRecord
@@ -29,12 +30,14 @@ data class TrajectoryDescriptor(
     fun toShotDescriptor(
         yawOffsetDegrees: Float = 0f,
         icon: ItemStack = ItemStack.EMPTY,
+        colorSource: DataComponentGetter = icon,
     ): TrajectoryShotDescriptor {
         return TrajectoryShotDescriptor(
             trajectoryInfo = trajectoryInfo,
             trajectoryType = trajectoryType,
             yawOffsetDegrees = yawOffsetDegrees,
-            icon = icon
+            icon = icon,
+            colorSource = colorSource,
         )
     }
 
@@ -86,4 +89,5 @@ data class TrajectoryShotDescriptor(
     val trajectoryType: TrajectoryType,
     val yawOffsetDegrees: Float = 0f,
     val icon: ItemStack = ItemStack.EMPTY,
+    val colorSource: DataComponentGetter = icon,
 )

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryDisplayResolver.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryDisplayResolver.kt
@@ -20,23 +20,69 @@
 package net.ccbluex.liquidbounce.utils.render.trajectory
 
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.minecraft.core.component.DataComponentGetter
+import net.minecraft.core.component.DataComponents
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.projectile.FireworkRocketEntity
 import net.minecraft.world.entity.projectile.arrow.AbstractArrow
 import net.minecraft.world.entity.projectile.arrow.Arrow
 import net.minecraft.world.entity.projectile.hurtingprojectile.Fireball
 import net.minecraft.world.entity.projectile.throwableitemprojectile.ThrowableItemProjectile
-import net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.alchemy.PotionContents
 
 object TrajectoryDisplayResolver {
+    /**
+     * @see Arrow.NO_EFFECT_COLOR
+     */
+    private const val POTION_ARROW_COLOR_NONE = -1
+
     @JvmStatic
-    fun resolveEntityColor(entity: Entity): Color4b {
-        return when (entity) {
-            is Arrow -> Color4b(255, 0, 0, 200)
-            is ThrownEnderpearl -> Color4b(128, 0, 128, 200)
-            is FireworkRocketEntity -> Color4b(255, 165, 0, 220)
-            else -> Color4b(200, 200, 200, 200)
+    fun resolveTrajectoryColor(
+        trajectoryType: TrajectoryType,
+        colorSource: DataComponentGetter = ItemStack.EMPTY,
+        entity: Entity? = null,
+    ): Color4b {
+        return when (trajectoryType) {
+            TrajectoryType.Arrow -> resolveArrowColor(colorSource, entity)
+            TrajectoryType.Potion -> resolvePotionColor(colorSource)
+            TrajectoryType.EnderPearl -> Color4b.PURPLE.alpha(200)
+            TrajectoryType.FishingBobber -> Color4b.CYAN.alpha(200)
+            TrajectoryType.Trident -> Color4b(180, 210, 255, 220)
+            TrajectoryType.Snowball -> Color4b.LIGHT_GRAY.alpha(220)
+            TrajectoryType.Egg -> Color4b(240, 234, 214, 220)
+            TrajectoryType.ExpBottle -> Color4b(120, 230, 120, 220)
+            TrajectoryType.FireworkRocket -> Color4b.ORANGE.alpha(220)
+            TrajectoryType.Fireball -> Color4b.ORANGE.alpha(220)
+            TrajectoryType.WindCharge -> Color4b(180, 235, 255, 220)
+        }
+    }
+
+    private fun resolveArrowColor(
+        colorSource: DataComponentGetter,
+        entity: Entity?,
+    ): Color4b {
+        if (entity is Arrow) {
+            val potionColor = entity.color
+            if (potionColor != POTION_ARROW_COLOR_NONE) {
+                return Color4b.fullAlpha(potionColor).alpha(220)
+            }
+        }
+
+        val potionColor = colorSource[DataComponents.POTION_CONTENTS]?.color
+        return if (potionColor != null) {
+            Color4b.fullAlpha(potionColor).alpha(220)
+        } else {
+            Color4b.WHITE.alpha(220)
+        }
+    }
+
+    private fun resolvePotionColor(colorSource: DataComponentGetter): Color4b {
+        val potionColor = colorSource[DataComponents.POTION_CONTENTS]?.color
+        return if (potionColor != null) {
+            Color4b.fullAlpha(potionColor).alpha(220)
+        } else {
+            Color4b.fullAlpha(PotionContents.BASE_POTION_COLOR).alpha(220)
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
@@ -24,8 +24,9 @@ import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
 import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.drawBoxSide
 import net.ccbluex.liquidbounce.render.drawLines
-import net.ccbluex.liquidbounce.render.utils.MutableVertexList
+import net.ccbluex.liquidbounce.render.drawLinesWithWidth
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.render.utils.lineStripAsLines
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
@@ -281,12 +282,13 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
         trajectoryColor: Color4b,
         blockHitColor: Color4b?,
         entityHitColor: Color4b?,
+        lineWidth: Float = 1f,
     ): SimulationResult {
         val simulationResult = runSimulation(maxTicks)
 
         val (landingPosition, positions) = simulationResult
 
-        env.drawTrajectoryForProjectile(positions, trajectoryColor.argb)
+        env.drawTrajectoryForProjectile(positions, trajectoryColor.argb, lineWidth)
 
         when (landingPosition) {
             null -> return simulationResult
@@ -308,17 +310,23 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
         return simulationResult
     }
 
-    private fun WorldRenderEnvironment.drawTrajectoryForProjectile(positions: List<Vec3>, argb: Int) {
+    private fun WorldRenderEnvironment.drawTrajectoryForProjectile(
+        positions: List<Vec3>,
+        argb: Int,
+        lineWidth: Float,
+    ) {
         val origin = positions.firstOrNull() ?: return
+        val lineVertices = MutableVertexList(positions.size).addAllRelative(positions, origin)
+            .lineStripAsLines()
 
         // Don't use LineStrip because in batch mode
         poseStack.pushPose()
         poseStack.translate(origin.add(renderOffset).subtract(camera.position()))
-        drawLines(
-            argb,
-            MutableVertexList(positions.size).addAllRelative(positions, origin)
-                .lineStripAsLines()
-        )
+        if (lineWidth == 1f) {
+            drawLines(argb, lineVertices)
+        } else {
+            drawLinesWithWidth(argb, lineWidth, lineVertices)
+        }
         poseStack.popPose()
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
@@ -23,8 +23,10 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleFreeze
 import net.ccbluex.liquidbounce.render.WorldRenderEnvironment
 import net.ccbluex.liquidbounce.render.drawBox
 import net.ccbluex.liquidbounce.render.drawBoxSide
-import net.ccbluex.liquidbounce.render.drawLineStripAsLines
+import net.ccbluex.liquidbounce.render.drawLines
+import net.ccbluex.liquidbounce.render.utils.MutableVertexList
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
+import net.ccbluex.liquidbounce.render.utils.lineStripAsLines
 import net.ccbluex.liquidbounce.render.withPositionRelativeToCamera
 import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
 import net.ccbluex.liquidbounce.utils.block.stateOrEmpty
@@ -34,7 +36,6 @@ import net.ccbluex.liquidbounce.utils.math.toRadians
 import net.ccbluex.liquidbounce.utils.client.world
 import net.ccbluex.liquidbounce.utils.entity.box
 import net.ccbluex.liquidbounce.utils.entity.interpolateCurrentPosition
-import net.ccbluex.liquidbounce.utils.kotlin.subList
 import net.ccbluex.liquidbounce.utils.math.copy
 import net.ccbluex.liquidbounce.utils.math.minus
 import net.ccbluex.liquidbounce.utils.math.move
@@ -308,13 +309,16 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
     }
 
     private fun WorldRenderEnvironment.drawTrajectoryForProjectile(positions: List<Vec3>, argb: Int) {
-        val renderedPositions = if (positions.size and 1 != 0) positions.subList(1) else positions
-        val origin = renderedPositions.firstOrNull() ?: return
+        val origin = positions.firstOrNull() ?: return
 
         // Don't use LineStrip because in batch mode
         poseStack.pushPose()
         poseStack.translate(origin.add(renderOffset).subtract(camera.position()))
-        drawLineStripAsLines(argb, renderedPositions.map { it - origin })
+        drawLines(
+            argb,
+            MutableVertexList(positions.size).addAllRelative(positions, origin)
+                .lineStripAsLines()
+        )
         poseStack.popPose()
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/trajectory/TrajectoryInfoRenderer.kt
@@ -60,7 +60,20 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
-    val owner: Entity,
+    /**
+     * Entity used by the simulation as the projectile source.
+     *
+     * This affects spawn position, inherited momentum, clip context, collision filtering,
+     * and projectile-specific hit margin handling.
+     */
+    val simulationOwner: Entity,
+    /**
+     * Entity displayed as the projectile owner in UI.
+     *
+     * This is separate from [simulationOwner] because some real projectiles have no traceable owner and
+     * still need a non-null simulation source entity.
+     */
+    val displayOwner: Entity?,
     val icon: ItemStack,
     velocity: Vec3,
     pos: Vec3,
@@ -94,7 +107,7 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
         @JvmStatic
         @JvmOverloads
         fun getHypotheticalTrajectory(
-            owner: Entity,
+            simulationOwner: Entity,
             trajectoryInfo: TrajectoryInfo,
             trajectoryType: TrajectoryType,
             rotation: Rotation,
@@ -104,31 +117,33 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
             val yawRadians = rotation.yaw.toRadians()
             val pitchRadians = rotation.pitch.toRadians()
 
-            val interpolatedOffset = owner.interpolateCurrentPosition(partialTicks) - owner.position()
+            val interpolatedOffset =
+                simulationOwner.interpolateCurrentPosition(partialTicks) - simulationOwner.position()
 
             val pos = Vec3(
-                owner.x,
-                owner.eyeY - 0.10000000149011612,
-                owner.z
+                simulationOwner.x,
+                simulationOwner.eyeY - 0.10000000149011612,
+                simulationOwner.z
             )
 
-            var velocity = Vec3(
-                -sin(yawRadians) * cos(pitchRadians).toDouble(),
-                -sin((rotation.pitch + trajectoryInfo.roll).toRadians()).toDouble(),
-                cos(yawRadians) * cos(pitchRadians).toDouble()
+            var velocity = projectileDirectionFromRotation(
+                yawRadians = yawRadians,
+                pitchRadians = pitchRadians,
+                pitchWithRollRadians = (rotation.pitch + trajectoryInfo.roll).toRadians()
             ).withLength(trajectoryInfo.initialVelocity)
 
             //In Freeze, this momentum is the residual value before freezing.
             if (trajectoryInfo.copiesPlayerVelocity && !ModuleFreeze.running) {
                 velocity = velocity.add(
-                    owner.deltaMovement.x,
-                    if (owner.onGround()) 0.0 else owner.deltaMovement.y,
-                    owner.deltaMovement.z
+                    simulationOwner.deltaMovement.x,
+                    if (simulationOwner.onGround()) 0.0 else simulationOwner.deltaMovement.y,
+                    simulationOwner.deltaMovement.z
                 )
             }
 
             return TrajectoryInfoRenderer(
-                owner = owner,
+                simulationOwner = simulationOwner,
+                displayOwner = simulationOwner,
                 icon = icon,
                 velocity = velocity,
                 pos = pos,
@@ -138,6 +153,19 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
                 renderOffset = interpolatedOffset.add(-cos(yawRadians) * 0.16, 0.0, -sin(yawRadians) * 0.16)
             )
         }
+
+        /**
+         * @see Projectile.shootFromRotation
+         */
+        private fun projectileDirectionFromRotation(
+            yawRadians: Float,
+            pitchRadians: Float,
+            pitchWithRollRadians: Float,
+        ): Vec3 = Vec3(
+            -sin(yawRadians) * cos(pitchRadians).toDouble(),
+            -sin(pitchWithRollRadians).toDouble(),
+            cos(yawRadians) * cos(pitchRadians).toDouble()
+        )
     }
 
     private val velocity = velocity.copy() // Used as mutable
@@ -213,7 +241,7 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
                 posAfter,
                 ClipContext.Block.COLLIDER,
                 ClipContext.Fluid.NONE,
-                owner
+                simulationOwner
             )
         )
         if (blockHitResult.type != HitResult.Type.MISS) {
@@ -222,17 +250,18 @@ class TrajectoryInfoRenderer @Suppress("LongParameterList") constructor(
 
         val entityHitResult = ProjectileUtil.getEntityHitResult(
             world,
-            owner,
+            simulationOwner,
             posBefore,
             posAfter,
             hitbox.move(posBefore).expandTowards(posAfter - posBefore).inflate(1.0),
             {
                 val canCollide = !it.isSpectator && it.isAlive
-                val shouldCollide = it.isPickable || owner !== player && it === player
+                val shouldCollide = it.isPickable || simulationOwner !== player && it === player
 
-                return@getEntityHitResult canCollide && shouldCollide && !owner.isPassengerOfSameVehicle(it)
+                return@getEntityHitResult canCollide && shouldCollide &&
+                    !simulationOwner.isPassengerOfSameVehicle(it)
             },
-            if (owner is Projectile) ProjectileUtil.computeMargin(owner) else 0f,
+            if (simulationOwner is Projectile) ProjectileUtil.computeMargin(simulationOwner) else 0f,
         )
 
         return if (entityHitResult != null && entityHitResult.type != HitResult.Type.MISS) {


### PR DESCRIPTION
- Reworked trajectories ownership/display handling to avoid showing the projectile itself as its owner.
- Added per-projectile trajectory colors for both held and active projectiles, including potion-colored potions and tipped arrows.
- Added separate line width settings for held vs active trajectories.
- Switched trajectory culling to use the render camera instead of the player view.
- Refactored trajectory rendering helpers to support wider line strips and cleaner projectile metadata flow.

closes #8586