### PR TITLE
feat(module): TridentBoost

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinTridentItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/item/MixinTridentItem.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.injection.mixins.minecraft.item;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleTridentBoost;
+import net.minecraft.world.item.TridentItem;
+import org.jspecify.annotations.NullMarked;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@NullMarked
+@Mixin(TridentItem.class)
+public abstract class MixinTridentItem {
+
+    @ModifyExpressionValue(
+        method = {"use", "releaseUsing"},
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;isInWaterOrRain()Z")
+    )
+    private boolean hookRiptideWaterRequirement(boolean original) {
+        return original || ModuleTridentBoost.ignoresWaterRequirement();
+    }
+
+    @ModifyArgs(
+        method = "releaseUsing",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;push(DDD)V")
+    )
+    private void hookRiptideImpulse(Args args) {
+        args.set(0, ModuleTridentBoost.scaleHorizontal(args.<Double>get(0)));
+        args.set(1, ModuleTridentBoost.scaleVertical(args.<Double>get(1)));
+        args.set(2, ModuleTridentBoost.scaleHorizontal(args.<Double>get(2)));
+    }
+
+}

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ModuleManager.kt
@@ -138,6 +138,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleSprint
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleStrafe
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleTargetStrafe
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleTeleport
+import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleTridentBoost
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleVehicleBoost
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleVehicleControl
 import net.ccbluex.liquidbounce.features.module.modules.movement.ModuleSnapTap
@@ -579,6 +580,7 @@ object ModuleManager : EventListener, Collection<ClientModule> by modules {
             ModuleReverseStep,
             ModuleStrafe,
             ModuleTerrainSpeed,
+            ModuleTridentBoost,
             ModuleVehicleBoost,
             ModuleVehicleControl,
             ModuleSpider,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTridentBoost.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/ModuleTridentBoost.kt
@@ -1,0 +1,45 @@
+/*
+ * This file is part of LiquidBounce (https://github.com/CCBlueX/LiquidBounce)
+ *
+ * Copyright (c) 2015 - 2026 CCBlueX
+ *
+ * LiquidBounce is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LiquidBounce is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiquidBounce. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package net.ccbluex.liquidbounce.features.module.modules.movement
+
+import net.ccbluex.liquidbounce.features.module.ClientModule
+import net.ccbluex.liquidbounce.features.module.ModuleCategories
+
+/**
+ * TridentBoost module
+ *
+ * Strengthens the riptide dash of a trident and allows it to be used on dry land.
+ */
+object ModuleTridentBoost : ClientModule("TridentBoost", ModuleCategories.MOVEMENT) {
+
+    private val horizontalMultiplier by float("HorizontalMultiplier", 2f, 0.1f..5f)
+    private val verticalMultiplier by float("VerticalMultiplier", 2f, 0.1f..5f)
+    private val onLand by boolean("OnLand", default = true)
+
+    @JvmStatic
+    fun scaleHorizontal(original: Double) = if (running) original * horizontalMultiplier else original
+
+    @JvmStatic
+    fun scaleVertical(original: Double) = if (running) original * verticalMultiplier else original
+
+    @JvmStatic
+    fun ignoresWaterRequirement() = running && onLand
+
+}

--- a/src/main/resources/liquidbounce.mixins.json
+++ b/src/main/resources/liquidbounce.mixins.json
@@ -99,6 +99,7 @@
     "minecraft.item.MixinItemCooldowns",
     "minecraft.item.MixinItemInHandRenderer",
     "minecraft.item.MixinItemStack",
+    "minecraft.item.MixinTridentItem",
     "minecraft.network.MixinAddressCheck",
     "minecraft.network.MixinClientboundRemoveEntitiesPacket",
     "minecraft.network.MixinClientHandshakePacketListenerImplMixin",


### PR DESCRIPTION
Scales the riptide dash of a trident and optionally lets it start on dry land.

`TridentItem` gates riptide behind `Player#isInWaterOrRain` in both `use` and `releaseUsing`, and applies the dash through a single `Player#push` call, with the strength coming from the enchantment (1.5 base, +0.75 per level above first). Those are the only spots involved, so the module needs one `@ModifyExpressionValue` covering the water check in both methods and one `@ModifyArgs` on the impulse.

Settings:

- `HorizontalMultiplier` and `VerticalMultiplier` — scale the dash separately, same layout as `VehicleBoost` in the same category
- `OnLand` — drops the water and rain requirement

Worth knowing before reviewing:

- The multiplier applies on remote servers as well, since `push` runs client-side. Tested on 26.2 in singleplayer and on a remote server; up to roughly 2.5 the movement is accepted, above that it gets corrected. Default is 2.0.
- `OnLand` only takes full effect in singleplayer, where the integrated server runs the same patched `TridentItem`. On a remote server the dash still moves the player, but the server never starts the spin attack, so there is no spin damage and the movement looks ordinary to anticheats.

Meteor has a module in the same spirit. Vanilla offers no other injection points, so those coincide, but this module is written for LiquidBounce and shares neither its structure nor its settings.
