### PR TITLE
fix(Fly): fix flight behavior and state handling

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/ModuleFly.kt
@@ -50,6 +50,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.vulca
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.modes.vulcan.FlyVulcan286Teleport
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.client.markAsError
+import net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket
 
 /**
@@ -117,12 +118,27 @@ object ModuleFly : ClientModule("Fly", ModuleCategories.MOVEMENT, aliases = list
 
     private val disableOnSetback by boolean("DisableOnSetback", false)
 
+    private var wasFlyingAllowed = false
+
+    override fun onEnabled() {
+        wasFlyingAllowed = player.abilities.mayfly
+        player.abilities.mayfly = false
+    }
+
+    override fun onDisabled() {
+        player.abilities.mayfly = wasFlyingAllowed
+    }
+
     @Suppress("unused")
     private val packetHandler = handler<PacketEvent> { event ->
         // Setback detection
-        if (event.packet is ClientboundPlayerPositionPacket && disableOnSetback) {
+        if (disableOnSetback && event.packet is ClientboundPlayerPositionPacket) {
             chat(markAsError(message("setbackDetected")))
             enabled = false
+        }
+
+        if (event.packet is ClientboundPlayerAbilitiesPacket) {
+            wasFlyingAllowed = event.packet.canFly()
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -32,11 +32,11 @@ import net.ccbluex.liquidbounce.event.sequenceHandler
 import net.ccbluex.liquidbounce.event.tickHandler
 import net.ccbluex.liquidbounce.event.waitTicks
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
-import net.ccbluex.liquidbounce.utils.network.MovePacketType
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.entity.withStrafe
 import net.ccbluex.liquidbounce.utils.math.sq
 import net.ccbluex.liquidbounce.utils.math.withLength
+import net.ccbluex.liquidbounce.utils.network.MovePacketType
 import net.minecraft.network.protocol.game.ClientboundExplodePacket
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket
@@ -116,10 +116,6 @@ internal object FlyCreative : Mode("Creative") {
 
     private val forceFlight by boolean("ForceFlight", true)
 
-    override fun enable() {
-        player.abilities.mayfly = true
-    }
-
     private fun shouldFlyDown(): Boolean {
         if (!bypassVanillaCheck) return false
         if (player.tickCount % 40 != 0) return false
@@ -154,7 +150,6 @@ internal object FlyCreative : Mode("Creative") {
     }
 
     override fun disable() {
-        player.abilities.mayfly = false
         player.abilities.flying = false
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/fly/modes/FlyGeneric.kt
@@ -79,8 +79,8 @@ internal object FlyVanilla : Mode("Vanilla") {
 
         player.deltaMovement = player.deltaMovement.withStrafe(speed = hSpeed.toDouble())
         player.deltaMovement.y = when {
-            mc.options.keyJump.isDown -> vSpeed.toDouble()
-            mc.options.keyShift.isDown -> (-vSpeed).toDouble()
+            mc.options.keyJump.isDown && !mc.options.keyShift.isDown -> vSpeed.toDouble()
+            mc.options.keyShift.isDown && !mc.options.keyJump.isDown -> (-vSpeed).toDouble()
             else -> glide.toDouble()
         }
 


### PR DESCRIPTION
## Resolved issues in the Fly module:

- **Disabling Fly in FlyCreative mode overwrites the player's `mayfly` ability**
  - This prevents the player from re-enabling vanilla creative flight via double-jump.

- **Pressing Jump and Shift simultaneously applies upward movement**
  - Both keys should cancel each other out, matching vanilla Creative flight behavior.

- **Double-jumping while Fly is enabled toggles vanilla creative flight**
  - This normally isn't an issue, but on servers with temporary flight it can consume the player's remaining flight time and may trigger anti-cheat setbacks.