### PR TITLE
Revert "chore(deps): bump polyglot from 25.0.3 to 25.1.3"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ mcef = "3.3.2-26.2-SNAPSHOT"
 # mc-authlib
 mc_authlib = "1.7.1"
 # Polyglot
-polyglot = "25.1.3"
+polyglot = "25.0.3"
 # djl
 djl = "0.36.0"
 # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp


### PR DESCRIPTION
Reverts CCBlueX/LiquidBounce#8589

This breaks the ability to load the engine on some old JDKs.