### PR TITLE
feat(antivoid): use item mode

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
@@ -26,7 +26,7 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidBlinkMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidFlagMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidGhostBlockMode
-import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidInteractMode
+import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidUseItemMode
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugGeometry
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
@@ -47,7 +47,7 @@ object ModuleAntiVoid : ClientModule("AntiVoid", ModuleCategories.PLAYER) {
             AntiVoidGhostBlockMode,
             AntiVoidFlagMode,
             AntiVoidBlinkMode,
-            AntiVoidInteractMode,
+            AntiVoidUseItemMode,
         )
     )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
@@ -26,6 +26,7 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategories
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidBlinkMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidFlagMode
 import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidGhostBlockMode
+import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode.AntiVoidInteractMode
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugGeometry
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
@@ -45,7 +46,8 @@ object ModuleAntiVoid : ClientModule("AntiVoid", ModuleCategories.PLAYER) {
         "Mode", AntiVoidGhostBlockMode, arrayOf(
             AntiVoidGhostBlockMode,
             AntiVoidFlagMode,
-            AntiVoidBlinkMode
+            AntiVoidBlinkMode,
+            AntiVoidInteractMode
         )
     )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/ModuleAntiVoid.kt
@@ -47,7 +47,7 @@ object ModuleAntiVoid : ClientModule("AntiVoid", ModuleCategories.PLAYER) {
             AntiVoidGhostBlockMode,
             AntiVoidFlagMode,
             AntiVoidBlinkMode,
-            AntiVoidInteractMode
+            AntiVoidInteractMode,
         )
     )
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidInteractMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidInteractMode.kt
@@ -1,0 +1,87 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.player.antivoid.mode
+
+import net.ccbluex.liquidbounce.config.types.group.ModeValueGroup
+import net.ccbluex.liquidbounce.features.module.modules.player.antivoid.ModuleAntiVoid
+import net.ccbluex.liquidbounce.features.module.modules.render.ModuleDebug.debugParameter
+import net.ccbluex.liquidbounce.utils.collection.itemSortedSetOf
+import net.ccbluex.liquidbounce.utils.entity.PlayerSimulationCache
+import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.inventory.findClosestSlot
+import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.minecraft.world.item.Items
+
+/**
+ * AntiVoid Interact mode.
+ *
+ * When the player is falling into the void with no way to recover, a configured item
+ * from the hotbar is used. This is useful on servers with power-ups where using
+ * specific items can prevent void death.
+ *
+ * The trigger conditions are:
+ * 1. the player is likely falling.
+ * 2. the player's y motion is fast enough to be below [yMotionThreshold].
+ * 3. the simulation predicts the player will not reach solid ground within 40 ticks.
+ */
+object AntiVoidInteractMode : AntiVoidMode("Interact") {
+
+    override val parent: ModeValueGroup<*>
+        get() = ModuleAntiVoid.mode
+
+    private val yMotionThreshold by float("YMotionThreshold", -0.5f, -1.0f..-0.1f)
+
+    val slotResetDelay by intRange("SlotResetDelay", 4..6, 0..40, "ticks")
+
+    /**
+     * Whitelist of items that can be used to prevent void death.
+     * The first matching item found in the hotbar/offhand will be used.
+     */
+    private val items by items("Items", itemSortedSetOf(Items.MAGMA_CREAM))
+    private const val SIMULATION_TICKS = 40
+
+    override fun rescue(): Boolean {
+        val motionY = player.deltaMovement.y
+        debugParameter("MotionY") { "%.3f".format(motionY) }
+        debugParameter("YThreshold") { "%.3f".format(yMotionThreshold.toDouble()) }
+
+        if (motionY >= yMotionThreshold) {
+            return false
+        }
+
+        val simulation = PlayerSimulationCache.getSimulationForLocalPlayer()
+        val canReachGround = (1..SIMULATION_TICKS).any { tick ->
+            simulation.getSnapshotAt(tick).onGround
+        }
+
+        debugParameter("CanReachGround") { canReachGround }
+
+        if (canReachGround) {
+            return false
+        }
+
+        val slot = Slots.OffhandWithHotbar.findClosestSlot(items) ?: return false
+
+        debugParameter("UsedItem") { slot.itemStack.hoverName.string }
+
+        useHotbarSlotOrOffhand(slot, ticksUntilReset = slotResetDelay.random())
+        return true
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidInteractMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidInteractMode.kt
@@ -47,7 +47,7 @@ object AntiVoidInteractMode : AntiVoidMode("Interact") {
 
     private val yMotionThreshold by float("YMotionThreshold", -0.5f, -1.0f..-0.1f)
 
-    val slotResetDelay by intRange("SlotResetDelay", 4..6, 0..40, "ticks")
+    private val slotResetDelay by intRange("SlotResetDelay", 4..6, 0..40, "ticks")
 
     /**
      * Whitelist of items that can be used to prevent void death.

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidUseItemMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidUseItemMode.kt
@@ -49,10 +49,6 @@ object AntiVoidUseItemMode : AntiVoidMode("UseItem") {
 
     private val slotResetDelay by intRange("SlotResetDelay", 4..6, 0..40, "ticks")
 
-    /**
-     * Whitelist of items that can be used to prevent void death.
-     * The first matching item found in the hotbar/offhand will be used.
-     */
     private val items by items("Items", itemSortedSetOf(Items.MAGMA_CREAM))
     private const val SIMULATION_TICKS = 40
 
@@ -66,9 +62,7 @@ object AntiVoidUseItemMode : AntiVoidMode("UseItem") {
         }
 
         val simulation = PlayerSimulationCache.getSimulationForLocalPlayer()
-        val canReachGround = (1..SIMULATION_TICKS).any { tick ->
-            simulation.getSnapshotAt(tick).onGround
-        }
+        val canReachGround = simulation.getSnapshotsBetween(1..SIMULATION_TICKS).any { it.onGround }
 
         debugParameter("CanReachGround") { canReachGround }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidUseItemMode.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/antivoid/mode/AntiVoidUseItemMode.kt
@@ -29,7 +29,7 @@ import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
 import net.minecraft.world.item.Items
 
 /**
- * AntiVoid Interact mode.
+ * AntiVoid UseItem mode.
  *
  * When the player is falling into the void with no way to recover, a configured item
  * from the hotbar is used. This is useful on servers with power-ups where using
@@ -40,7 +40,7 @@ import net.minecraft.world.item.Items
  * 2. the player's y motion is fast enough to be below [yMotionThreshold].
  * 3. the simulation predicts the player will not reach solid ground within 40 ticks.
  */
-object AntiVoidInteractMode : AntiVoidMode("Interact") {
+object AntiVoidUseItemMode : AntiVoidMode("UseItem") {
 
     override val parent: ModeValueGroup<*>
         get() = ModuleAntiVoid.mode


### PR DESCRIPTION
adds an interact mode to antivoid, useful on minigame servers with powerups where a module is better than reaction time for saving yourself from the void. could also be used as a ragequit/return-to-checkpoint feature on parkour too. useful for both closet and blatant.