### PR TITLE
fix(ClickGUI): sync module toggles outside worlds

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/config/ConfigSystem.kt
@@ -37,6 +37,20 @@ import java.io.File
 import java.io.Reader
 import java.io.Writer
 
+@Volatile
+internal var loadingAllConfigs = false
+    private set
+
+internal fun <T> withLoadingAllConfigs(block: () -> T): T {
+    val wasLoading = loadingAllConfigs
+    loadingAllConfigs = true
+    return try {
+        block()
+    } finally {
+        loadingAllConfigs = wasLoading
+    }
+}
+
 /**
  * A hierarchy config system
  */
@@ -166,7 +180,7 @@ object ConfigSystem {
     /**
      * Loads all registered configs.
      */
-    fun loadAll() {
+    fun loadAll() = withLoadingAllConfigs {
         for (valueGroup in configs) { // Make a new .json file to save our root config
             load(valueGroup)
         }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import net.ccbluex.liquidbounce.config.ConfigSystem
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig
 import net.ccbluex.liquidbounce.config.autoconfig.AutoConfig.loadingNow
+import net.ccbluex.liquidbounce.config.loadingAllConfigs
 import net.ccbluex.liquidbounce.config.gson.stategies.Exclude
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.config.types.group.ToggleableValueGroup
@@ -153,7 +154,9 @@ open class ClientModule(
 
     final override fun onToggled(state: Boolean): Boolean {
         if (!inGame) {
-            EventManager.callEvent(ModuleToggleEvent(name, hidden, state))
+            if (!loadingAllConfigs) {
+                EventManager.callEvent(ModuleToggleEvent(name, hidden, state))
+            }
             return state
         }
         calledSinceStartup = true

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -153,6 +153,7 @@ open class ClientModule(
 
     final override fun onToggled(state: Boolean): Boolean {
         if (!inGame) {
+            EventManager.callEvent(ModuleToggleEvent(name, hidden, state))
             return state
         }
         calledSinceStartup = true

--- a/src/test/kotlin/net/ccbluex/liquidbounce/features/module/ClientModuleTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/features/module/ClientModuleTest.kt
@@ -1,0 +1,58 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module
+
+import net.ccbluex.liquidbounce.event.EventListener
+import net.ccbluex.liquidbounce.event.EventManager
+import net.ccbluex.liquidbounce.event.events.ModuleToggleEvent
+import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.utils.client.inGame
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ClientModuleTest {
+
+    private object TestEventListener : EventListener {
+        override val running: Boolean = true
+    }
+
+    @Test
+    fun `toggle outside game emits module toggle events`() {
+        assertFalse(inGame)
+
+        val module = ClientModule("Test", ModuleCategories.MISC)
+        val states = mutableListOf<Boolean>()
+        val eventHook = TestEventListener.handler<ModuleToggleEvent> { event ->
+            if (event.moduleName == module.name) {
+                states += event.enabled
+            }
+        }
+
+        try {
+            module.onToggled(true)
+            module.onToggled(false)
+        } finally {
+            EventManager.unregisterEventHook(ModuleToggleEvent::class.java, eventHook)
+        }
+
+        assertEquals(listOf(true, false), states)
+    }
+
+}

--- a/src/test/kotlin/net/ccbluex/liquidbounce/features/module/ClientModuleTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/features/module/ClientModuleTest.kt
@@ -18,10 +18,12 @@
  */
 package net.ccbluex.liquidbounce.features.module
 
+import net.ccbluex.liquidbounce.config.withLoadingAllConfigs
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.ModuleToggleEvent
 import net.ccbluex.liquidbounce.event.handler
+import net.ccbluex.liquidbounce.test.MinecraftBootstrap
 import net.ccbluex.liquidbounce.utils.client.inGame
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,15 +31,45 @@ import kotlin.test.assertFalse
 
 class ClientModuleTest {
 
+    companion object {
+        init {
+            MinecraftBootstrap.ensureInitialized()
+        }
+    }
+
     private object TestEventListener : EventListener {
         override val running: Boolean = true
     }
 
     @Test
-    fun `toggle outside game emits module toggle events`() {
+    fun `toggle outside game after startup emits module toggle events`() {
         assertFalse(inGame)
 
         val module = ClientModule("Test", ModuleCategories.MISC)
+        val states = captureToggleStates(module) {
+            module.onToggled(true)
+            module.onToggled(false)
+        }
+
+        assertEquals(listOf(true, false), states)
+    }
+
+    @Test
+    fun `toggle during startup does not emit module toggle events`() {
+        assertFalse(inGame)
+
+        val module = ClientModule("Test", ModuleCategories.MISC)
+        val states = captureToggleStates(module) {
+            withLoadingAllConfigs {
+                module.onToggled(true)
+                module.onToggled(false)
+            }
+        }
+
+        assertEquals(emptyList(), states)
+    }
+
+    private fun captureToggleStates(module: ClientModule, block: () -> Unit): List<Boolean> {
         val states = mutableListOf<Boolean>()
         val eventHook = TestEventListener.handler<ModuleToggleEvent> { event ->
             if (event.moduleName == module.name) {
@@ -46,13 +78,11 @@ class ClientModuleTest {
         }
 
         try {
-            module.onToggled(true)
-            module.onToggled(false)
+            block()
         } finally {
             EventManager.unregisterEventHook(ModuleToggleEvent::class.java, eventHook)
         }
 
-        assertEquals(listOf(true, false), states)
+        return states
     }
-
 }


### PR DESCRIPTION
## Summary

- Emit `ModuleToggleEvent` when a module is toggled outside a world so ClickGUI state updates from the main menu.
- Suppress toggle events while `ConfigSystem.loadAll()` restores startup state, avoiding a burst of unnecessary events.
- Add regression coverage for both startup loading and post-startup toggles outside a world.

Fixes #8540

## Testing

- `./gradlew test --tests net.ccbluex.liquidbounce.features.module.ClientModuleTest`
- `./gradlew detekt`