### PR TITLE
feat(Clip/Fancy): add liquid clipping and increase vertical range

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/module/teleport/CommandVClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/command/commands/module/teleport/CommandVClip.kt
@@ -108,7 +108,7 @@ object CommandVClip : Command.Factory {
             newPos = newPos.below()
         }
 
-        for (x in 1 until max) {
+        for (x in 0 until max) {
             // go to the next position in the direction
             newPos = newPos.relative(direction)
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
@@ -18,8 +18,10 @@
  */
 package net.ccbluex.liquidbounce.features.module.modules.exploit
 
+import net.ccbluex.fastutil.enumSetOf
 import net.ccbluex.liquidbounce.config.types.group.Mode
 import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
+import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.NotificationEvent
 import net.ccbluex.liquidbounce.event.events.OverlayRenderEvent
 import net.ccbluex.liquidbounce.event.handler
@@ -30,24 +32,30 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.features.module.modules.movement.fly.ModuleFly
 import net.ccbluex.liquidbounce.render.engine.type.Color4b
 import net.ccbluex.liquidbounce.utils.block.canStandOn
-import net.ccbluex.liquidbounce.utils.block.getState
+import net.ccbluex.liquidbounce.utils.block.state
 import net.ccbluex.liquidbounce.utils.client.notification
 import net.ccbluex.liquidbounce.utils.client.scaledDimension
-import net.ccbluex.liquidbounce.utils.math.toRadians
 import net.ccbluex.liquidbounce.utils.collection.Pools
+import net.ccbluex.liquidbounce.utils.math.toRadians
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
+import net.minecraft.tags.FluidTags
 import kotlin.math.cos
 import kotlin.math.sin
 
 /**
  * Clip module
  *
- * Allows you to clip through blocks by jumping or snekaing.
+ * Allows you to clip through blocks by jumping or sneaking.
  */
 object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
 
     val modes = choices("Choice", Fancy, arrayOf(Fancy, Old))
+
+    enum class AllowedLiquids(override val tag: String) : Tagged {
+        WATER("Water"),
+        LAVA("Lava");
+    }
 
     object Old : Mode("Old") {
 
@@ -78,7 +86,8 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
 
 
         private val horizontal by int("Horizontal", 0, 0..6)
-        private val vertical by int("Vertical", 5, 0..6)
+        private val vertical by int("Vertical", 5, 0..10)
+        private val allowedLiquids by multiEnumChoice("AllowedLiquids", enumSetOf<AllowedLiquids>())
 
         private val requiresStandOn by boolean("RequiresStandOn", true)
 
@@ -175,8 +184,11 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
             repeat(length) {
                 position.move(movementDirection)
 
-                if (isPossibleLocation(position, requiresStandOn = requiresStandOn &&
-                        movementDirection != Direction.UP)) {
+                if (isPossibleLocation(
+                        position, requiresStandOn = requiresStandOn &&
+                            movementDirection != Direction.UP
+                    )
+                ) {
                     // We do not want to clip if there is no wall between us
                     if (wallBetween) {
                         clip(position)
@@ -193,7 +205,19 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
                 return false
             }
 
-            return blockPos.getState()?.isAir == true && blockPos.above().getState()?.isAir == true
+            val blockState = blockPos.state ?: return false
+            val aboveState = blockPos.above().state ?: return false
+
+            return when {
+                blockState.isAir && aboveState.isAir -> true
+                AllowedLiquids.WATER in allowedLiquids && blockState.fluidState.`is`(FluidTags.WATER) &&
+                    (aboveState.isAir || aboveState.fluidState.`is`(FluidTags.WATER)) -> true
+
+                AllowedLiquids.LAVA in allowedLiquids && blockState.fluidState.`is`(FluidTags.LAVA) &&
+                    (aboveState.isAir || aboveState.fluidState.`is`(FluidTags.LAVA)) -> true
+
+                else -> false
+            }
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/exploit/ModuleClip.kt
@@ -40,6 +40,8 @@ import net.ccbluex.liquidbounce.utils.math.toRadians
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.tags.FluidTags
+import net.minecraft.tags.TagKey
+import net.minecraft.world.level.material.Fluid
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -50,14 +52,14 @@ import kotlin.math.sin
  */
 object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
 
-    val modes = choices("Choice", Fancy, arrayOf(Fancy, Old))
+    private val modes = choices("Choice", Fancy, arrayOf(Fancy, Old))
 
-    enum class AllowedLiquids(override val tag: String) : Tagged {
-        WATER("Water"),
-        LAVA("Lava");
+    private enum class AllowedLiquids(override val tag: String, val fluidTag: TagKey<Fluid>) : Tagged {
+        WATER("Water", FluidTags.WATER),
+        LAVA("Lava", FluidTags.LAVA);
     }
 
-    object Old : Mode("Old") {
+    private object Old : Mode("Old") {
 
         override val parent: ModeValueGroup<Mode>
             get() = modes
@@ -79,11 +81,10 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
         }
     }
 
-    object Fancy : Mode("Fancy") {
+    private object Fancy : Mode("Fancy") {
 
         override val parent: ModeValueGroup<Mode>
             get() = modes
-
 
         private val horizontal by int("Horizontal", 0, 0..6)
         private val vertical by int("Vertical", 5, 0..10)
@@ -91,7 +92,7 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
 
         private val requiresStandOn by boolean("RequiresStandOn", true)
 
-        private val possibleClipDirections = hashSetOf<Direction>()
+        private val possibleClipDirections = enumSetOf<Direction>()
 
         @Suppress("unused")
         val repeatable = tickHandler {
@@ -208,15 +209,9 @@ object ModuleClip : ClientModule("Clip", ModuleCategories.MOVEMENT) {
             val blockState = blockPos.state ?: return false
             val aboveState = blockPos.above().state ?: return false
 
-            return when {
-                blockState.isAir && aboveState.isAir -> true
-                AllowedLiquids.WATER in allowedLiquids && blockState.fluidState.`is`(FluidTags.WATER) &&
-                    (aboveState.isAir || aboveState.fluidState.`is`(FluidTags.WATER)) -> true
-
-                AllowedLiquids.LAVA in allowedLiquids && blockState.fluidState.`is`(FluidTags.LAVA) &&
-                    (aboveState.isAir || aboveState.fluidState.`is`(FluidTags.LAVA)) -> true
-
-                else -> false
+            return (blockState.isAir && aboveState.isAir) || allowedLiquids.any {
+                blockState.fluidState.`is`(it.fluidTag) &&
+                    (aboveState.isAir || aboveState.fluidState.`is`(it.fluidTag))
             }
         }
     }


### PR DESCRIPTION
## Added

* Support for clipping into configured liquids in Fancy mode.
* Configurable allowed liquid types (Water and Lava).

## Changed

* Increased the maximum vertical clipping range in Fancy mode from **6** to **10** blocks.

## Fixed

* Smart `.vclip` command now correctly searches up to the configured maximum distance instead of stopping one block early.

