### PR TITLE
feat(ClickGUI): support multi-word search in searchable lists

### DIFF
--- a/src-theme/src/routes/clickgui/setting/list/SearchableList.svelte
+++ b/src-theme/src/routes/clickgui/setting/list/SearchableList.svelte
@@ -8,11 +8,12 @@
     let renderedItems: NamedItem[] = items;
 
     $: {
-        let filteredItems = items;
-        if (searchQuery) {
-            filteredItems = filteredItems.filter(b => b.name.toLowerCase().includes(searchQuery.toLowerCase()));
-        }
-        renderedItems = filteredItems;
+        const queryParts = searchQuery.toLowerCase().match(/\S+/g) ?? [];
+
+        renderedItems = items.filter(item => {
+            const name = item.name.toLowerCase();
+            return queryParts.every(part => name.includes(part));
+        });
     }
 </script>
 


### PR DESCRIPTION
Allow searching using multiple terms, regardless of their order.

For example, `gold block` now finds `Block of Gold`.
`acacia  button` now finds `Acacia Button`, even with multiple spaces.