### PR TITLE
fix(SnapTap): don't work with InventoryMove

### DIFF
--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSnapTap.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleSnapTap.kt
@@ -94,8 +94,6 @@ object ModuleSnapTap : ClientModule("SnapTap", ModuleCategories.MOVEMENT, aliase
 
     @Suppress("unused")
     val onMovementInput = handler<MovementInputEvent> { event ->
-        if (mc.gui.screen() != null) return@handler
-
         var isKeyLeftHeld = event.directionalInput.left
         var isKeyRightHeld = event.directionalInput.right
         var isKeyForwardHeld = event.directionalInput.forwards


### PR DESCRIPTION
Fix the issues caused by the changes in #8804.
Honestly, I didn't even understand what it was for until #8804 was merged.
Maybe we should update module description? It’s pretty hard to understand what this module does without looking at the src or docs.