### PR TITLE
fix(ClickGui): panel position not immediatly updated when expand goes offscreen

### DIFF
--- a/src-theme/src/routes/clickgui/Panel.svelte
+++ b/src-theme/src/routes/clickgui/Panel.svelte
@@ -121,8 +121,26 @@
     function toggleExpanded() {
         panelConfig.expanded = !panelConfig.expanded;
 
-        fixPosition();
         savePanelConfig();
+    }
+
+    /**
+     * The panel only reaches its new height once the `max-height` transition of the module
+     * list has finished, so the position can only be clamped here. Doing it right after the
+     * toggle would measure the height the panel had *before* it was expanded or collapsed.
+     */
+    function handleModulesTransitionEnd(e: TransitionEvent) {
+        if (e.target !== modulesElement || e.propertyName !== "max-height") {
+            return;
+        }
+
+        const {left, top} = panelConfig;
+
+        fixPosition();
+
+        if (panelConfig.left !== left || panelConfig.top !== top) {
+            savePanelConfig();
+        }
     }
 
     function handleModulesScroll() {
@@ -213,6 +231,7 @@
             class="modules"
             class:expanded={panelConfig.expanded}
             on:scroll={handleModulesScroll}
+            on:transitionend={handleModulesTransitionEnd}
             bind:this={modulesElement}
     >
         {#each modules as {name, enabled, description, aliases} (name)}


### PR DESCRIPTION
Updated description:
---

Click GUI panels are not meant to go outside the viewport and are thus clamped such that they automatically teleport back into view if they happen to go outside. This behavior was not automtcally triggered if the expansion of a category caused the lower section to go offscreen. This PR automatically forces the panel back inside the viewport *after* the expansion animation has stopped.


Original description:
---

Refs #9084 — this fixes the panel-position half of that issue. Deliberately not `Fixes`, so the issue stays open for the z-index request described at the bottom.

### Problem

`toggleExpanded()` clamps the panel back into the viewport immediately after flipping `expanded`:

```js
function toggleExpanded() {
    panelConfig.expanded = !panelConfig.expanded;

    fixPosition();   // <- panel still has its old height here
    savePanelConfig();
}
```

At that moment the module list has neither been re-rendered nor run its `max-height` transition, so `panelElement.offsetHeight` is still the height the panel had *before* the toggle.

Collapsing therefore clamps `top` against the **expanded** height:

```
maxTop = viewportHeight - expandedHeight
```

Every panel positioned lower than that gets yanked upwards, even though a collapsed panel is only ~40px tall and needs no clamping at all. When an expanded panel is taller than the viewport, `maxTop` goes negative and the panel snaps all the way to `top: 0` — which is where the reporter sees them pile up behind the search bar.

This is a regression from #4625: before that refactor the clamp was deferred with `setTimeout(..., 500)`, i.e. it ran after the animation.

### Fix

Clamp when the `max-height` transition of the module list has finished, where the panel actually has its new size, and only persist the config if the position really changed.

- **Collapsing** no longer moves the panel — it stays where the user put it.
- **Expanding** still pulls a panel that would overflow the bottom back into view (now using the correct height, so it works in the cases where it previously silently did nothing).

### Verification

`npm run build` and `npm run check` pass (`svelte-check` reports only the 21 pre-existing errors in `hud/` and `menu/`, none in `Panel.svelte`).

Behaviour was measured in a standalone harness that reproduces the panel geometry and CSS (250px wide panel, `.modules` `max-height: 0 -> 545px`, `300ms` transition) with the old and the new logic side by side, in a 962px viewport:

| scenario | panel `top` before | old logic | this PR |
|---|---|---|---|
| collapse a panel at `top: 520` | 520 | **418** (clamped against the 544px expanded height) | 520 |
| expand a panel at `top: 880` | 880 | 418 | 418 |

So the jump on collapse is gone and the keep-in-view behaviour on expand is preserved.

### Not included

The issue also suggests giving the search bar a lower z-index than the panels. That is a separate UX decision — `.search` only raises itself to `z-index: 9999999999` while it is hovered or focused, so a panel is only swallowed once the cursor crosses the search bar — and I left it out to keep this PR to the actual bug. Happy to follow up if you want it changed.

### On depending on `transitionend`

The clamp now runs when the `max-height` transition ends, so it is skipped if that transition never runs — a zero-duration or overridden `transition` on `.modules`, or a panel toggled while not rendered. In that case expanding a panel that overflows the bottom would no longer pull it back into view.

I did not add a timeout fallback for it: the duration lives in this component's own CSS (`transition: max-height 300ms ease`) and `max-height` always changes between `0` and `545px` on toggle, so the event fires on the normal path. A `transitionend` + `setTimeout` pair would duplicate the CSS duration as a second source of truth for an edge case that does not exist today. Happy to add one if you would rather have the belt and braces.

