### PR TITLE
fix(Sneak/Vanilla): does nothing due to protocol change since 1.21.6

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSneak.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSneak.kt
@@ -77,8 +77,26 @@ object ModuleSneak : ClientModule("Sneak", ModuleCategories.MOVEMENT) {
 
     private object Vanilla : Mode("Vanilla") {
 
+        private var networkSneaking = false
+
         override val parent: ModeValueGroup<Mode>
             get() = modes
+
+        @Suppress("unused")
+        private val networkTick = handler<PlayerNetworkMovementTickEvent> {
+            if (!usesViaFabricPlus || isNewerThanOrEquals1_21_6) {
+                return@handler
+            }
+
+            val shouldSneak = !player.moving || !notDuringMove
+            if (shouldSneak && !networkSneaking) {
+                network.send1_21_5StartSneaking()
+                networkSneaking = true
+            } else if (!shouldSneak && networkSneaking) {
+                network.send1_21_5StopSneaking()
+                networkSneaking = false
+            }
+        }
 
         @Suppress("unused")
         private val sneakNetworkHandler = handler<PacketEvent> { event ->
@@ -87,6 +105,13 @@ object ModuleSneak : ClientModule("Sneak", ModuleCategories.MOVEMENT) {
             }
 
             event.packet.forceSneak = true
+        }
+
+        override fun disable() {
+            if (networkSneaking) {
+                network.send1_21_5StopSneaking()
+                networkSneaking = false
+            }
         }
 
     }


### PR DESCRIPTION
Since 1.21.6, enum entry `START_SNEAKING` and `STOP_SNEAKING` have been removed from `ServerboundPlayerCommandPacket.Action`.

Now directly send it with Via's API

closes #8139