### PR TITLE
feat(UI): Suppress menu header transitions

### DIFF
--- a/src-theme/src/App.svelte
+++ b/src-theme/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import Router, {push} from "svelte-spa-router";
+    import Router, {location, push} from "svelte-spa-router";
     import Hud from "./routes/hud/Hud.svelte";
     import {getMetadata, getTheme, getVirtualScreen} from "./integration/rest";
     import {cleanupListeners, listenAlways} from "./integration/ws";
@@ -18,16 +18,21 @@
     import TabbedClickGui from "./routes/clickgui/TabbedClickGui.svelte";
     import {intToRgba, rgbaToHex} from "./integration/util";
     import type {ThemeColorChangeEvent} from "./integration/events";
+    import Menu from "./routes/menu/common/Menu.svelte";
+    import MenuContent from "./routes/menu/common/MenuContent.svelte";
 
-    const routes = {
-        "/clickgui": TabbedClickGui,
-        "/hud": Hud,
-        "/inventory": Inventory,
+    const menuRoutes = {
         "/title": Title,
         "/multiplayer": Multiplayer,
         "/altmanager": AltManager,
         "/singleplayer": Singleplayer,
         "/proxymanager": ProxyManager,
+    };
+
+    const routes = {
+        "/clickgui": TabbedClickGui,
+        "/hud": Hud,
+        "/inventory": Inventory,
         "/none": None,
         "/disconnected": Disconnected,
         "/browser": Browser
@@ -35,10 +40,18 @@
 
     const SURFACE_TINT_MIX = 18;
 
+    function isMenuRoute(route: string): boolean {
+        return route in menuRoutes;
+    }
+
     async function changeRoute(name: string) {
-        cleanupListeners();
+        const nextRoute = `/${name}`;
+        if (!isMenuRoute($location) || !isMenuRoute(nextRoute)) {
+            cleanupListeners();
+        }
+
         console.log(`[Router] Redirecting to ${name}`);
-        await push(`/${name}`);
+        await push(nextRoute);
     }
 
     function setThemeColor(name: string, value: string) {
@@ -116,5 +129,15 @@
 </script>
 
 <main>
-    <Router {routes}/>
+    {#if isMenuRoute($location)}
+        <Menu>
+            {#key $location}
+                <MenuContent>
+                    <Router routes={menuRoutes}/>
+                </MenuContent>
+            {/key}
+        </Menu>
+    {:else}
+        <Router {routes}/>
+    {/if}
 </main>

--- a/src-theme/src/routes/menu/altmanager/AltManager.svelte
+++ b/src-theme/src/routes/menu/altmanager/AltManager.svelte
@@ -12,7 +12,6 @@
     import SwitchSetting from "../common/setting/SwitchSetting.svelte";
     import OptionBar from "../common/optionbar/OptionBar.svelte";
     import MenuListItem from "../common/menulist/MenuListItem.svelte";
-    import Menu from "../common/Menu.svelte";
     import ButtonContainer from "../common/buttons/ButtonContainer.svelte";
     import MenuListItemTag from "../common/menulist/MenuListItemTag.svelte";
     import MenuList from "../common/menulist/MenuList.svelte";
@@ -118,7 +117,6 @@
 
 <DirectLoginModal bind:visible={directLoginModalVisible}/>
 <AddAccountModal bind:visible={addAccountModalVisible}/>
-<Menu>
     <OptionBar>
         <Search on:search={handleSearch}/>
         <SwitchSetting title="Premium Only" bind:value={premiumOnly}/>
@@ -170,7 +168,6 @@
             <IconTextButton icon="icon-back.svg" title="Back" on:click={() => deleteScreen()}/>
         </ButtonContainer>
     </BottomButtonWrapper>
-</Menu>
 
 <style lang="scss">
   .uuid {

--- a/src-theme/src/routes/menu/common/Menu.svelte
+++ b/src-theme/src/routes/menu/common/Menu.svelte
@@ -19,11 +19,11 @@
         <div transition:fly|global={{duration: 700, y: -100}}>
             <Header/>
         </div>
-
-        <div class="menu-wrapper">
-            <slot/>
-        </div>
     {/if}
+
+    <div class="menu-wrapper">
+        <slot/>
+    </div>
 </div>
 
 <style lang="scss">

--- a/src-theme/src/routes/menu/common/MenuContent.svelte
+++ b/src-theme/src/routes/menu/common/MenuContent.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import {onMount} from "svelte";
+
+    const TRANSITION_DURATION = 700;
+
+    let ready = false;
+
+    onMount(() => {
+        const timeout = window.setTimeout(() => {
+            ready = true;
+        }, TRANSITION_DURATION);
+
+        return () => window.clearTimeout(timeout);
+    });
+</script>
+
+{#if ready}
+    <slot/>
+{/if}

--- a/src-theme/src/routes/menu/common/header/account/Account.svelte
+++ b/src-theme/src/routes/menu/common/header/account/Account.svelte
@@ -34,8 +34,8 @@
 
     $: renderedAccounts = accounts.filter(a => a.username.toLowerCase().includes(searchQuery.toLowerCase()) || searchQuery === "");
 
-    const inAccountManager = $location === "/altmanager";
-    const inTitle = $location === "/title";
+    $: inAccountManager = $location === "/altmanager";
+    $: inTitle = $location === "/title";
 
     async function refreshSession() {
         const session = await getSession();
@@ -258,6 +258,7 @@
       cursor: pointer;
       display: flex;
       align-items: center;
+      transition: ease opacity .2s;
 
       &:disabled {
         pointer-events: none;

--- a/src-theme/src/routes/menu/common/modal/Modal.svelte
+++ b/src-theme/src/routes/menu/common/modal/Modal.svelte
@@ -11,10 +11,18 @@
         dispatch("close");
         visible = false;
     }
+
+    function portal(node: HTMLElement) {
+        document.body.appendChild(node);
+
+        return {
+            destroy: () => node.remove()
+        };
+    }
 </script>
 
 {#if visible}
-    <div class="modal-wrapper" transition:fade|global={{duration: 200}}>
+    <div class="modal-wrapper" transition:fade|global={{duration: 200}} use:portal>
         <div class="modal" in:fly|global={{duration: 300, y: -100}} out:fly|global={{duration: 300, y: -100}}>
             <button class="button-modal-close" on:click={handleClick}>
                 <img src="img/menu/icon-close.svg" alt="close">

--- a/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
+++ b/src-theme/src/routes/menu/multiplayer/Multiplayer.svelte
@@ -4,7 +4,6 @@
     import BottomButtonWrapper from "../common/buttons/BottomButtonWrapper.svelte";
     import ButtonContainer from "../common/buttons/ButtonContainer.svelte";
     import IconTextButton from "../common/buttons/IconTextButton.svelte";
-    import Menu from "../common/Menu.svelte";
     import Search from "../common/Search.svelte";
     import MenuListItem from "../common/menulist/MenuListItem.svelte";
     import MenuListItemButton from "../common/menulist/MenuListItemButton.svelte";
@@ -173,7 +172,6 @@
                      resourcePackPolicy={currentEditServer.resourcePackPolicy}/>
 {/if}
 <DirectConnectModal bind:visible={directConnectModalVisible}/>
-<Menu>
     <OptionBar>
         <Search on:search={handleSearch}/>
 
@@ -238,4 +236,3 @@
             <IconTextButton icon="icon-back.svg" title="Back" on:click={() => openScreen("title")}/>
         </ButtonContainer>
     </BottomButtonWrapper>
-</Menu>

--- a/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
+++ b/src-theme/src/routes/menu/proxymanager/ProxyManager.svelte
@@ -13,7 +13,6 @@
     import BottomButtonWrapper from "../common/buttons/BottomButtonWrapper.svelte";
     import OptionBar from "../common/optionbar/OptionBar.svelte";
     import MenuListItem from "../common/menulist/MenuListItem.svelte";
-    import Menu from "../common/Menu.svelte";
     import ButtonContainer from "../common/buttons/ButtonContainer.svelte";
     import MenuListItemTag from "../common/menulist/MenuListItemTag.svelte";
     import MenuList from "../common/menulist/MenuList.svelte";
@@ -184,7 +183,6 @@
                     password={currentEditProxy.credentials?.password ?? ""}
                     requiresAuthentication={currentEditProxy.credentials !== undefined}/>
 {/if}
-<Menu>
     <OptionBar>
         <Search on:search={handleSearch}/>
         <SwitchSetting title="Favorites Only" bind:value={favoritesOnly}/>
@@ -237,4 +235,3 @@
             <IconTextButton icon="icon-back.svg" title="Back" on:click={() => deleteScreen()}/>
         </ButtonContainer>
     </BottomButtonWrapper>
-</Menu>

--- a/src-theme/src/routes/menu/singleplayer/Singleplayer.svelte
+++ b/src-theme/src/routes/menu/singleplayer/Singleplayer.svelte
@@ -9,7 +9,6 @@
     import BottomButtonWrapper from "../common/buttons/BottomButtonWrapper.svelte";
     import OptionBar from "../common/optionbar/OptionBar.svelte";
     import MenuListItem from "../common/menulist/MenuListItem.svelte";
-    import Menu from "../common/Menu.svelte";
     import ButtonContainer from "../common/buttons/ButtonContainer.svelte";
     import MenuListItemTag from "../common/menulist/MenuListItemTag.svelte";
     import MenuList from "../common/menulist/MenuList.svelte";
@@ -67,7 +66,6 @@
     }
 </script>
 
-<Menu>
     <OptionBar>
         <Search on:search={handleSearch}/>
         <MultiSelect title="Game Mode" options={["Survival", "Creative", "Adventure", "Spectator"]}
@@ -115,7 +113,6 @@
             <IconTextButton icon="icon-back.svg" title="Back" on:click={() => openScreen("title")}/>
         </ButtonContainer>
     </BottomButtonWrapper>
-</Menu>
 
 <style lang="scss">
   .world-name {

--- a/src-theme/src/routes/menu/title/Title.svelte
+++ b/src-theme/src/routes/menu/title/Title.svelte
@@ -12,7 +12,6 @@
         openScreen,
         toggleBackgroundShaderEnabled
     } from "../../../integration/rest";
-    import Menu from "../common/Menu.svelte";
     import {fly} from "svelte/transition";
     import {onMount} from "svelte";
     import {notification} from "../common/header/notification_store";
@@ -56,7 +55,6 @@
         <ConfettiBackground />
     {/if}
 
-    <Menu>
         <div class="content">
             <div class="main-buttons">
                 {#if regularButtonsShown}
@@ -99,13 +97,15 @@
                 </ButtonContainer>
             </div>
         </div>
-    </Menu>
 </div>
 
 <style>
     .title-screen {
         position: relative;
         isolation: isolate;
+        display: flex;
+        flex: 1;
+        flex-direction: column;
     }
 
     .content {


### PR DESCRIPTION
Currently, every time a menu route is changed, the header disappeats and reappears unnecessarily. This PR suppresses this behavior when not needed (e.g., when transitioning from a HTML UI to a HTML UI).