### PR TITLE
fix(client): avoid Unit-to-Void cast during resource reload

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -522,11 +522,10 @@ object LiquidBounce : EventListener {
                 .thenCompose {
                     val prepareDispatcher = prepareExecutor.asCoroutineDispatcher()
                     val applyDispatcher = applyExecutor.asCoroutineDispatcher()
-                    @Suppress("UNCHECKED_CAST") // Kotlin Unit to Java Void
                     initializeClient(
                         workerDispatcher = prepareDispatcher,
                         renderThreadDispatcher = applyDispatcher,
-                    ) as CompletableFuture<Void>
+                    ).thenApply<Void> { null }
                 }
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -196,11 +196,11 @@ object LiquidBounce : EventListener {
     private fun initializeClient(
         workerDispatcher: CoroutineDispatcher,
         renderThreadDispatcher: CoroutineDispatcher,
-    ): CompletableFuture<Unit> = CoroutineScope(
+    ): CompletableFuture<Void?> = CoroutineScope(
         renderThreadDispatcher + CoroutineName("$CLIENT_NAME Initializer")
-    ).future {
+    ).future<Void?> {
         if (isInitialized) {
-            return@future
+            return@future null
         }
 
         // Ensure we are on the render thread
@@ -237,6 +237,7 @@ object LiquidBounce : EventListener {
 
         isInitialized = true
         logger.info("$CLIENT_NAME has been successfully initialized.")
+        null
     }.exceptionally { throwable ->
         ErrorHandler.fatal(throwable, additionalMessage = "$CLIENT_NAME initializer")
     }
@@ -525,7 +526,7 @@ object LiquidBounce : EventListener {
                     initializeClient(
                         workerDispatcher = prepareDispatcher,
                         renderThreadDispatcher = applyDispatcher,
-                    ).thenApply<Void> { null }
+                    )
                 }
         }
 


### PR DESCRIPTION
## Description

`ClientResourceReloader.reload` declares a `CompletableFuture<Void>`, but it
currently unchecked-casts the `CompletableFuture<Unit>` returned by
`initializeClient`.

Because generic types are erased, the cast initially succeeds. Once
initialization completes, however, the future still contains `kotlin.Unit`.
Minecraft's reload chain then attempts to consume that value as
`java.lang.Void`, resulting in:

```text
java.lang.ClassCastException: class kotlin.Unit cannot be cast to class java.lang.Void
```

This causes Minecraft to treat the resource-pack reload as failed and can
leave the client at a black screen during startup.

Map the successful initializer result to `null` with
`thenApply<Void> { null }` instead. `null` is the expected completion value
for `CompletableFuture<Void>`, while exceptional completion remains
unchanged.

## Testing

- `./gradlew compileKotlin`
- `./gradlew build`
  - Detekt passed
  - 231 tests passed
- Manually validated the equivalent completion-value fix with Minecraft 26.2,
  Fabric Loader 0.19.3, and LiquidBounce 0.38.1; client initialization
  completed and the black screen was resolved.
