### PR TITLE
feat(clickgui): auto-align panels on background double-click

### DIFF
--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -5,23 +5,148 @@
     import Description from "./Description.svelte";
     import {fade} from "svelte/transition";
     import {onMount} from "svelte";
+    import {get} from "svelte/store";
     import {getModules} from "../../integration/rest";
     import {groupByCategory} from "../../integration/util";
+    import {animatePanels, panelHandles, scaleFactor} from "./clickgui_store";
 
     let categories = $state<GroupedModules>({});
     let modules = $state<Module[]>([]);
+
+    type AlignZone = "left" | "right" | "center";
+
+    const ALIGN_GAP = 15;
+    const EDGE_MARGIN = 15;
+    const CENTER_TOP = 150;
 
     onMount(async () => {
         modules = await getModules();
         categories = groupByCategory(modules);
     });
+
+    function detectZone(nx: number): AlignZone {
+        if (nx < 0.4) return "left";
+        if (nx > 0.6) return "right";
+        return "center";
+    }
+
+    function handleBackgroundDblClick(e: MouseEvent) {
+        const nx = e.clientX / window.innerWidth;
+
+        arrangePanels(detectZone(nx));
+    }
+
+    function arrangePanels(zone: AlignZone) {
+        const handles = get(panelHandles).slice().sort((a, b) => a.index - b.index);
+        if (handles.length === 0) {
+            return;
+        }
+
+        const areaWidth = document.documentElement.clientWidth * (2 / $scaleFactor);
+        const areaHeight = document.documentElement.clientHeight * (2 / $scaleFactor);
+
+        const items = handles.map((handle) => ({handle, ...handle.getSize()}));
+
+        $animatePanels = true;
+
+        switch (zone) {
+            case "left":
+            case "right": {
+                let columnEdge = zone === "left" ? EDGE_MARGIN : areaWidth - EDGE_MARGIN;
+                let y = EDGE_MARGIN;
+                let columnWidth = 0;
+
+                for (const {handle, width, height} of items) {
+                    if (y + height > areaHeight - EDGE_MARGIN && y > EDGE_MARGIN) {
+                        columnEdge += (zone === "left" ? 1 : -1) * (columnWidth + ALIGN_GAP);
+                        y = EDGE_MARGIN;
+                        columnWidth = 0;
+                    }
+                    handle.setPosition(zone === "left" ? columnEdge : columnEdge - width, y);
+                    y += height + ALIGN_GAP;
+                    columnWidth = Math.max(columnWidth, width);
+                }
+                break;
+            }
+            case "center": {
+                const layout: { left: number; top: number }[] = [];
+                let x = 0;
+                let y = 0;
+                let rowHeight = 0;
+                let blockWidth = 0;
+
+                for (const {width, height} of items) {
+                    if (x + width > areaWidth && x > 0) {
+                        y += rowHeight + ALIGN_GAP;
+                        x = 0;
+                        rowHeight = 0;
+                    }
+                    layout.push({left: x, top: y});
+                    x += width + ALIGN_GAP;
+                    rowHeight = Math.max(rowHeight, height);
+                    blockWidth = Math.max(blockWidth, x - ALIGN_GAP);
+                }
+
+                const offsetX = Math.max(0, (areaWidth - blockWidth) / 2);
+
+                items.forEach(({handle}, i) => {
+                    handle.setPosition(layout[i].left + offsetX, layout[i].top + CENTER_TOP);
+                });
+                break;
+            }
+        }
+
+        setTimeout(() => ($animatePanels = false), 300);
+    }
 </script>
 
 <div class="clickgui" transition:fade|global={{ duration: 200 }}>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+            class="align-catcher"
