### PR TITLE
fix(ClickGUI): sliders clamping values that exceed their declared range

### DIFF
--- a/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatRangeSetting.svelte
@@ -17,13 +17,24 @@
     let apiSlider: API;
 
     onMount(() => {
+        // The value can sit outside the declared range (e.g. set through the `.value` command),
+        // so widen the slider instead of letting noUiSlider clamp it away.
+        const min = Math.min(cSetting.range.from, cSetting.value.from, cSetting.value.to);
+        const max = Math.max(cSetting.range.to, cSetting.value.from, cSetting.value.to);
+
+        // Coarsen the step by however much the track had to grow, so an outlier in
+        // either direction does not get an absurdly fine step. Reduces to
+        // `cSetting.range.to` whenever the value is within its declared range.
+        const grownBy = (max - min) - (cSetting.range.to - cSetting.range.from);
+        const stepBasis = cSetting.range.to + grownBy;
+
         let step = 0.01;
 
-        if (cSetting.range.to > 100) {
+        if (stepBasis > 100) {
             step = 0.1;
-        } else if (cSetting.range.to <= 0.1) {
+        } else if (stepBasis <= 0.1) {
             step = 0.0001;
-        } else if (cSetting.range.to <= 1.0) {
+        } else if (stepBasis <= 1.0) {
             step = 0.001;
         }
 
@@ -31,8 +42,8 @@
             start: [cSetting.value.from, cSetting.value.to],
             connect: true,
             range: {
-                min: cSetting.range.from,
-                max: cSetting.range.to,
+                min,
+                max,
             },
             step: step,
             format: {

--- a/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/FloatSetting.svelte
@@ -17,13 +17,24 @@
     let apiSlider: API;
 
     onMount(() => {
+        // The value can sit outside the declared range (e.g. set through the `.value` command),
+        // so widen the slider instead of letting noUiSlider clamp it away.
+        const min = Math.min(cSetting.range.from, cSetting.value);
+        const max = Math.max(cSetting.range.to, cSetting.value);
+
+        // Coarsen the step by however much the track had to grow, so an outlier in
+        // either direction does not get an absurdly fine step. Reduces to
+        // `cSetting.range.to` whenever the value is within its declared range.
+        const grownBy = (max - min) - (cSetting.range.to - cSetting.range.from);
+        const stepBasis = cSetting.range.to + grownBy;
+
         let step = 0.01;
 
-        if (cSetting.range.to > 100) {
+        if (stepBasis > 100) {
             step = 0.1;
-        } else if (cSetting.range.to <= 0.1) {
+        } else if (stepBasis <= 0.1) {
             step = 0.0001;
-        } else if (cSetting.range.to <= 1.0) {
+        } else if (stepBasis <= 1.0) {
             step = 0.001;
         }
 
@@ -31,8 +42,8 @@
             start: cSetting.value,
             connect: "lower",
             range: {
-                min: cSetting.range.from,
-                max: cSetting.range.to,
+                min,
+                max,
             },
             step: step,
             format: {

--- a/src-theme/src/routes/clickgui/setting/IntRangeSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/IntRangeSetting.svelte
@@ -17,12 +17,17 @@
     let apiSlider: API;
 
     onMount(() => {
+        // The value can sit outside the declared range (e.g. set through the `.value` command),
+        // so widen the slider instead of letting noUiSlider clamp it away.
+        const min = Math.min(cSetting.range.from, cSetting.value.from, cSetting.value.to);
+        const max = Math.max(cSetting.range.to, cSetting.value.from, cSetting.value.to);
+
         apiSlider = noUiSlider.create(slider, {
             start: [cSetting.value.from, cSetting.value.to],
             connect: true,
             range: {
-                min: cSetting.range.from,
-                max: cSetting.range.to,
+                min,
+                max,
             },
             step: 1,
         });

--- a/src-theme/src/routes/clickgui/setting/IntSetting.svelte
+++ b/src-theme/src/routes/clickgui/setting/IntSetting.svelte
@@ -17,12 +17,17 @@
     let apiSlider: API;
 
     onMount(() => {
+        // The value can sit outside the declared range (e.g. set through the `.value` command),
+        // so widen the slider instead of letting noUiSlider clamp it away.
+        const min = Math.min(cSetting.range.from, cSetting.value);
+        const max = Math.max(cSetting.range.to, cSetting.value);
+
         apiSlider = noUiSlider.create(slider, {
             start: cSetting.value,
             connect: "lower",
             range: {
-                min: cSetting.range.from,
-                max: cSetting.range.to,
+                min,
+                max,
             },
             step: 1,
         });


### PR DESCRIPTION
Fixes #8116.

### Problem

Every ClickGUI slider builds noUiSlider with the *declared* range and the *current* value:

```js
apiSlider = noUiSlider.create(slider, {
    start: [cSetting.value.from, cSetting.value.to],
    range: { min: cSetting.range.from, max: cSetting.range.to },
    ...
});
```

noUiSlider clamps `start` into `range`. A value that was pushed past its limits — `.value set modules.backtrack.delay 5000..5000` on a `0..1000` setting, or a config imported from a build with wider limits — is therefore drawn at `1000..1000` while the module actually runs on `5000..5000`.

It is not only a display problem. `update` fires as soon as the listener is attached, and the handler writes the clamped number back into the component's copy of the setting:

```js
apiSlider.on("update", values => {
    cSetting.value = { from: newValue[0], to: newValue[1] };
    setting = { ...cSetting };
});
```

`Module.svelte` then sends the **whole** configurable on the next change:

```js
async function updateModuleSettings() {
    await setModuleSettings(name, configurable);
    ...
}
```

So opening the panel and toggling any unrelated setting of that module silently overwrites the real value with the clamped one. Nothing in the config system coerces values into `range` (`RangedValue.setByString` validates only `split.size == 2`), so the client happily stores and uses them — the ClickGUI is the only place that disagrees.

### Fix

Widen the slider to cover the current value instead of clamping it, across all four sliders (`IntSetting`, `IntRangeSetting`, `FloatSetting`, `FloatRangeSetting`) — these are the only `noUiSlider.create` call sites in the theme.

For the two range sliders both endpoints feed both bounds:

```js
const min = Math.min(cSetting.range.from, cSetting.value.from, cSetting.value.to);
const max = Math.max(cSetting.range.to, cSetting.value.from, cSetting.value.to);
```

`RangedValue.setByString` does not validate ordering, so `.value set … 5000..-5000` is storable; keying `min` off `value.from` alone would leave that case clamped to the declared bounds exactly as before.

For the two float sliders the step heuristic is coarsened by however much the track grew, rather than keyed off `range.to`:

```js
const grownBy = (max - min) - (cSetting.range.to - cSetting.range.from);
const stepBasis = cSetting.range.to + grownBy;
```

This is symmetric — a value of `-500` on a `0..1` setting widens the track just as much as `+500` does, and both deserve the coarser step. It reduces to exactly `cSetting.range.to` whenever the value is inside its declared range, so in-range behaviour is untouched for any declared range, including ones with a negative lower bound.

I deliberately did not make the config system clamp on `set` instead: exceeding a slider limit through `.value` is an established capability, and the GUI is what should follow the value, not the other way round.

### Verification

`npm run build` and `npm run check` pass — `svelte-check` reports only the 21 pre-existing errors in `hud/` and `menu/`, none in `clickgui/setting/`.

Behaviour was measured in a standalone harness that drives the real `nouislider` build through the same mount path as the components, reading back the track it builds and what the `update` handler writes into `cSetting.value`.

Range sliders, declared range `0..1000`:

| stored value | track before | written before | track after | written after |
|---|---|---|---|---|
| `5000..5000` | `0..1000` | **`1000..1000`** | `-…`/`0..5000` | `5000..5000` |
| `5000..-5000` | `0..1000` | **`1000..1000`** | `-5000..5000` | `5000..5000` |
| `200..400` | `0..1000` | `200..400` | `0..1000` | `200..400` |

Float sliders, declared range `0..1` unless noted:

| stored value | written before | step before | written after | step after |
|---|---|---|---|---|
| `500` | **`1`** | `0.001` | `500` | `0.1` |
| `-500` | **`0`** | `0.001` | `-500` | `0.1` |
| `0.5` | `0.5` | `0.001` | `0.5` | `0.001` |
| `150` (range `100..200`) | `150` | `0.1` | `150` | `0.1` |
| `0.5` (range `-1..1`) | `0.5` | `0.001` | `0.5` | `0.001` |

In-range values — the overwhelmingly common case — are bit-for-bit unchanged, including the chosen step.

One honest limitation: a two-handle slider cannot represent a reversed range, so `5000..-5000` is still normalised to `5000..5000` by noUiSlider's handle ordering. That normalisation is pre-existing and independent of this change (`900..100` on a `0..1000` setting is already rewritten to `900..900` on current `nextgen`); what this PR removes is the *additional* clamping down to the declared bounds.
