### PR TITLE
feat(ClickGUI): clickable expand arrow

### DIFF
--- a/src-theme/src/routes/clickgui/Module.svelte
+++ b/src-theme/src/routes/clickgui/Module.svelte
@@ -95,7 +95,9 @@
         }
     }
 
-    async function toggleExpanded() {
+    async function toggleExpanded(e: MouseEvent) {
+        e.stopPropagation();
+
         expanded = !expanded;
         await setItem(path, expanded.toString());
     }
@@ -105,7 +107,6 @@
 <div
         class="module"
         class:expanded
-        class:has-settings={hasSettings}
         in:slide={{ duration: 500, easing: quintOut }}
         out:slide={{ duration: 500, easing: quintOut }}
 >
@@ -121,6 +122,17 @@
             class:highlight={name === $highlightModuleName}
     >
         {$spaceSeperatedNames ? convertToSpacedString(name) : name}
+
+        {#if hasSettings}
+            <button
+                    class="expand-arrow"
+                    aria-label="Expand settings"
+                    aria-expanded={expanded}
+                    on:click={toggleExpanded}
+            >
+                <span class="expand-arrow-icon"></span>
+            </button>
+        {/if}
     </div>
 
     {#if expanded && configurable}
@@ -133,8 +145,6 @@
 </div>
 
 <style lang="scss">
-  @use "./icon-settings-expand" as *;
-
   .module {
     position: relative;
 
@@ -176,16 +186,34 @@
       padding: 0 11px 0 7px;
     }
 
-    &.has-settings {
-      .name::after {
-        @include icon-settings-expand($right: 15px);
-        opacity: 0.5;
-      }
+    .expand-arrow {
+      all: unset;
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 40px;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
 
-      &.expanded .name::after {
-        transform: translateY(-50%) rotate(0);
-        opacity: 1;
-      }
+    .expand-arrow-icon {
+      width: 11px;
+      height: 11px;
+      display: block;
+      background-image: url("/img/clickgui/icon-settings-expand.svg");
+      background-position: center;
+      background-repeat: no-repeat;
+      opacity: 0.5;
+      transform: rotate(-90deg);
+      transition: ease opacity 0.2s, ease transform 0.4s;
+    }
+
+    &.expanded .expand-arrow-icon {
+      transform: rotate(0);
+      opacity: 1;
     }
   }
 </style>


### PR DESCRIPTION
This PR makes the expand arrow of modules left-clickable. This should prevent confusion with people who do not realize they need to rightclick modules to show their settings.