+            ondblclick={handleBackgroundDblClick}
+    ></div>
+
     <Description/>
     <Search modules={structuredClone($state.snapshot(modules))}/>
 
     {#each Object.entries(categories) as [category, modules], panelIndex (category)}
         <Panel {category} {modules} {panelIndex}/>
     {/each}
+
+    <div class="align-hint">Double-click empty space to align panels</div>
 </div>
+
+<style lang="scss">
+  .align-catcher {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .align-hint {
+    position: fixed;
+    bottom: 22px;
+    left: 50%;
+    z-index: 100000;
+    transform: translateX(-50%) translateY(6px);
+    padding: 7px 15px;
+    border-radius: 999px;
+    background-color: var(--clickgui-base-90-color);
+    color: var(--clickgui-text-dimmed-color);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 0 10px var(--clickgui-base-50-color);
+    opacity: 0;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .align-catcher:hover ~ .align-hint {
+    opacity: 0.85;
+    transform: translateX(-50%) translateY(0);
+    transition: opacity 0.3s ease 0.5s, transform 0.3s ease 0.5s;
+  }
+</style>

--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {onMount} from "svelte";
+    import {onDestroy, onMount} from "svelte";
     import type {Module as TModule} from "../../integration/types";
     import {listen} from "../../integration/ws";
     import Module from "./Module.svelte";
@@ -7,9 +7,12 @@
     import {fade} from "svelte/transition";
     import {quintOut} from "svelte/easing";
     import {
+        animatePanels,
         gridSize,
         highlightModuleName,
         maxPanelZIndex,
+        type PanelHandle,
+        panelHandles,
         scaleFactor,
         showGrid,
         snappingEnabled
@@ -90,6 +93,8 @@
     function onMouseDown(e: MouseEvent) {
         if (e.button !== 0 && e.button !== 1) return;
 
+        $animatePanels = false;
+
         moving = true;
         offsetX = e.clientX * (2 / $scaleFactor) - panelConfig.left;
         offsetY = e.clientY * (2 / $scaleFactor) - panelConfig.top;
@@ -158,7 +163,24 @@
         modules = modules;
     });
 
+    const panelHandle: PanelHandle = {
+        category,
+        index: panelIndex,
+        getSize: () => ({
+            width: panelElement.offsetWidth,
+            height: panelElement.offsetHeight,
+        }),
+        setPosition: (left: number, top: number) => {
+            panelConfig.left = left;
+            panelConfig.top = top;
+            fixPosition();
+            savePanelConfig();
+        },
+    };
+
     onMount(() => {
+        panelHandles.update((handles) => [...handles, panelHandle]);
+
         if (!modulesElement) {
             return;
         }
@@ -167,6 +189,10 @@
             top: panelConfig.scrollTop,
             behavior: "smooth"
         });
+    });
+
+    onDestroy(() => {
+        panelHandles.update((handles) => handles.filter((h) => h !== panelHandle));
     });
 
     function handleKeydown(e: KeyboardEvent) {
@@ -192,6 +218,7 @@
 
 <div
         class="panel"
+        class:animate={$animatePanels}
         style="left: {panelConfig.left}px; top: {panelConfig.top}px; z-index: {panelConfig.zIndex};"
         bind:this={panelElement}
         transition:fade|global={{duration: 200, easing: quintOut}}
@@ -238,6 +265,10 @@
     will-change: transform;
     transition: none;
     user-select: none;
+
+    &.animate {
+      transition: left 0.25s ease, top 0.25s ease;
+    }
   }
 
   .title {

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -22,3 +22,14 @@ export const showGrid: Writable<boolean> = writable(false);
 export const snappingEnabled: Writable<boolean> = writable(true);
 
 export const gridSize: Writable<number> = writable(10);
+
+export interface PanelHandle {
+    category: string;
+    index: number;
+    getSize: () => { width: number; height: number };
+    setPosition: (left: number, top: number) => void;
+}
+
+export const panelHandles: Writable<PanelHandle[]> = writable([]);
+
+export const animatePanels: Writable<boolean> = writable(false);


### PR DESCRIPTION
Double-click empty space in the ClickGUI to auto-arrange all panels toward that spot:
- left / right = vertical column on that side
- center = grouped near the top under the search bar

Panels glide into place and dragging still works like before.
