### PR TITLE
fix(render2d): empty scissor guard

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
@@ -79,7 +79,7 @@ private fun Matrix3x2fc.transformMaxBounds(
 }
 
 /**
- * @see net.minecraft.client.gui.render.state.ColoredRectangleRenderState.getBounds
+ * @see net.minecraft.client.renderer.state.gui.ColoredRectangleRenderState.getBounds
  */
 fun GuiGraphicsExtractor.getBounds(left: Float, top: Float, right: Float, bottom: Float): ScreenRectangle {
     val rect = this.pose().transformMaxBounds(left, top, right, bottom)
@@ -87,7 +87,7 @@ fun GuiGraphicsExtractor.getBounds(left: Float, top: Float, right: Float, bottom
 }
 
 /**
- * @see net.minecraft.client.gui.render.state.ColoredRectangleRenderState.getBounds
+ * @see net.minecraft.client.renderer.state.gui.ColoredRectangleRenderState.getBounds
  */
 fun GuiGraphicsExtractor.getBoundsXYWH(x: Float, y: Float, w: Float, h: Float): ScreenRectangle {
     return getBounds(x, y, x + w, y + h)
@@ -113,12 +113,10 @@ inline fun GuiGraphicsExtractor.ScissorStack.withPush(
     rect: ScreenRectangle,
     block: GuiGraphicsExtractor.ScissorStack.() -> Unit,
 ) {
+    if (rect.width <= 0 || rect.height <= 0) return
     push(rect)
     try {
-        val visible = peek()
-        if (visible != null && visible.width() > 0 && visible.height() > 0) {
-            block()
-        }
+        block()
     } finally {
         pop()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/render/Render2D.kt
@@ -115,7 +115,10 @@ inline fun GuiGraphicsExtractor.ScissorStack.withPush(
 ) {
     push(rect)
     try {
-        block()
+        val visible = peek()
+        if (visible != null && visible.width() > 0 && visible.height() > 0) {
+            block()
+        }
     } finally {
         pop()
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/Alignment.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/utils/render/Alignment.kt
@@ -58,7 +58,7 @@ class Alignment(
             ScreenAxisY.TOP -> verticalOffset.toFloat()
             ScreenAxisY.CENTER_TRANSLATED -> screenHeight / 2f - height / 2f + verticalOffset.toFloat()
             ScreenAxisY.BOTTOM -> screenHeight - height - verticalOffset.toFloat()
-            ScreenAxisY.CENTER -> screenWidth / 2f - height / 2f + verticalOffset.toFloat()
+            ScreenAxisY.CENTER -> screenHeight / 2f - height / 2f + verticalOffset.toFloat()
         }
 
         return BoundingBox2f(x, y, x + width, y + height)


### PR DESCRIPTION
Two small render fixes:
- ScreenAxisY.CENTER used screenWidth instead of screenHeight, so vertical centering was off
- ScissorStack.withPush now skips drawing when the visible area is empty
