### PR TITLE
chore(UI): Fix package.lock file using disallowed remote registries

### DIFF
--- a/src-theme/package-lock.json
+++ b/src-theme/package-lock.json
@@ -31,7 +31,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -478,7 +478,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
@@ -1118,7 +1118,7 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmmirror.com/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
       "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
       "dev": true,
       "license": "MIT",
@@ -1128,7 +1128,7 @@
     },
     "node_modules/@sveltejs/load-config": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmmirror.com/@sveltejs/load-config/-/load-config-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
       "integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
       "dev": true,
       "license": "MIT",
@@ -1176,7 +1176,7 @@
     },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmmirror.com/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
       "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
       "dev": true,
       "license": "MIT"
@@ -1196,7 +1196,7 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
@@ -1209,7 +1209,7 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1266,7 +1266,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "dev": true,
       "license": "MIT",
@@ -1411,7 +1411,7 @@
     },
     "node_modules/esrap": {
       "version": "1.4.9",
-      "resolved": "https://registry.npmmirror.com/esrap/-/esrap-1.4.9.tgz",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.9.tgz",
       "integrity": "sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==",
       "dev": true,
       "license": "MIT",
@@ -1671,7 +1671,7 @@
     },
     "node_modules/sass": {
       "version": "1.100.0",
-      "resolved": "https://registry.npmmirror.com/sass/-/sass-1.100.0.tgz",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
       "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
       "dev": true,
       "license": "MIT",
@@ -1692,7 +1692,7 @@
     },
     "node_modules/sass/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
@@ -1708,7 +1708,7 @@
     },
     "node_modules/sass/node_modules/readdirp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
@@ -1762,7 +1762,7 @@
     },
     "node_modules/svelte-check": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmmirror.com/svelte-check/-/svelte-check-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
       "integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
NPM 12 changed the default value for `all-remote` to `none`. This broke `npm install` on this version for the theme.