### PR TITLE
fix(SmoothCamera): camera position while riding minecarts

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/render/MixinCamera.java
@@ -139,13 +139,17 @@ public abstract class MixinCamera {
         }
     }
 
-    @Redirect(method = "alignWithEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;add(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;"))
-    private Vec3 modifyPositionVehicle(Vec3 instance, Vec3 vec) {
+    @ModifyArg(
+        method = "alignWithEntity",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;setPosition(Lnet/minecraft/world/phys/Vec3;)V")
+    )
+    private Vec3 modifyPositionVehicle(Vec3 original) {
         if (ModuleFreeLook.INSTANCE.getRunning()) {
-            return vec;
+            return original;
         }
 
-        return ModuleSmoothCamera.shouldApplyChanges() ? vec.add(0, 1, 0) : vec;
+        ModuleSmoothCamera.cameraUpdate(original);
+        return ModuleSmoothCamera.shouldApplyChanges() ? ModuleSmoothCamera.INSTANCE.getSmoothPos() : original;
     }
 
     @ModifyArgs(method = "alignWithEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;setPosition(DDD)V"))


### PR DESCRIPTION
`Camera#alignWithEntity` only calls `Vec3#add(Vec3)` inside the branch guarded by `NewMinecartBehavior#cartHasPosRotLerp`, which is reached while riding a minecart with the Minecart Improvements experiment enabled:

```java
Vec3 vec3 = minecart.getPassengerRidingPosition(this.entity)
    .subtract(minecart.position())
    .subtract(this.entity.getVehicleAttachmentPoint(minecart))
    .add(new Vec3(0.0, Mth.lerp(partialTicks, this.eyeHeightOld, this.eyeHeight), 0.0));
this.setRotation(this.entity.getViewYRot(partialTicks), this.entity.getViewXRot(partialTicks));
this.setPosition(newMinecartBehavior.getCartLerpPosition(partialTicks).add(vec3));
```

The `@Redirect` introduced in #7222 returns `vec` and drops `instance`, so the second call collapses to `vec3`. The cart position is discarded and the camera ends up at the local offset, around (0, 1.6, 0), which looks like the world disappeared while riding. Nothing throws, so the log stays clean and it is easy to mistake for a rendering or chunk issue. FreeLook returned from the same branch, so it was affected in the same way.

`@ModifyArg` on `setPosition(Vec3)` mirrors the existing `setPosition(DDD)` hook right below it. The minecart branch calls it exactly once, so the selector is unambiguous, and the two branches are mutually exclusive, so `cameraUpdate` still runs once per frame. SmoothCamera now also applies while riding, which the `@Redirect` never did - it only added a flat +1 on Y.

Checked the bytecode of `Camera#alignWithEntity` on 26.2 and of `Camera#setup` on 1.21.11, both have the same shape. Tested in game on 1.21.11 with the same change backported onto 0.37.0: before it the world vanished as soon as the cart moved, after it the camera stays on the cart, in first and third person.

The regression is in 0.36.0, 0.35.3 is not affected.
