### PR TITLE
feat(Event): player container input event

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinAbstractContainerScreen.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/gui/MixinAbstractContainerScreen.java
@@ -21,7 +21,6 @@ package net.ccbluex.liquidbounce.injection.mixins.minecraft.gui;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.ccbluex.liquidbounce.features.module.modules.misc.ModuleItemScroller;
-import net.ccbluex.liquidbounce.features.module.modules.movement.inventorymove.ModuleInventoryMove;
 import net.ccbluex.liquidbounce.features.module.modules.player.cheststealer.features.FeatureSilentScreen;
 import net.ccbluex.liquidbounce.features.module.modules.render.ModuleBetterInventory;
 import net.ccbluex.liquidbounce.injection.mixins.minecraft.client.MixinMouseHandlerAccessor;
@@ -29,7 +28,6 @@ import net.minecraft.client.MouseHandler;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.util.Util;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -77,11 +75,6 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
 
     @Inject(method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V", at = @At("HEAD"), cancellable = true)
     private void cancelMouseClick(Slot slot, int slotId, int button, ContainerInput actionType, CallbackInfo ci) {
-        var inventoryMove = ModuleInventoryMove.INSTANCE;
-        if ((AbstractContainerScreen<?>) (Object) this instanceof InventoryScreen && inventoryMove.getRunning() && inventoryMove.getDoNotAllowClicking()) {
-            ci.cancel();
-        }
-
         if (FeatureSilentScreen.INSTANCE.getShouldHide()) {
             ci.cancel();
         }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinMultiPlayerGameMode.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/mixins/minecraft/network/MixinMultiPlayerGameMode.java
@@ -31,6 +31,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.level.GameType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -47,9 +48,7 @@ public abstract class MixinMultiPlayerGameMode {
     @Inject(method = "attack", at = @At("HEAD"), cancellable = true)
     private void hookAttack(Player player, Entity target, CallbackInfo callbackInfo) {
         var event = EventManager.INSTANCE.callEvent(new AttackEntityEvent(target));
-        if (event.isCancelled()) {
-            callbackInfo.cancel();
-        }
+        if (event.isCancelled()) callbackInfo.cancel();
     }
 
     /**
@@ -57,30 +56,22 @@ public abstract class MixinMultiPlayerGameMode {
      */
     @Inject(method = "continueDestroyBlock", at = @At(value = "HEAD"))
     private void hookBlockBreakingProgress(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
-        final BlockBreakingProgressEvent blockBreakingProgressEvent = new BlockBreakingProgressEvent(pos);
-        EventManager.INSTANCE.callEvent(blockBreakingProgressEvent);
+        EventManager.INSTANCE.callEvent(new BlockBreakingProgressEvent(pos));
     }
 
     /**
      * Hook into cancel block breaking at HEAD and call cancel block breaking event, which is able to cancel the execution.
      */
     @Inject(method = "stopDestroyBlock", at = @At("HEAD"), cancellable = true)
-    private void hookCancelBlockBreaking(CallbackInfo callbackInfo) {
-        final CancelBlockBreakingEvent cancelEvent = new CancelBlockBreakingEvent();
-        EventManager.INSTANCE.callEvent(cancelEvent);
-
-        if (cancelEvent.isCancelled()) {
-            callbackInfo.cancel();
-        }
+    private void hookCancelBlockBreaking(CallbackInfo ci) {
+        final var event = EventManager.INSTANCE.callEvent(new CancelBlockBreakingEvent());
+        if (event.isCancelled()) ci.cancel();
     }
 
     @Inject(method = "startDestroyBlock", at = @At("HEAD"), cancellable = true)
     private void hookAttackBlock(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
-        var attackEvent = new BlockAttackEvent(pos);
-        EventManager.INSTANCE.callEvent(attackEvent);
-        if (attackEvent.isCancelled()) {
-            cir.setReturnValue(false);
-        }
+        final var event =  EventManager.INSTANCE.callEvent(new BlockAttackEvent(pos));
+        if (event.isCancelled()) cir.setReturnValue(false);
     }
 
     /**
@@ -99,11 +90,8 @@ public abstract class MixinMultiPlayerGameMode {
 
     @Inject(method = "useItem", at = @At("HEAD"), cancellable = true)
     private void hookItemInteractAtHead(Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
-        final PlayerInteractItemEvent cancelEvent = new PlayerInteractItemEvent(player, hand);
-        EventManager.INSTANCE.callEvent(cancelEvent);
-        if (cancelEvent.isCancelled()) {
-            cir.setReturnValue(InteractionResult.PASS);
-        }
+        final var event = EventManager.INSTANCE.callEvent(new PlayerInteractItemEvent(player, hand));
+        if (event.isCancelled()) cir.setReturnValue(InteractionResult.PASS);
     }
 
     @Inject(method = "releaseUsingItem", at = @At("HEAD"))
@@ -112,18 +100,24 @@ public abstract class MixinMultiPlayerGameMode {
     }
 
     @Inject(method = "setLocalMode(Lnet/minecraft/world/level/GameType;)V", at = @At("RETURN"))
-    private void setGameMode(GameType gameMode, CallbackInfo callbackInfo) {
-        EventManager.INSTANCE.callEvent(new GameModeChangeEvent(gameMode));
+    private void setGameMode(GameType mode, CallbackInfo callbackInfo) {
+        EventManager.INSTANCE.callEvent(new GameModeChangeEvent(mode));
     }
 
     @Inject(method = "setLocalMode(Lnet/minecraft/world/level/GameType;Lnet/minecraft/world/level/GameType;)V", at = @At("RETURN"))
-    private void setGameModes(GameType gameMode, GameType previousGameMode, CallbackInfo callbackInfo) {
-        EventManager.INSTANCE.callEvent(new GameModeChangeEvent(gameMode));
+    private void setGameModes(GameType mode, GameType previousMode, CallbackInfo callbackInfo) {
+        EventManager.INSTANCE.callEvent(new GameModeChangeEvent(mode));
     }
 
     @Inject(method = "destroyBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/Block;destroy(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V", shift = At.Shift.AFTER))
     private void hookBreakBlock(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         ClientBlockBreakTrigger.INSTANCE.clientBreakHandler();
+    }
+
+    @Inject(method = "handleContainerInput", at = @At("HEAD"), cancellable = true)
+    private void hookContainerInput(int containerId, int slotNum, int buttonNum, ContainerInput containerInput, Player player, CallbackInfo ci) {
+        final var event = EventManager.INSTANCE.callEvent(new PlayerContainerInputEvent(containerId, slotNum, buttonNum, containerInput));
+        if (event.isCancelled()) ci.cancel();
     }
 
 }

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/EventManager.kt
@@ -95,6 +95,7 @@ import net.ccbluex.liquidbounce.event.events.PacketEvent
 import net.ccbluex.liquidbounce.event.events.PerspectiveEvent
 import net.ccbluex.liquidbounce.event.events.PipelineEvent
 import net.ccbluex.liquidbounce.event.events.PlayerAfterJumpEvent
+import net.ccbluex.liquidbounce.event.events.PlayerContainerInputEvent
 import net.ccbluex.liquidbounce.event.events.PlayerFluidCollisionCheckEvent
 import net.ccbluex.liquidbounce.event.events.PlayerInteractItemEvent
 import net.ccbluex.liquidbounce.event.events.PlayerInteractedItemEvent
@@ -258,6 +259,7 @@ internal val ALL_EVENT_CLASSES: Array<Class<out Event>> = arrayOf(
     TagEntityEvent::class.java,
     MouseScrollInHotbarEvent::class.java,
     PlayerFluidCollisionCheckEvent::class.java,
+    PlayerContainerInputEvent::class.java,
     PlayerSneakMultiplier::class.java,
     PerspectiveEvent::class.java,
     ItemLoreQueryEvent::class.java,

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/PlayerEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/PlayerEvents.kt
@@ -29,6 +29,7 @@ import net.minecraft.world.InteractionHand
 import net.minecraft.world.InteractionResult
 import net.minecraft.world.entity.MoverType
 import net.minecraft.world.entity.player.Player
+import net.minecraft.world.inventory.ContainerInput
 import net.minecraft.world.level.material.Fluid
 import net.minecraft.world.phys.Vec3
 
@@ -105,3 +106,11 @@ class PlayerStepSuccessEvent(val movementVec: Vec3, var adjustedVec: Vec3) : Eve
 
 @Tag("playerFluidCollisionCheck")
 class PlayerFluidCollisionCheckEvent(val fluid: TagKey<Fluid>) : CancellableEvent()
+
+@Tag("playerContainerInput")
+class PlayerContainerInputEvent(
+    val containerId: Int,
+    val slot: Int,
+    val button: Int,
+    val input: ContainerInput,
+) : CancellableEvent()

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/inventorymove/ModuleInventoryMove.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/movement/inventorymove/ModuleInventoryMove.kt
@@ -25,6 +25,7 @@ import net.ccbluex.liquidbounce.config.types.list.Tagged
 import net.ccbluex.liquidbounce.event.events.KeyboardKeyEvent
 import net.ccbluex.liquidbounce.event.events.MovementInputEvent
 import net.ccbluex.liquidbounce.event.events.PacketEvent
+import net.ccbluex.liquidbounce.event.events.PlayerContainerInputEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.features.module.ModuleCategories
@@ -90,14 +91,6 @@ object ModuleInventoryMove : ClientModule("InventoryMove", ModuleCategories.MOVE
             mc.options.keyShift, false,
         )
 
-    /**
-     * Restricts user from clicking while moving or sprinting in inventory.
-     */
-    val doNotAllowClicking
-        get() = behavior === Behaviour.SAFE && movementKeys.fastIterable().any {
-            it.booleanValue && shouldHandleInputs(it.key)
-        }
-
     init {
         tree(InventoryMoveSprintControlFeature)
         tree(InventoryMoveSneakControlFeature)
@@ -148,16 +141,24 @@ object ModuleInventoryMove : ClientModule("InventoryMove", ModuleCategories.MOVE
     }
 
     @Suppress("unused")
-    private val movementInputHandler = handler<MovementInputEvent>(FINAL_DECISION) {
+    private val movementInputHandler = handler<MovementInputEvent>(FINAL_DECISION) { event ->
         if (delayedContainerPackets.isEmpty()) return@handler
 
         val packetsSnapshot = delayedContainerPackets.toTypedArray()
         delayedContainerPackets.clear()
-        it.sneak = false
-        it.jump = false
-        it.directionalInput = DirectionalInput.NONE
+        event.sneak = false
+        event.jump = false
+        event.directionalInput = DirectionalInput.NONE
         // `schedule` will force the Runnable to be run in next loop
         mc.schedule { packetsSnapshot.forEach(::sendPacketSilently) }
+    }
+
+    @Suppress("unused")
+    private val playerContainerInputHandler = handler<PlayerContainerInputEvent> { event ->
+        if (behavior !== Behaviour.SAFE) return@handler
+
+        if (event.containerId != 0) return@handler
+        if (movementKeys.fastIterable().any { it.booleanValue && shouldHandleInputs(it.key) }) event.cancelEvent()
     }
 
     @Suppress("unused")


### PR DESCRIPTION
**Summary**
Adds a new cancellable **PlayerContainerInputEvent**.
Allows other modules to cancel player container click actions without using mixin.

**Differences in behavior**
1.`InventoryMove/Safe` may cancel click actions from other modules. This is expected behavior.
