### PR TITLE
fix(build): relocate bundled okhttp/okio into a private package

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraft.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraft.java
@@ -134,7 +134,7 @@ public abstract class MixinMinecraft {
     /**
      * Entry point
      */
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;resizeGui()V"))
+    @Inject(method = "<init>(Lnet/minecraft/client/main/GameConfig;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;resizeGui()V"))
     private void startClient(CallbackInfo callback) {
         EventManager.INSTANCE.callEvent(ClientStartEvent.INSTANCE);
     }
@@ -148,7 +148,7 @@ public abstract class MixinMinecraft {
         EventManager.INSTANCE.callEvent(ClientShutdownEvent.INSTANCE);
     }
 
-    @Inject(method = "<init>", at = @At(value = "FIELD",
+    @Inject(method = "<init>(Lnet/minecraft/client/main/GameConfig;)V", at = @At(value = "FIELD",
         target = "Lnet/minecraft/client/Minecraft;profileKeyPairManager:Lnet/minecraft/client/multiplayer/ProfileKeyPairManager;",
         ordinal = 0, shift = At.Shift.AFTER, opcode = Opcodes.PUTFIELD))
     private void onSessionInit(CallbackInfo callback) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatComponent.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatComponent.java
@@ -65,7 +65,7 @@ public abstract class MixinChatComponent {
     @Shadow
     public abstract void scrollChat(int scroll);
 
-    @Inject(method = "<init>", at = @At(value = "TAIL"))
+    @Inject(method = "<init>(Lnet/minecraft/client/Minecraft;)V", at = @At(value = "TAIL"))
     public void hookNewArrayList2(Minecraft minecraft, CallbackInfo ci) {
         allMessages = new ArrayListDeque<>(100);
         // ArrayDeque for addFirst operations


### PR DESCRIPTION
This might be overkill for one crash, so say if you'd rather not carry it. The alternative
is patching call sites as they break, like #7315 did, but Lunar is on a pre-Kotlin okhttp,
so anything reaching a 4.x or 5.x API breaks there and that list doesn't get shorter.

Lunar Client bundles okhttp 3.14.9, which predates okhttp's move to Kotlin, so its `Headers`
has no `Companion`. We ship okhttp 5 as jar-in-jar and Lunar's copy wins on the shared
classloader, which kills client init:

```
java.lang.NoSuchFieldError: Class okhttp3.Headers does not have member field 'okhttp3.Headers$Companion Companion'
	at Genesis//net.ccbluex.liquidbounce.integration.theme.Theme.<init>(Theme.kt:63)
	at Genesis//net.ccbluex.liquidbounce.integration.theme.ThemeManager.init(ThemeManager.kt:117)
```

Moves the bundled okhttp/okio to `net.ccbluex.liquidbounce.libs` in the `jar` task so we
always link our own copy. Eight of the 61 nested jars end up referencing it and get a
`liquidbounce_` mod id prefix, so Fabric can't dedup them against a copy that still links the
original packages. `HideAppearance` follows the mcef rename. The rest are passed through
untouched, so the build stays reproducible.

Also qualifies the `Minecraft` and `ChatComponent` constructor selectors. Lunar has no-arg
overloads vanilla doesn't declare, so a bare `<init>` is selected for two constructors, and
`MixinChatComponent#hookNewArrayList2` captures a `Minecraft` argument that `<init>()V`
cannot supply.

Tested in-game on Lunar 26.2 and vanilla Fabric 26.2.

Fixes #8386
