### PR TITLE
feat(ClickGUI): Scrollbars

### DIFF
--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -94,7 +94,7 @@
         offsetX = e.clientX * (2 / $scaleFactor) - panelConfig.left;
         offsetY = e.clientY * (2 / $scaleFactor) - panelConfig.top;
         panelConfig.zIndex = ++$maxPanelZIndex;
-        
+
         $showGrid = $snappingEnabled && !expandButtonElement.contains(e.target as HTMLElement);
     }
 
@@ -268,10 +268,15 @@
     &.expanded {
       max-height: 545px;
     }
-  }
 
-  .modules::-webkit-scrollbar {
-    width: 0;
+    &::-webkit-scrollbar {
+      width: 2px;
+      height: 2px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 2px;
+    }
   }
 
   .expand-toggle {


### PR DESCRIPTION
This PR adds thin scrollbars to the ClickGUI panels. I believe some people don't realize they can scroll down otherwise.

<img width="1263" height="778" alt="image" src="https://github.com/user-attachments/assets/2a0ecd7a-178a-4bc6-9aa8-296ea6b6b6cd" />
