### PR TITLE
fix(UI): HUD component setting expanded states not unique

### DIFF
--- a/src-theme/src/routes/clickgui/tabs/hud_editor/ComponentSettings.svelte
+++ b/src-theme/src/routes/clickgui/tabs/hud_editor/ComponentSettings.svelte
@@ -89,7 +89,7 @@
 >
     <div class="settings" style="transform: translateX({marginLeft}px)">
         {#if configurable !== undefined}
-            <TogglableSetting path={name} bind:setting={configurable} on:change={handleSettingChange}>
+            <TogglableSetting path="hud.components.{name}.{id}" bind:setting={configurable} on:change={handleSettingChange}>
                 <div class="remove-component" slot="control" let:disable let:label>
                     <button
                             title="Remove component"


### PR DESCRIPTION
This PR ensures that the path of each HUD component setting is unique to the actual instance of said component. For example, two text components would previously have referenced the same expanded state.