### PR TITLE
fix(injection): qualify ambiguous constructor selectors

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraft.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/client/MixinMinecraft.java
@@ -134,7 +134,7 @@ public abstract class MixinMinecraft {
     /**
      * Entry point
      */
-    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;resizeGui()V"))
+    @Inject(method = "<init>(Lnet/minecraft/client/main/GameConfig;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;resizeGui()V"))
     private void startClient(CallbackInfo callback) {
         EventManager.INSTANCE.callEvent(ClientStartEvent.INSTANCE);
     }
@@ -148,7 +148,7 @@ public abstract class MixinMinecraft {
         EventManager.INSTANCE.callEvent(ClientShutdownEvent.INSTANCE);
     }
 
-    @Inject(method = "<init>", at = @At(value = "FIELD",
+    @Inject(method = "<init>(Lnet/minecraft/client/main/GameConfig;)V", at = @At(value = "FIELD",
         target = "Lnet/minecraft/client/Minecraft;profileKeyPairManager:Lnet/minecraft/client/multiplayer/ProfileKeyPairManager;",
         ordinal = 0, shift = At.Shift.AFTER, opcode = Opcodes.PUTFIELD))
     private void onSessionInit(CallbackInfo callback) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatComponent.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinChatComponent.java
@@ -65,7 +65,7 @@ public abstract class MixinChatComponent {
     @Shadow
     public abstract void scrollChat(int scroll);
 
-    @Inject(method = "<init>", at = @At(value = "TAIL"))
+    @Inject(method = "<init>(Lnet/minecraft/client/Minecraft;)V", at = @At(value = "TAIL"))
     public void hookNewArrayList2(Minecraft minecraft, CallbackInfo ci) {
         allMessages = new ArrayListDeque<>(100);
         // ArrayDeque for addFirst operations


### PR DESCRIPTION
Lunar Client declares no-arg `Minecraft` and `ChatComponent` constructors that vanilla doesn't.
A bare `method = "<init>"` matches both.
`hookNewArrayList2` captures a `Minecraft` argument that `<init>()V` can't supply, so it throws at load.
The two `MixinMinecraft` handlers capture nothing, so they don't throw, but they still get applied to the stub.

Spells out the descriptor on the three selectors.
On vanilla each of those classes declares a single constructor, so this selects the same one as before and nothing changes there.

Split out of #8767, which also tried to fix the okhttp side.
That part lives in https://github.com/obus-globus/lb-lunar-compat instead.
