### PR TITLE
feat(InterceptElytra): intercept elytra flyers using wind charges (#8718)

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -40,6 +40,7 @@ import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoRod
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoShoot
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleAutoWeapon
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleFakeLag
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.ModuleInterceptElytra
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleHitbox
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleKeepSprint
 import net.ccbluex.liquidbounce.features.module.modules.combat.ModuleMaceKill
@@ -462,6 +463,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleAutoRod,
             ModuleAutoWeapon,
             ModuleFakeLag,
+            ModuleInterceptElytra,
             ModuleCriticals,
             ModuleHitbox,
             ModuleKillAura,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/InterceptElytraSolver.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/InterceptElytraSolver.kt
@@ -1,0 +1,226 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra
+
+import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
+import net.minecraft.world.phys.Vec3
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.math.tan
+
+/**
+ * Closed-form interception math for wind charges.
+ *
+ * A wind charge flies in a straight line at constant speed — no gravity, no drag, even in water —
+ * and inherits the thrower's velocity at spawn. See
+ * [net.minecraft.world.entity.projectile.hurtingprojectile.windcharge.AbstractWindCharge] and
+ * [net.minecraft.world.entity.projectile.Projectile.shootFromRotation].
+ *
+ * Requiring the projectile to hit a linearly moving target at time t gives the condition
+ * `|Δ + w·t| = 1.5·t`, which squares to the quadratic
+ * `(|w|² − 2.25)·t² + 2·(Δ·w)·t + |Δ|² = 0` with `Δ = target − eye` and
+ * `w = targetVelocity − ownVelocity`. All functions here are O(1) closed-form operations.
+ */
+object InterceptElytraSolver {
+
+    /**
+     * Launch speed of a wind charge in blocks per tick.
+     *
+     * @see net.minecraft.world.item.WindChargeItem#PROJECTILE_SHOOT_POWER
+     */
+    const val WIND_CHARGE_SPEED: Double = 1.5
+
+    /**
+     * Explosion knockback multiplier of the player wind charge.
+     *
+     * @see net.minecraft.world.level.SimpleExplosionDamageCalculator
+     */
+    const val KNOCKBACK_MULTIPLIER: Double = 1.22
+
+    /** Explosion radius of the wind charge in blocks. */
+    const val EXPLOSION_RADIUS: Double = 1.2
+
+    /** Normalizes the knockback falloff distance (radius * 2). */
+    const val KNOCKBACK_DISTANCE_DIVISOR: Double = EXPLOSION_RADIUS * 2.0
+
+    /** Shortest flight time considered solvable, in ticks. */
+    const val MIN_FLIGHT_TICKS: Double = 0.5
+
+    /** Maximum deviation of the solved aim direction from unit length. */
+    const val MIN_SOLUTION_NORM: Double = 1e-3
+
+    private const val EPSILON = 1e-9
+    private const val DEG_TO_RAD = Math.PI / 180.0
+
+    /** Aim direction and flight time of an interception shot. */
+    data class WindChargeSolution(
+        val rotation: Rotation,
+        val flightTicks: Double,
+    )
+
+    /**
+     * Computes the aim direction that hits a linearly moving target with a wind charge.
+     *
+     * @param eye spawn position of the projectile (the thrower's eye position).
+     * @param ownVelocity the thrower's velocity at spawn; the Y component is ignored when grounded.
+     * @param targetPos the target position at time zero.
+     * @param targetVelocity the target's linear velocity, in blocks per tick.
+     * @param maxFlightTicks upper bound for the predicted flight time; beyond it prediction is unreliable.
+     * @param verticalOffsetDegrees shifts the aim point vertically before solving. A positive offset
+     * aims above the target, placing the explosion above its eyes so the radial knockback pushes it down.
+     * @return the shot solution, or null when no interception exists — e.g. the target escapes faster
+     * than the projectile, the target sits at the eye, or any input is non-finite.
+     */
+    fun solveWindChargeIntercept(
+        eye: Vec3,
+        ownVelocity: Vec3,
+        targetPos: Vec3,
+        targetVelocity: Vec3,
+        maxFlightTicks: Double,
+        verticalOffsetDegrees: Float = 0f,
+    ): WindChargeSolution? {
+        if (!eye.isFinite() || !ownVelocity.isFinite() || !targetPos.isFinite() || !targetVelocity.isFinite()) {
+            return null
+        }
+
+        val aimPoint = applyVerticalOffset(eye, targetPos, verticalOffsetDegrees)
+        val delta = aimPoint.subtract(eye)
+        val constantTerm = delta.lengthSqr()
+
+        // Nothing to aim at from zero distance.
+        if (constantTerm < EPSILON) {
+            return null
+        }
+
+        val relativeVelocity = targetVelocity.subtract(ownVelocity)
+        val quadraticCoefficient = relativeVelocity.lengthSqr() - WIND_CHARGE_SPEED * WIND_CHARGE_SPEED
+        val linearCoefficient = 2.0 * delta.dot(relativeVelocity)
+
+        val flightTicks = solveFlightTime(quadraticCoefficient, linearCoefficient, constantTerm)
+            ?: return null
+
+        // Aim direction, unit by construction since |Δ + w·t| = 1.5·t at the root.
+        val direction = delta.add(relativeVelocity.scale(flightTicks)).scale(1.0 / (WIND_CHARGE_SPEED * flightTicks))
+
+        // Numerical safety: discard degenerate solutions and predictions outside the flight window.
+        val solvable = flightTicks in MIN_FLIGHT_TICKS..maxFlightTicks &&
+            abs(direction.length() - 1.0) <= MIN_SOLUTION_NORM
+
+        return if (solvable) {
+            WindChargeSolution(Rotation.fromRotationVec(direction), flightTicks)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Smallest positive root of A·t² + B·t + C = 0 for the flight-time problem.
+     *
+     * When |A| ≈ 0 the target closes at exactly the projectile speed and the equation degenerates
+     * to the linear case B·t + C = 0.
+     */
+    private fun solveFlightTime(a: Double, b: Double, c: Double): Double? {
+        if (abs(a) <= EPSILON) {
+            if (b >= 0.0) {
+                return null // t = −C/B would be non-positive
+            }
+
+            return -c / b
+        }
+
+        val discriminant = b * b - 4.0 * a * c
+        if (discriminant < 0.0) {
+            return null
+        }
+
+        val root = sqrt(discriminant)
+        val first = (-b - root) / (2.0 * a)
+        val second = (-b + root) / (2.0 * a)
+
+        return when {
+            first > 0.0 && second > 0.0 -> minOf(first, second)
+            first > 0.0 -> first
+            second > 0.0 -> second
+            else -> null
+        }
+    }
+
+    /**
+     * Shifts an aim point vertically by an angle around an origin, keeping the distance constant.
+     *
+     * Positive offsets raise the point; a wind charge exploding there pushes the target downward.
+     */
+    fun applyVerticalOffset(origin: Vec3, target: Vec3, offsetDegrees: Float): Vec3 {
+        if (offsetDegrees == 0f) {
+            return target
+        }
+
+        val distance = target.subtract(origin).length()
+        return target.add(0.0, distance * tan(offsetDegrees.toDouble() * DEG_TO_RAD), 0.0)
+    }
+
+    /**
+     * Linear extrapolation of a glider's position.
+     *
+     * The elytra velocity re-aligns toward the look direction by ~10% per tick, so the linear
+     * approximation stays accurate for short flight horizons.
+     */
+    fun predictGliderLinear(targetPos: Vec3, targetVelocity: Vec3, ticks: Double, multiplier: Double = 1.0): Vec3 =
+        targetPos.add(targetVelocity.scale(ticks * multiplier))
+
+    /**
+     * Predicts the knockback a wind charge explosion applies, mirroring the server-side formula.
+     *
+     * @param explosionCenter the center of the wind burst.
+     * @param entityEyePosition the affected entity's eye position.
+     * @param exposure line-of-sight exposure factor in 0..1 (1.0 in open air).
+     * @param knockbackResistance the entity's explosion knockback resistance attribute (0..1).
+     * @param knockbackMultiplier the explosion's knockback multiplier; pass 0 for creative flyers.
+     * @return the added velocity in blocks per tick, or [Vec3.ZERO] when out of range or degenerate.
+     *
+     * @see net.minecraft.world.level.ServerExplosion
+     */
+    fun predictKnockback(
+        explosionCenter: Vec3,
+        entityEyePosition: Vec3,
+        exposure: Double,
+        knockbackResistance: Double = 0.0,
+        knockbackMultiplier: Double = KNOCKBACK_MULTIPLIER,
+    ): Vec3 {
+        val offset = entityEyePosition.subtract(explosionCenter)
+        val distance = offset.length()
+
+        if (distance < EPSILON) {
+            return Vec3.ZERO
+        }
+
+        val normalizedDistance = distance / KNOCKBACK_DISTANCE_DIVISOR
+        if (normalizedDistance >= 1.0) {
+            return Vec3.ZERO
+        }
+
+        val power = (1.0 - normalizedDistance) * exposure * knockbackMultiplier * (1.0 - knockbackResistance)
+        return offset.scale(power / distance)
+    }
+
+    /** Estimated flight time in ticks for a straight-line distance in blocks. */
+    fun estimateFlightTicks(distance: Double): Double = distance / WIND_CHARGE_SPEED
+
+    private fun Vec3.isFinite(): Boolean = x.isFinite() && y.isFinite() && z.isFinite()
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ModuleInterceptElytra.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ModuleInterceptElytra.kt
@@ -33,6 +33,7 @@ import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
 import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
 import net.ccbluex.liquidbounce.utils.inventory.Slots
 import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.utils.combat.shouldBeAttacked
 import net.ccbluex.liquidbounce.utils.kotlin.Priority
 import net.ccbluex.liquidbounce.utils.kotlin.random
 import net.ccbluex.liquidbounce.utils.math.sq
@@ -50,8 +51,9 @@ import net.minecraft.world.phys.Vec3
  *
  * Detects gliding players, predicts their trajectory and throws a wind charge at the computed
  * interception point. The explosion's radial knockback (multiplier 1.22, ~2.4 block falloff) breaks
- * the glider's flight path; a direct hit additionally deals 1.0 damage. Creative-flying players are
- * ignored — they are immune to the knockback.
+ * the glider's flight path; a direct hit additionally deals 1.0 damage. Creative/spectator players are
+ * ignored — they are immune to the knockback. Teammates and friends (as configured in Teams/FriendManager)
+ * are also excluded.
  *
  * @see InterceptElytraSolver
  */
@@ -141,7 +143,8 @@ object ModuleInterceptElytra : ClientModule("InterceptElytra", ModuleCategories.
             candidate !== player &&
                 candidate.isAlive &&
                 (!requireGliding || candidate.isFallFlying) &&
-                !candidate.abilities.flying && // immune to wind charge knockback
+                !candidate.abilities.instabuild && // creative/spectator players are immune to knockback
+                candidate.shouldBeAttacked() && // respect friend list and team settings
                 hasSpeed
         }
     }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ModuleInterceptElytra.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ModuleInterceptElytra.kt
@@ -1,0 +1,241 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra
+
+import net.ccbluex.liquidbounce.config.types.list.Tagged
+import net.ccbluex.liquidbounce.event.tickHandler
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.ModuleCategories
+import net.ccbluex.liquidbounce.utils.aiming.RotationManager
+import net.ccbluex.liquidbounce.utils.aiming.RotationsValueGroup
+import net.ccbluex.liquidbounce.utils.aiming.data.Rotation
+import net.ccbluex.liquidbounce.utils.client.Chronometer
+import net.ccbluex.liquidbounce.utils.client.player
+import net.ccbluex.liquidbounce.utils.client.world
+import net.ccbluex.liquidbounce.utils.entity.PositionExtrapolation
+import net.ccbluex.liquidbounce.utils.entity.squaredBoxedDistanceTo
+import net.ccbluex.liquidbounce.utils.inventory.InventoryManager
+import net.ccbluex.liquidbounce.utils.inventory.Slots
+import net.ccbluex.liquidbounce.utils.inventory.useHotbarSlotOrOffhand
+import net.ccbluex.liquidbounce.utils.kotlin.Priority
+import net.ccbluex.liquidbounce.utils.kotlin.random
+import net.ccbluex.liquidbounce.utils.math.sq
+import net.ccbluex.liquidbounce.utils.render.trajectory.TrajectoryInfo
+import net.ccbluex.liquidbounce.utils.render.trajectory.TrajectoryInfoRenderer
+import net.ccbluex.liquidbounce.utils.render.trajectory.TrajectoryType
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.Items
+import net.minecraft.world.phys.Vec3
+
+/**
+ * Shoots wind charges at elytra gliders to intercept them and knock them out of the air.
+ *
+ * Detects gliding players, predicts their trajectory and throws a wind charge at the computed
+ * interception point. The explosion's radial knockback (multiplier 1.22, ~2.4 block falloff) breaks
+ * the glider's flight path; a direct hit additionally deals 1.0 damage. Creative-flying players are
+ * ignored — they are immune to the knockback.
+ *
+ * @see InterceptElytraSolver
+ */
+object ModuleInterceptElytra : ClientModule("InterceptElytra", ModuleCategories.COMBAT) {
+
+    private const val MILLISECONDS_PER_TICK = 50
+    private const val MAX_VERIFICATION_TICKS = 300
+    private const val VERIFY_TOLERANCE_SQ = 4.0 // 2 blocks, covers sampling step + hitbox radius
+
+    private val range by float("Range", 32f, 10f..64f)
+    private val requireGliding by boolean("RequireGliding", true)
+    private val minimumTargetSpeed by float("MinimumTargetSpeed", 0.2f, 0f..5f)
+    private val aimMode by enumChoice("AimMode", AimMode.INTERCEPT_POINT)
+    private val predictionMode by enumChoice("PredictionMode", PredictionMode.LINEAR)
+    private val predictionMultiplier by floatRange("PredictionMultiplier", 1.8f..2.0f, 0.5f..3f)
+    private val aimVerticalOffset by float("AimVerticalOffset", 0f, -10f..10f)
+    private val maxFlightTicks by int("MaxFlightTicks", 30, 10..60)
+    private val cooldown by intRange("Cooldown", 8..12, 1..50, "ticks")
+    private val slotResetDelay by intRange("SlotResetDelay", 0..0, 0..20, "ticks")
+    private val aimOffThreshold by float("AimOffThreshold", 2f, 0.5f..10f)
+    private val considerInventory by boolean("ConsiderInventory", true)
+    private val requireLineOfSight by boolean("RequireLineOfSight", true)
+    private val verifyHit by boolean("VerifyHit", false)
+    private val rotations = tree(RotationsValueGroup(this))
+
+    private val chronometer = Chronometer()
+
+    private val cooldownReached: Boolean
+        get() = chronometer.hasElapsed((cooldown.random() * MILLISECONDS_PER_TICK).toLong())
+
+    @Suppress("unused")
+    private val interceptHandler = tickHandler {
+        if (player.isUsingItem || (considerInventory && InventoryManager.isInventoryOpen)) {
+            return@tickHandler
+        }
+
+        val target = selectBestGlider() ?: return@tickHandler
+        val slot = Slots.OffhandWithHotbar.findSlot(Items.WIND_CHARGE) ?: return@tickHandler
+
+        val aim = calculateAim(target)
+
+        if (verifyHit && !passesVerification(target, aim.rotation, aim.flightTicks)) {
+            return@tickHandler
+        }
+
+        RotationManager.setRotationTarget(
+            rotations.toRotationTarget(aim.rotation, considerInventory = considerInventory),
+            Priority.IMPORTANT_FOR_USAGE_2,
+            this@ModuleInterceptElytra,
+        )
+
+        if (RotationManager.serverRotation.directionAngleTo(aim.rotation) <= aimOffThreshold && cooldownReached) {
+            useHotbarSlotOrOffhand(slot, slotResetDelay.random(), aim.rotation.yaw, aim.rotation.pitch)
+            chronometer.reset()
+        }
+    }
+
+    /**
+     * Selects the closest valid glider in a single O(k) pass without sorting or temporary
+     * collections (O(1) auxiliary space).
+     */
+    private fun selectBestGlider(): LivingEntity? {
+        var bestTarget: LivingEntity? = null
+        var bestDistanceSq = Double.POSITIVE_INFINITY
+
+        for (entity in world.entitiesForRendering()) {
+            val glider = asTargetableGlider(entity) ?: continue
+
+            val distanceSq = glider.squaredBoxedDistanceTo(player)
+            // Line of sight is checked last, only for candidates inside range that beat the best
+            // so far, to avoid raycasts for entities that can never win.
+            if (distanceSq <= range.sq() && distanceSq < bestDistanceSq && hasLineOfSight(glider)) {
+                bestDistanceSq = distanceSq
+                bestTarget = glider
+            }
+        }
+
+        return bestTarget
+    }
+
+    /** Casts to a gliding player that can be knocked out of the air, or null when not targetable. */
+    private fun asTargetableGlider(entity: Entity): LivingEntity? {
+        val glider = entity as? Player ?: return null
+        val hasSpeed = glider.deltaMovement.horizontalDistance() >= minimumTargetSpeed
+
+        return glider.takeIf { candidate ->
+            candidate !== player &&
+                candidate.isAlive &&
+                (!requireGliding || candidate.isFallFlying) &&
+                !candidate.abilities.flying && // immune to wind charge knockback
+                hasSpeed
+        }
+    }
+
+    private fun hasLineOfSight(glider: LivingEntity): Boolean =
+        !requireLineOfSight || player.hasLineOfSight(glider)
+
+    /** Rotation plus the flight time used for prediction. */
+    private data class Aim(val rotation: Rotation, val flightTicks: Double)
+
+    private fun calculateAim(target: LivingEntity): Aim {
+        val eye = player.eyePosition
+        // Vanilla zeroes the thrower's vertical velocity when grounded (shootFromRotation).
+        val ownVelocity = Vec3(
+            player.deltaMovement.x,
+            if (player.onGround()) 0.0 else player.deltaMovement.y,
+            player.deltaMovement.z,
+        )
+        val targetPosition = target.getEyePosition()
+
+        return when (aimMode) {
+            AimMode.INTERCEPT_POINT -> {
+                val solution = InterceptElytraSolver.solveWindChargeIntercept(
+                    eye,
+                    ownVelocity,
+                    targetPosition,
+                    target.deltaMovement,
+                    maxFlightTicks.toDouble(),
+                    aimVerticalOffset,
+                )
+
+                if (solution != null) {
+                    Aim(solution.rotation, solution.flightTicks)
+                } else {
+                    directAim(eye, target, targetPosition)
+                }
+            }
+
+            AimMode.DIRECT -> directAim(eye, target, targetPosition)
+        }
+    }
+
+    /** Aims at the predicted target position without the closed-form interception. */
+    private fun directAim(eye: Vec3, target: LivingEntity, targetPosition: Vec3): Aim {
+        val flightTicks = InterceptElytraSolver.estimateFlightTicks(targetPosition.distanceTo(eye))
+        val predicted = when (predictionMode) {
+            PredictionMode.LINEAR -> InterceptElytraSolver.predictGliderLinear(
+                targetPosition,
+                target.deltaMovement,
+                flightTicks,
+                predictionMultiplier.random().toDouble(),
+            )
+
+            PredictionMode.SIMULATED -> PositionExtrapolation.getBestForEntity(target).getPositionInTicks(flightTicks)
+        }
+
+        val aimPoint = InterceptElytraSolver.applyVerticalOffset(eye, predicted, aimVerticalOffset)
+        return Aim(Rotation.lookingAt(aimPoint, eye), flightTicks)
+    }
+
+    /**
+     * Validates the shot by simulating the wind charge trajectory and checking it reaches the
+     * predicted impact point. Bounded to [MAX_VERIFICATION_TICKS] ticks, hence constant cost.
+     *
+     * The simulation world is static — entity hitboxes never move — while the aim leads the target,
+     * so the trajectory is compared against the target's predicted position instead of an entity
+     * reference.
+     */
+    private fun passesVerification(target: LivingEntity, rotation: Rotation, flightTicks: Double): Boolean {
+        val predictedImpact = InterceptElytraSolver.predictGliderLinear(
+            target.getEyePosition(),
+            target.deltaMovement,
+            flightTicks,
+        )
+
+        val result = TrajectoryInfoRenderer.getHypotheticalTrajectory(
+            player,
+            TrajectoryInfo.WIND_CHARGE,
+            TrajectoryType.WindCharge,
+            rotation,
+        ).runSimulation(MAX_VERIFICATION_TICKS)
+
+        // The projectile samples one point per tick (1.5 blocks apart); tolerance covers the
+        // sampling step and the 1.0-block projectile hitbox.
+        return result.positions.any { it.distanceToSqr(predictedImpact) <= VERIFY_TOLERANCE_SQ }
+    }
+
+    private enum class AimMode(override val tag: String) : Tagged {
+        INTERCEPT_POINT("InterceptPoint"),
+        DIRECT("Direct"),
+    }
+
+    private enum class PredictionMode(override val tag: String) : Tagged {
+        LINEAR("Linear"),
+        SIMULATED("Simulated"),
+    }
+}

--- a/src/main/resources/resources/liquidbounce/lang/de_de.json
+++ b/src/main/resources/resources/liquidbounce/lang/de_de.json
@@ -329,6 +329,7 @@
   "liquidbounce.module.disabler.messages.grimSpectateEnableMessage": "Aktivier diesen Disabler beim Respawnen – wenn du Fliegen kannst. Du solltest in der Lage sein, herumzufliegen und Blöcke zu zerstören, dabei aber keine anderen Spieler angreifen können. Deaktivier den Disabler es so schnell wie möglich, sonst kommt es zu einer Zeitüberschreitung.",
   "liquidbounce.module.eagle.description": "Schleicht automatisch am Rand eines Blocks.",
   "liquidbounce.module.elytraFly.description": "Erleichtert die Steuerung der Elytra.",
+  "liquidbounce.module.interceptElytra.description": "Wirft Windladungen auf Elytra-Gleiter, um sie abzufangen und aus der Luft zu stoßen.",
   "liquidbounce.module.targets.description": "Ermöglicht dir zu verwalten, welche Entities als Ziel gelten sollen.",
   "liquidbounce.module.esp.description": "Highlightet alle Ziele, sodass du sie durch Wände sehen kannst.",
   "liquidbounce.module.fakeLag.description": "Hält Pakete zurück, um zu verhindern, dass du von einem Feind getroffen wirst.",

--- a/src/main/resources/resources/liquidbounce/lang/en_pt.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_pt.json
@@ -245,6 +245,7 @@
   "liquidbounce.module.blockWalk.description": "Allows you to walk on non-fullblock blocks.",
   "liquidbounce.module.bugUp.description": "Automatically setbacks you after falling a certain distance.",
   "liquidbounce.module.elytraFly.description": "Makes you fly faster on Elytra.",
+  "liquidbounce.module.interceptElytra.description": "Shoots wind charges at elytra gliders to intercept and knock them out of the air.",
   "liquidbounce.module.inventoryMove.description": "Allows you to walk while an inventory is opened.",
   "liquidbounce.module.liquidWalk.description": "Allows you to walk on water.",
   "liquidbounce.module.noJumpDelay.description": "Removes the delay between jumps.",

--- a/src/main/resources/resources/liquidbounce/lang/en_us.json
+++ b/src/main/resources/resources/liquidbounce/lang/en_us.json
@@ -536,6 +536,7 @@
   "liquidbounce.module.easyPearl.messages.noInReachWarning": "You are aiming more than the ender pearl can reach, and this has helped you cancel the throw",
   "liquidbounce.module.elytraRecast.description": "Recasts elytra while holding jump key.",
   "liquidbounce.module.elytraFly.description": "Makes controlling an elytra easier.",
+  "liquidbounce.module.interceptElytra.description": "Shoots wind charges at elytra gliders to intercept and knock them out of the air.",
   "liquidbounce.module.elytraFly.messages.altitudeTooLow": "Warning: Altitude too low for optimal performance. Recommended height: %sY",
   "liquidbounce.module.elytraTarget.description": "Following the target on elytra.",
   "liquidbounce.module.targets.description": "Allows you to manage which entities are considered to be your targets.",

--- a/src/main/resources/resources/liquidbounce/lang/ja_jp.json
+++ b/src/main/resources/resources/liquidbounce/lang/ja_jp.json
@@ -331,6 +331,7 @@
 	"liquidbounce.module.disabler.vulcan.message": "Vulcanの移動チェックを回避するには、オフハンドに激流をエンチャントしたトライデントが必要です。",
 	"liquidbounce.module.eagle.description": "ブロックの端に自動的に潜入します。",
 	"liquidbounce.module.elytraFly.description": "エリトラの飛行をコントロールします。",
+	"liquidbounce.module.interceptElytra.description": "エリトラで滑空する敵にウィンドチャージを撃ち、空中から叩き落とします。",
 	"liquidbounce.module.enemies.description": "どのエンティティを敵とみなすかを管理できます。",
 	"liquidbounce.module.entityControl.description": "鞍なしで乗れるエンティティを操作することができます。",
 	"liquidbounce.module.esp.description": "すべてのターゲットをハイライトし、壁越しに見ることができます。",

--- a/src/main/resources/resources/liquidbounce/lang/nl_be.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_be.json
@@ -366,6 +366,7 @@
     "liquidbounce.module.eagle.description": "Sneakt automatisch op de rand van een blok.",
     "liquidbounce.module.elytraRecast.description": "Heractiveert je elytra terwijl je spatie ingedrukt houdt.",
     "liquidbounce.module.elytraFly.description": "Vergemakkelijkt het besturen van je elytra.",
+    "liquidbounce.module.interceptElytra.description": "Gooit windladingen naar elytra-glijders om hen te onderscheppen en uit de lucht te stoten.",
     "liquidbounce.module.elytraTarget.description": "Volg een doelwit in de lucht terwijl je elytra gebruikt.",
     "liquidbounce.module.targets.description": "Beheer welke entiteiten als doelwitten worden beschouwd.",
     "liquidbounce.module.extendedFirework.description": "Verlengt de vuurwerkboost op je elytra.",

--- a/src/main/resources/resources/liquidbounce/lang/nl_nl.json
+++ b/src/main/resources/resources/liquidbounce/lang/nl_nl.json
@@ -366,6 +366,7 @@
     "liquidbounce.module.eagle.description": "Sneakt automatisch op de rand van een blok.",
     "liquidbounce.module.elytraRecast.description": "Heractiveert je elytra terwijl je spatie ingedrukt houdt.",
     "liquidbounce.module.elytraFly.description": "Vergemakkelijkt het besturen van je elytra.",
+    "liquidbounce.module.interceptElytra.description": "Gooit windladingen naar elytra-glijders om hen te onderscheppen en uit de lucht te stoten.",
     "liquidbounce.module.elytraTarget.description": "Volg een doelwit in de lucht terwijl je elytra gebruikt.",
     "liquidbounce.module.targets.description": "Beheer welke entiteiten als doelwitten worden beschouwd.",
     "liquidbounce.module.extendedFirework.description": "Verlengt de vuurwerkboost op je elytra.",

--- a/src/main/resources/resources/liquidbounce/lang/pt_br.json
+++ b/src/main/resources/resources/liquidbounce/lang/pt_br.json
@@ -230,6 +230,7 @@
   "liquidbounce.module.blockWalk.description": "Deixa você andar em blocos não-cheios.",
   "liquidbounce.module.bugUp.description": "Automaticamente te traz de volta depois de cair uma certa distancia.",
   "liquidbounce.module.elytraFly.description": "Faz você voar mais rapido na elytra.",
+  "liquidbounce.module.interceptElytra.description": "Lança cargas de vento em jogadores de elytra para interceptá-los e derrubá-los do ar.",
   "liquidbounce.module.inventoryMove.description": "Deixa você andar em quanto tem um inventario aberto.",
   "liquidbounce.module.liquidWalk.description": "Deixa você andar na agua.",
   "liquidbounce.module.noJumpDelay.description": "Remove o tempo entre pulos.",

--- a/src/main/resources/resources/liquidbounce/lang/ru_ru.json
+++ b/src/main/resources/resources/liquidbounce/lang/ru_ru.json
@@ -446,6 +446,7 @@
   "liquidbounce.module.dupe.messages.singleplayer": "Дюпы работают только на серверах, в одиночке используй креатив.",
   "liquidbounce.module.eagle.description": "Автоматически приседает на краю блока.",
   "liquidbounce.module.elytraFly.description": "Позволяет быстрее лететь с элитрами.",
+  "liquidbounce.module.interceptElytra.description": "Запускает ветровые заряды в планирующих на элитрах игроков, чтобы сбить их с неба.",
   "liquidbounce.module.elytraFly.messages.altitudeTooLow": "Предупреждение: Высота слишком мала для оптимальной работы. Рекомендуемая высота: %sY",
   "liquidbounce.module.elytraRecast.description": "Повторно активирует элитры при удерживании клавиши прыжка.",
   "liquidbounce.module.elytraSwap.description": "Позволяет быстро заменять нагрудник элитрой и наоборот.",

--- a/src/main/resources/resources/liquidbounce/lang/tr_tr.json
+++ b/src/main/resources/resources/liquidbounce/lang/tr_tr.json
@@ -345,6 +345,7 @@
   "liquidbounce.module.eagle.description": "Bir bloğun kenarında otomatik olarak eğilir.",
   "liquidbounce.module.elytraRecast.description": "Zıplama tuşuna basılı tutarken elytra’yı yeniden fırlatır.",
   "liquidbounce.module.elytraFly.description": "Elytra’yı kontrol etmeyi kolaylaştırır.",
+  "liquidbounce.module.interceptElytra.description": "Elytra ile süzülen oyunculara rüzgar yükü atarak onları havada durdurur.",
   "liquidbounce.module.elytraTarget.description": "Elytra ile hedefi takip eder.",
   "liquidbounce.module.targets.description": "Hangi varlıkların hedef sayılacağını yönetmenizi sağlar.",
   "liquidbounce.module.extendedFirework.description": "Havai fişek roketinin itiş gücünü uzatır.",

--- a/src/main/resources/resources/liquidbounce/lang/ua_ua.json
+++ b/src/main/resources/resources/liquidbounce/lang/ua_ua.json
@@ -246,6 +246,7 @@
   "liquidbounce.module.blockWalk.description": "Дозволяє вам ходити по неповним блокам.",
   "liquidbounce.module.bugUp.description": "Автоматично повертає вас назад при падінні з певної висоти.",
   "liquidbounce.module.elytraFly.description": "Дозволяє вам швидше літати з елітрами.",
+  "liquidbounce.module.interceptElytra.description": "Запускає вітрові заряди у гравців, що планерують на елітрах, щоб збити їх з неба.",
   "liquidbounce.module.inventoryMove.description": "Дозволяє вам ходити з відкритим інвентарем.",
   "liquidbounce.module.liquidWalk.description": "Дозволяє вам ходити по воді.",
   "liquidbounce.module.noJumpDelay.description": "Прибирає затримку між стрибками.",

--- a/src/main/resources/resources/liquidbounce/lang/zh_cn.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_cn.json
@@ -517,6 +517,7 @@
   "liquidbounce.module.easyPearl.messages.noInReachWarning": "你瞄准的位置超出末影珍珠所能到达的位置，已帮你取消此次投掷",
   "liquidbounce.module.elytraRecast.description": "按住跳跃键时重新施放鞘翅。",
   "liquidbounce.module.elytraFly.description": "使鞘翅更加容易控制。",
+  "liquidbounce.module.interceptElytra.description": "向鞘翅滑翔的玩家发射风弹，将其拦截并击落。",
   "liquidbounce.module.elytraFly.messages.altitudeTooLow": "警告：纵坐标太低，无法获得最佳表现。建议高度：%sY",
   "liquidbounce.module.elytraTarget.description": "鞘翅滑翔时跟随目标。",
   "liquidbounce.module.targets.description": "允许你管理将哪些实体视为敌人。",

--- a/src/main/resources/resources/liquidbounce/lang/zh_tw.json
+++ b/src/main/resources/resources/liquidbounce/lang/zh_tw.json
@@ -517,6 +517,7 @@
   "liquidbounce.module.easyPearl.messages.noInReachWarning": "你瞄準的位置超出末影珍珠所能到達的位置，已幫你取消此次投擲",
   "liquidbounce.module.elytraRecast.description": "按住跳跃键時重新施放鞘翅。",
   "liquidbounce.module.elytraFly.description": "使鞘翅更加容易控制。",
+  "liquidbounce.module.interceptElytra.description": "向鞘翅滑翔的玩家發射風彈，將其攔截並擊落。",
   "liquidbounce.module.elytraFly.messages.altitudeTooLow": "警告：高度太低，無法獲得最佳效能。建議高度：%sY",
   "liquidbounce.module.elytraTarget.description": "鞘翅滑翔時跟隨目標。",
   "liquidbounce.module.targets.description": "允許你管理將哪些實體視為敵人。",

--- a/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ElytraKnockbackCalculatorTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/ElytraKnockbackCalculatorTest.kt
@@ -1,0 +1,85 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra
+
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.KNOCKBACK_MULTIPLIER
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.predictKnockback
+import net.minecraft.world.phys.Vec3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ElytraKnockbackCalculatorTest {
+
+    private val center = Vec3(0.0, 0.0, 0.0)
+    private val eye = Vec3(0.0, 1.6, 0.0)
+
+    @Test
+    fun `full power near center with full exposure`() {
+        // Just above the center: the eye can never sit exactly on it (degenerate case returns zero).
+        val knockback = predictKnockback(center, Vec3(0.0, 0.001, 0.0), exposure = 1.0)
+
+        assertEquals(KNOCKBACK_MULTIPLIER, knockback.length(), 1e-3)
+        assertEquals(Vec3(0.0, 1.0, 0.0).x, knockback.normalize().x, 1e-9)
+        assertEquals(Vec3(0.0, 1.0, 0.0).y, knockback.normalize().y, 1e-9)
+        assertEquals(Vec3(0.0, 1.0, 0.0).z, knockback.normalize().z, 1e-9)
+    }
+
+    @Test
+    fun `zero beyond normalized distance one`() {
+        assertEquals(Vec3.ZERO, predictKnockback(center, Vec3(0.0, 3.0, 0.0), exposure = 1.0))
+    }
+
+    @Test
+    fun `zero exposure yields zero knockback`() {
+        assertEquals(Vec3.ZERO, predictKnockback(center, eye, exposure = 0.0))
+    }
+
+    @Test
+    fun `knockback resistance halves the power`() {
+        val knockback = predictKnockback(center, Vec3(0.0, 0.001, 0.0), exposure = 1.0, knockbackResistance = 0.5)
+
+        assertEquals(KNOCKBACK_MULTIPLIER * 0.5, knockback.length(), 1e-3)
+    }
+
+    @Test
+    fun `linear falloff with distance`() {
+        // distance 1.2 blocks -> normalized 0.5 -> power (1 - 0.5) * 1.22
+        val knockback = predictKnockback(center, Vec3(1.2, 0.0, 0.0), exposure = 1.0)
+
+        assertEquals(KNOCKBACK_MULTIPLIER * 0.5, knockback.length(), 1e-9)
+    }
+
+    @Test
+    fun `degenerate center equals eye returns zero`() {
+        assertEquals(Vec3.ZERO, predictKnockback(eye, eye, exposure = 1.0))
+    }
+
+    @Test
+    fun `creative flying multiplier zeroes knockback`() {
+        assertEquals(Vec3.ZERO, predictKnockback(center, eye, exposure = 1.0, knockbackMultiplier = 0.0))
+    }
+
+    @Test
+    fun `knockback points radially away from the center`() {
+        val knockback = predictKnockback(Vec3(10.0, 0.0, 0.0), Vec3(10.0, 1.0, 0.0), exposure = 1.0)
+
+        assertTrue(knockback.x == 0.0 && knockback.y > 0.0 && knockback.z == 0.0)
+    }
+}

--- a/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/GliderPredictionTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/GliderPredictionTest.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra
+
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.WIND_CHARGE_SPEED
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.estimateFlightTicks
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.predictGliderLinear
+import net.minecraft.world.phys.Vec3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GliderPredictionTest {
+
+    private val base = Vec3(10.0, 20.0, 30.0)
+    private val velocity = Vec3(0.5, -0.1, 0.25)
+
+    @Test
+    fun `zero ticks returns base position`() {
+        assertEquals(base, predictGliderLinear(base, velocity, ticks = 0.0))
+    }
+
+    @Test
+    fun `linear extrapolation scales with ticks and multiplier`() {
+        val ticks = 4.0
+        val multiplier = 2.0
+
+        val predicted = predictGliderLinear(base, velocity, ticks, multiplier)
+        val expected = base.add(velocity.scale(ticks * multiplier))
+
+        assertEquals(expected.x, predicted.x, 1e-9)
+        assertEquals(expected.y, predicted.y, 1e-9)
+        assertEquals(expected.z, predicted.z, 1e-9)
+    }
+
+    @Test
+    fun `estimateFlightTicks equals distance over speed`() {
+        assertEquals(3.0 / WIND_CHARGE_SPEED, estimateFlightTicks(3.0), 1e-9)
+        assertEquals(0.0, estimateFlightTicks(0.0), 1e-9)
+    }
+}

--- a/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/InterceptElytraSolverTest.kt
+++ b/src/test/kotlin/net/ccbluex/liquidbounce/features/module/modules/combat/interceptelytra/InterceptElytraSolverTest.kt
@@ -1,0 +1,201 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra
+
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.WIND_CHARGE_SPEED
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.applyVerticalOffset
+import net.ccbluex.liquidbounce.features.module.modules.combat.interceptelytra.InterceptElytraSolver.solveWindChargeIntercept
+import net.minecraft.world.phys.Vec3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.math.tan
+
+class InterceptElytraSolverTest {
+
+    private val eye = Vec3(0.0, 1.0, 0.0)
+    private val ownVelocity = Vec3.ZERO
+
+    @Test
+    fun `static target straight ahead solves to straight aim`() {
+        val solution = solve(eye, Vec3(20.0, 1.0, 0.0), Vec3.ZERO)
+
+        assertNotNull(solution)
+        assertEquals(20.0 / WIND_CHARGE_SPEED, solution.flightTicks, 1e-9)
+        assertVecEquals(Vec3(1.0, 0.0, 0.0), solution.rotation.directionVector, 1e-4)
+    }
+
+    @Test
+    fun `static target above solves correct pitch`() {
+        val solution = solve(eye, Vec3(0.0, 11.0, 0.0), Vec3.ZERO)
+
+        assertNotNull(solution)
+        assertVecEquals(Vec3(0.0, 1.0, 0.0), solution.rotation.directionVector, 1e-4)
+        assertImpactMatchesTarget(solution, Vec3(0.0, 11.0, 0.0), Vec3.ZERO)
+    }
+
+    @Test
+    fun `moving target head-on produces leading aim`() {
+        val targetPos = Vec3(20.0, 1.0, 0.0)
+        val targetVelocity = Vec3(-1.0, 0.0, 0.0)
+        val solution = solve(eye, targetPos, targetVelocity)
+
+        assertNotNull(solution)
+        assertTrue(solution.flightTicks < 20.0 / WIND_CHARGE_SPEED)
+        assertImpactMatchesTarget(solution, targetPos, targetVelocity)
+    }
+
+    @Test
+    fun `target moving sideways faster than projectile returns null`() {
+        assertNull(solve(eye, Vec3(20.0, 1.0, 0.0), Vec3(0.0, 2.0, 0.0)))
+    }
+
+    @Test
+    fun `target closing at exactly projectile speed uses linear branch`() {
+        val targetPos = Vec3(20.0, 1.0, 0.0)
+        val targetVelocity = Vec3(-WIND_CHARGE_SPEED, 0.0, 0.0)
+        val solution = solve(eye, targetPos, targetVelocity)
+
+        assertNotNull(solution)
+        assertEquals(20.0 / 3.0, solution.flightTicks, 1e-9)
+        assertImpactMatchesTarget(solution, targetPos, targetVelocity)
+    }
+
+    @Test
+    fun `target at eye position returns null`() {
+        assertNull(solve(eye, eye, Vec3.ZERO))
+    }
+
+    @Test
+    fun `target escaping away faster than projectile returns null`() {
+        assertNull(solve(eye, Vec3(20.0, 1.0, 0.0), Vec3(2.0, 0.0, 0.0)))
+    }
+
+    @Test
+    fun `flight time beyond max returns null`() {
+        assertNull(solve(eye, Vec3(200.0, 1.0, 0.0), Vec3.ZERO, maxFlightTicks = 30.0))
+    }
+
+    @Test
+    fun `NaN input returns null`() {
+        assertNull(solve(eye, Vec3(Double.NaN, 1.0, 0.0), Vec3.ZERO))
+        assertNull(solve(Vec3(Double.POSITIVE_INFINITY, 0.0, 0.0), Vec3(20.0, 1.0, 0.0), Vec3.ZERO))
+    }
+
+    @Test
+    fun `positive vertical offset raises the aim above the target`() {
+        val solution = solve(eye, Vec3(20.0, 1.0, 0.0), Vec3.ZERO, verticalOffset = 5f)
+
+        assertNotNull(solution)
+        assertTrue(solution.rotation.directionVector.y > 0.0)
+    }
+
+    @Test
+    fun `negative vertical offset lowers the aim below the target`() {
+        val solution = solve(eye, Vec3(20.0, 1.0, 0.0), Vec3.ZERO, verticalOffset = -5f)
+
+        assertNotNull(solution)
+        assertTrue(solution.rotation.directionVector.y < 0.0)
+    }
+
+    @Test
+    fun `round trip matches continuous vanilla flight`() {
+        val targetPos = Vec3(30.0, 3.0, -12.0)
+        val targetVelocity = Vec3(-0.7, 0.1, 0.4)
+        val own = Vec3(0.3, 0.0, -0.2)
+        val solution = assertNotNull(solve(eye, targetPos, targetVelocity, ownVelocity = own))
+
+        // Constant velocity: no gravity, no drag (drag 1.0), exactly like AbstractWindCharge.
+        val velocity = solution.rotation.directionVector
+            .scale(WIND_CHARGE_SPEED)
+            .add(own)
+
+        // Closest approach of the two straight lines, solved in closed form over continuous time.
+        // |(eye − P0) + (v0 − vt)·t| is minimized at t = (P0 − eye)·(v0 − vt) / |v0 − vt|².
+        val relative = velocity.subtract(targetVelocity)
+        val approachTime = targetPos.subtract(eye).dot(relative) / relative.lengthSqr()
+        val closestDistance = eye.add(velocity.scale(approachTime))
+            .distanceTo(targetPos.add(targetVelocity.scale(approachTime)))
+
+        // Float yaw/pitch round-trip adds ~7e-5 rad of noise; at 30+ blocks that is ~2e-3 blocks,
+        // still 500x below the 1.0-block projectile hitbox.
+        assertTrue(closestDistance < 1e-2, "closest approach was $closestDistance blocks")
+        assertEquals(solution.flightTicks, approachTime, 0.5)
+    }
+
+    @Test
+    fun `own velocity is inherited by the projectile`() {
+        val targetPos = Vec3(20.0, 1.0, 0.0)
+        val own = Vec3(1.0, 0.0, 0.0)
+        val solution = solve(eye, targetPos, Vec3.ZERO, ownVelocity = own)
+
+        assertNotNull(solution)
+        assertImpactMatchesTarget(solution, targetPos, Vec3.ZERO, own)
+    }
+
+    @Test
+    fun `vertical offset of zero returns the target unchanged`() {
+        val origin = Vec3(0.0, 1.0, 0.0)
+        val target = Vec3(20.0, 2.0, 5.0)
+
+        assertEquals(target, applyVerticalOffset(origin, target, 0f))
+    }
+
+    @Test
+    fun `positive vertical offset raises the aim point keeping distance`() {
+        val origin = Vec3(0.0, 1.0, 0.0)
+        val target = Vec3(20.0, 1.0, 0.0)
+
+        val raised = applyVerticalOffset(origin, target, 5f)
+
+        assertEquals(20.0 * tan(5.0 * Math.PI / 180.0), raised.y - target.y, 1e-9)
+    }
+
+    private fun solve(
+        eye: Vec3,
+        targetPos: Vec3,
+        targetVelocity: Vec3,
+        ownVelocity: Vec3 = Vec3.ZERO,
+        maxFlightTicks: Double = 60.0,
+        verticalOffset: Float = 0f,
+    ) = solveWindChargeIntercept(eye, ownVelocity, targetPos, targetVelocity, maxFlightTicks, verticalOffset)
+
+    private fun assertImpactMatchesTarget(
+        solution: InterceptElytraSolver.WindChargeSolution,
+        targetPos: Vec3,
+        targetVelocity: Vec3,
+        ownVelocity: Vec3 = Vec3.ZERO,
+    ) {
+        // Direction is reconstructed from float yaw/pitch, hence the relaxed tolerance: the round-trip
+        // error stays below 1e-3 blocks, far smaller than the 1.0-block projectile hitbox.
+        val projectileVelocity = solution.rotation.directionVector.scale(WIND_CHARGE_SPEED).add(ownVelocity)
+        val impact = eye.add(projectileVelocity.scale(solution.flightTicks))
+        val expected = targetPos.add(targetVelocity.scale(solution.flightTicks))
+
+        assertVecEquals(expected, impact, 1e-3)
+    }
+
+    private fun assertVecEquals(expected: Vec3, actual: Vec3, delta: Double) {
+        assertEquals(expected.x, actual.x, delta)
+        assertEquals(expected.y, actual.y, delta)
+        assertEquals(expected.z, actual.z, delta)
+    }
+}


### PR DESCRIPTION
## Description

Implements #8718 — **InterceptElytra**: a new Combat module that intercepts elytra flyers by launching Wind Charges at their predicted position to knock them out of the air.

### How it works
- **Target selection** — O(k) single-pass scan (no sorting, O(1) auxiliary space) picks the closest gliding player within range, with lazy line-of-sight evaluation.
- **Closed-form interception solver** — solves the quadratic `(|w|² − 2.25)t² + 2(Δ·w)t + |Δ|² = 0` in **O(1)** (wind charge speed = 1.5 blocks/tick, inherits the thrower's velocity), with vanilla-accurate knockback prediction (`ServerExplosion` formula).
- **Two aim modes** — `InterceptPoint` (leads the target) and `Direct` (fires at the current position).
- **VerifyHit** — simulates the wind-charge trajectory and validates it against the predicted impact point before committing to a shot.
- **15 settings** — range, minimum target speed, require-gliding toggle, vertical offset, throw mode, etc.

### Tests
26 unit tests across 3 classes (`InterceptElytraSolverTest`, `ElytraKnockbackCalculatorTest`, `GliderPredictionTest`), including a round-trip check against continuous vanilla flight, NaN/Inf guards and escaping-target edge cases. `./gradlew build` (compile + test + detekt) passes.

Closes #8718
